### PR TITLE
Improve matching of Git status entries to files

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -1,6 +1,7 @@
 use std::old_io::{fs, IoResult};
 use std::old_io as io;
 use std::ascii::AsciiExt;
+use std::env::current_dir;
 
 use ansi_term::{ANSIString, ANSIStrings, Colour, Style};
 use ansi_term::Style::Plain;
@@ -415,7 +416,8 @@ impl<'a> File<'a> {
 
     fn git_status(&self) -> Cell {
         let status = match self.dir {
-            Some(d) => d.git_status(&self.path, self.stat.kind == io::FileType::Directory),
+            Some(d) => d.git_status(&current_dir().unwrap_or(Path::new(".")).join(&self.path),
+                                    self.stat.kind == io::FileType::Directory),
             None    => GREY.paint("--").to_string(),
         };
 


### PR DESCRIPTION
The challenge is that the paths returned from libgit2's status listing
are from the perspective of the Git repository and thus effectively
relative to the working tree root, while the other paths we're
manipulating are (potentially) relative to our current working
directory. So, if those two aren't identical (if running from outside
the working tree, or from a subdirectory), the paths won't match up.

A reasonably reliable way around this is to resolve both types of paths
to absolute paths before comparing them. This fixes #15 at a basic
level, anyway.

What still doesn't work: referring to the working tree or one of its
descendants via a symlink. For that, we'd probably need to fully resolve
symlinks in the file path.

(The unwrap_or()'s are messy and will probably just result in missing
status information, but then, what information could you hope to get
without having both a current working directory and a Git working tree?)