### PR TITLE
Get rid of explicit `as_slice()` calls.

### DIFF
--- a/src/column.rs
+++ b/src/column.rs
@@ -70,8 +70,8 @@ impl Alignment {
     /// string is not as simple as just getting its length.
     pub fn pad_string(&self, string: &String, padding: usize) -> String {
         match *self {
-            Alignment::Left  => format!("{}{}", string, spaces(padding).as_slice()),
-            Alignment::Right => format!("{}{}", spaces(padding), string.as_slice()),
+            Alignment::Left  => format!("{}{}", string, spaces(padding)),
+            Alignment::Right => format!("{}{}", spaces(padding), string),
         }
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -81,19 +81,19 @@ impl<'a> File<'a> {
             dir:   parent,
             stat:  stat,
             name:  filename.to_string(),
-            ext:   ext(filename.as_slice()),
+            ext:   ext(&filename),
             this:  this,
         }
     }
 
     /// Whether this file is a dotfile or not.
     pub fn is_dotfile(&self) -> bool {
-        self.name.as_slice().starts_with(".")
+        self.name.starts_with(".")
     }
 
     /// Whether this file is a temporary file or not.
     pub fn is_tmpfile(&self) -> bool {
-        let name = self.name.as_slice();
+        let name = &self.name;
         name.ends_with("~") || (name.starts_with("#") && name.ends_with("#"))
     }
 
@@ -150,11 +150,11 @@ impl<'a> File<'a> {
                                    GREY.paint("=>"),
                                    Cyan.paint(target_path.dirname_str().unwrap()),
                                    Cyan.paint("/"),
-                                   file.file_colour().paint(file.name.as_slice())),
+                                   file.file_colour().paint(&file.name)),
                 Err(filename) => format!("{} {} {}",
                                          style.paint(name),
                                          Red.paint("=>"),
-                                         Red.underline().paint(filename.as_slice())),
+                                         Red.underline().paint(&filename)),
             }
         }
         else {
@@ -173,7 +173,7 @@ impl<'a> File<'a> {
     /// characters are 1 columns wide, but in some contexts, certain
     /// characters are actually 2 columns wide.
     pub fn file_name_width(&self) -> usize {
-        self.name.as_slice().width(false)
+        self.name.width(false)
     }
 
     /// Assuming the current file is a symlink, follows the link and
@@ -193,7 +193,7 @@ impl<'a> File<'a> {
                 dir:   self.dir,
                 stat:  stat,
                 name:  filename.to_string(),
-                ext:   ext(filename.as_slice()),
+                ext:   ext(&filename),
                 this:  None,
             })
         }
@@ -322,7 +322,7 @@ impl<'a> File<'a> {
                 DateFormat::parse("{2>:D} {:M} {4>:Y}").unwrap()
             };
 
-        Cell::paint(Blue.normal(), format.format(date, locale).as_slice())
+        Cell::paint(Blue.normal(), &format.format(date, locale))
     }
 
     /// This file's type, represented by a coloured character.
@@ -388,7 +388,7 @@ impl<'a> File<'a> {
     /// valid without `foo.coffee`.
     pub fn get_source_files(&self) -> Vec<Path> {
         if let Some(ref ext) = self.ext {
-            match ext.as_slice() {
+            match &ext[..] {
                 "class" => vec![self.path.with_extension("java")],  // Java
                 "css"   => vec![self.path.with_extension("sass"),   self.path.with_extension("less")],  // SASS, Less
                 "elc"   => vec![self.path.with_extension("el")],    // Emacs Lisp

--- a/src/filetype.rs
+++ b/src/filetype.rs
@@ -83,7 +83,7 @@ pub trait HasType {
 
 impl<'a> HasType for File<'a> {
     fn get_type(&self) -> FileType {
-        let name = self.name.as_slice();
+        let name = &self.name[..];
         if self.stat.kind == io::FileType::Directory {
             return Directory;
         }

--- a/src/options.rs
+++ b/src/options.rs
@@ -148,7 +148,7 @@ impl SortField {
 
     /// Find which field to use based on a user-supplied word.
     fn from_word(word: String) -> Result<SortField, Misfire> {
-        match word.as_slice() {
+        match &word[..] {
             "name" | "filename"  => Ok(SortField::Name),
             "size" | "filesize"  => Ok(SortField::Size),
             "ext"  | "extension" => Ok(SortField::Extension),
@@ -342,7 +342,7 @@ impl TimeTypes {
                 return Err(Misfire::Useless("accessed", true, "time"));
             }
 
-            match word.as_slice() {
+            match &word[..] {
                 "mod" | "modified"  => Ok(TimeTypes { accessed: false, modified: true, created: false }),
                 "acc" | "accessed"  => Ok(TimeTypes { accessed: true, modified: false, created: false }),
                 "cr"  | "created"   => Ok(TimeTypes { accessed: false, modified: false, created: true }),

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -92,7 +92,7 @@ impl Details {
                 if let Some(ref dir) = file.this {
                     let mut files = dir.files(true);
                     self.filter.transform_files(&mut files);
-                    self.get_files(columns, cache, locale, dest, files.as_slice(), depth + 1);
+                    self.get_files(columns, cache, locale, dest, &files, depth + 1);
                 }
             }
         }

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -81,7 +81,7 @@ impl Grid {
                     }
 
                     let ref file = files[num];
-                    let styled_name = file.file_colour().paint(file.name.as_slice()).to_string();
+                    let styled_name = file.file_colour().paint(&file.name).to_string();
                     if x == widths.len() - 1 {
                         // The final column doesn't need to have trailing spaces
                         print!("{}", styled_name);


### PR DESCRIPTION
This is obviously completely unnecessary but `as_slice` will be going away eventually.