### PR TITLE
Add simple Makefile to build and install exa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+PREFIX ?= /usr/local
+
+BUILD = target/release/exa
+
+$(BUILD):
+	@which rustc > /dev/null || { echo "Exa requires Rust-lang to compile. For installation instructions, please visit http://rust-lang.org/"; exit 1; }
+	cargo build --release
+
+build: $(BUILD)
+
+INSTALL = $(PREFIX)/bin/exa
+
+$(INSTALL):
+	cp target/release/exa $(PREFIX)/bin/
+	cp man/*.1 $(PREFIX)/share/man/man1/
+
+install: build $(INSTALL)
+
+.PHONY: install

--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ You can sort by **name**, **size**, **ext**, **inode**, **modified**, **created*
 
 ## Installation
 
-exa is written in [Rust](http://www.rust-lang.org). You'll have to use the nightly -- I try to keep it up to date with the latest version when possible.  Once you have it set up, a simple `cargo build --release` will pull in all the dependencies and compile exa as `target/release/exa`.
+exa is written in [Rust](http://www.rust-lang.org). You'll have to use the nightly -- I try to keep it up to date with the latest version when possible.  Once you have it set up, a simple `make install` will compile exa and install it into `/usr/local/bin`.
 
 exa depends on [libgit2](https://github.com/alexcrichton/git2-rs) for certain features. If you're unable to compile libgit2, you can opt out of Git support by passing `--no-default-features` to Cargo.


### PR DESCRIPTION
This patch adds a Makefile that will build and install exa along with
its recently added manual page. This provides a little bit of a nicer
installation path while we wait for Cargo to, hopefully, provide its own
built-in installation method for packages that contain binaries.

Signed-off-by: David Celis <me@davidcel.is>