### PR TITLE
Use file_name_width in grid

### DIFF
--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -51,7 +51,7 @@ impl Grid {
                 else {
                     index / num_lines
                 };
-                column_widths[index] = max(column_widths[index], file.name.len());
+                column_widths[index] = max(column_widths[index], file.file_name_width());
             }
 
             // If they all fit in the terminal, combined, then success!
@@ -87,8 +87,8 @@ impl Grid {
                         print!("{}", styled_name);
                     }
                     else {
-                        assert!(widths[x] >= file.name.len());
-                        print!("{}", Left.pad_string(&styled_name, widths[x] - file.name.len() + 2));
+                        assert!(widths[x] >= file.file_name_width());
+                        print!("{}", Left.pad_string(&styled_name, widths[x] - file.file_name_width() + 2));
                     }
                 }
                 print!("\n");


### PR DESCRIPTION
Filenames with characters that need multiple bytes in UTF-8, and/or
control characters like combining diacritics, would break the grid.
`StrExt::width` seems to do the right thing, and there's conveniently a
function here (which was otherwise unused) to call that.