### PR TITLE
FIX bitflags depedency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "exa"
 version = "0.1.0"
 dependencies = [
  "ansi_term 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "datetime 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ natord = "1.0.7"
 number_prefix = "0.2.3"
 pad = "0.1.1"
 users = "0.2.3"
+bitflags = "0.1"
 
 [features]
 default = [ "git" ]


### PR DESCRIPTION
I applied this change to fix following error :
```
 Downloading bitflags v0.1.1
Unable to get packages from source

Caused by:
  Failed to download package `bitflags v0.1.1` from https://crates.io/api/v1/crates/bitflags/0.1.1/download

Caused by:
  Couldn't resolve host name
```