### PR TITLE
Fix a missing '/' in symlink targets

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -162,13 +162,8 @@ impl<'a> File<'a> {
                         for component in path_bytes.init().iter() {
                             let string = String::from_utf8_lossy(component).to_string();
                             path_prefix.push_str(&string);
+                            path_prefix.push_str("/");
                         }
-                    }
-
-                    // Only add a slash when there's something in the path
-                    // prefix so far.
-                    if path_bytes.len() > 1 {
-                        path_prefix.push_str("/");
                     }
 
                     format!("{} {} {}",


### PR DESCRIPTION
In cases where symlink targets were more than a single directory down,
exa did not print the `/` characters to separate directories, resulting
in the following output:

    symlink => dirAdirBdirC/file

Instead of

    symlink => dirA/dirB/dirC/file

By adding a `/` character after each component of the filename, this
error is fixed.

Fixes #33 