### PR TITLE
Add a man page entry for exa

### DIFF
--- a/man/exa.1
+++ b/man/exa.1
@@ -1,0 +1,112 @@
+.TH EXA "1" "February 2015" "exa 0.1.0" "User Commands"
+.SH NAME
+exa \- A replacement for ls with git integration
+.SH SYNOPSIS
+.B exa
+[\fIOPTIONS\fR] [\fIFILES...\fR]
+
+.SH DESCRIPTION
+exa is a replacement for ls, written in Rust. If built with libgit2, it includes git integration and can display relevant information when used in git repositories.
+
+.SH OPTIONS
+
+.TP
+\fB\-?\fR, \fB\-\-help\fR
+Display a help message
+
+.TP
+\fB\-@\fR, \fB\-\-extended\fR
+Display extended attribute keys and sizes in long (-l) output.
+
+.TP
+\fB\-1\fR, \fB\-\-oneline\fR
+Display one entry per line.
+
+.TP
+\fB\-a\fR, \fB\-\-all\fR
+Display entries whose names begin with a dot (.).
+
+.TP
+\fB\-b\fR, \fB\-\-binary\fR
+Use binary prefixes in file sizes.
+
+.TP
+\fB\-B\fR, \fB\-\-bytes\fR
+Display file sizes in bytes, without prefixes.
+
+.TP
+\fB\-d\fR, \fB\-\-list\-dirs\fR
+Display directories as regular files.
+
+.TP
+\fB\-g\fR, \fB\-\-group\fR
+Display each entry's group as well as user.
+
+.TP
+\fB\-h\fR, \fB\-\-header\fR
+Display a header row at the top of the output.
+
+.TP
+\fB\-H\fR, \fB\-\-links\fR
+Display each entry's number of hard links.
+
+.TP
+\fB\-i\fR, \fB\-\-inode\fR
+Display each entry's inode number.
+
+.TP
+\fB\-l\fR, \fB\-\-long\fR
+Display extended details and attributes.
+
+.TP
+\fB\-m\fR, \fB\-\-modified\fR
+Display timestamps for each entry's most recent modification.
+
+.TP
+\fB\-r\fR, \fB\-\-reverse\fR
+Reverse the order of output.
+
+.TP
+\fB\-R\fR, \fB\-\-recurse\fR
+Recurse into directories.
+
+.TP
+\fB\-s\fR, \fB\-\-sort\fR ATTRIBUTE
+Sort output by a given attribute (name, size, ext, inode, modified, created, accessed, or none).
+
+.TP
+\fB\-S\fR, \fB\-\-blocks\fR
+Display number of file system blocks.
+
+.TP
+\fB\-t\fR, \fB\-\-time\fR TIMESTAMP
+Change the timestamp displayed for each entry (created, modified, or accessed)
+
+.TP
+\fB\-T\fR, \fB\-\-tree\fR
+Recurse into directories in a tree view.
+
+.TP
+\fB\-u\fR, \fB\-\-accessed\fR
+Display each entry's time of last access.
+
+.TP
+\fB\-U\fR, \fB\-\-created\fR
+Display each entry's time of creation.
+
+.TP
+\fB\-x\fR, \fB\-\-across\fR
+Sort multi-column output horizontally instead of vertically.
+
+.SH "EXAMPLES"
+
+To organize a list of files with the largest files at the top:
+
+    $ exa -lrs size
+
+.SH "SEE ALSO"
+
+ls
+
+.SH "AUTHOR"
+exa is maintained by Benjamin Sago. A full list of contributors can be found at \fIhttps://github.com/ogham/exa/contributors\fR\.


### PR DESCRIPTION
Hi! First off, thanks for writing this utility! I've been playing around with it and the git integration is really awesome. I hope this PR isn't too out of the blue... But I (and probably other UNIX users) have a reflex to type `man <command>` to find out more about how to use it. I typically immediately try a `--help` option if that doesn't work, and I'm glad exa has one. But then I thought that it could be pretty neat for `exa` to have a manpage as well. This patch adds a manual page that can be parsed and outputted by the `man` command. Some notes:

 * This manual page was hand crafted. I had hoped to find some Rust
   utility that could generate manual pages to prevent having to change
   this file whenever changes to options are made. There are tools to
   write manual pages in a nicer syntax and then convert them into the
   groff syntax, but I hesitated to add more tools to the build process.
   This might make the file more difficult to maintain, but unless exa's
   signature changes frequently, it should be okay.
 * The manual page isn't automatically copied into the
   /usr/local/share/man/man1 directory, where it would need to be for
   `man` to read it. My first inkling to have installation be a nice
   process would be to craft a Makefile that will run `cargo build
   --release`, copy the binary into /usr/local/bin, and copy the man
   page into the aforementioned directory. If it's alright with you (and
   regardless of whether or not you like the idea of a man page), I'd
   love to handle that in this PR or another one if you like the idea
   of a Makefile to ease installation!
 * I didn't directly and copy the verbiage from the `--help` option; I
   instead chose to carefully reword some things to better match the
   style that man pages (in my experience) tend to have. I hope that's
   okay as well.

Signed-off-by: David Celis <me@davidcel.is>