### PR TITLE
Make Git Column Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - **-B**, **--bytes**: list file sizes in bytes, without prefixes
 - **-d**, **--list-dirs**: list directories as regular files
 - **-g**, **--group**: show group as well as user
+- **--git**: show git status (depends on libgit2, see below)
 - **-h**, **--header**: show a header row
 - **-H**, **--links**: show number of hard links column
 - **-i**, **--inode**: show inode number column

--- a/src/options.rs
+++ b/src/options.rs
@@ -72,6 +72,10 @@ impl Options {
         opts.optflag("",  "version",   "display version of exa");
         opts.optflag("?", "help",      "show list of command-line options");
 
+        if cfg!(feature="git") {
+            opts.optflag("", "git", "show git status");
+        }
+
         if xattr::feature_implemented() {
             opts.optflag("@", "extended", "display extended attribute keys and sizes in long (-l) output");
         }
@@ -490,6 +494,7 @@ pub struct Columns {
     links: bool,
     blocks: bool,
     group: bool,
+    git: bool
 }
 
 impl Columns {
@@ -501,6 +506,7 @@ impl Columns {
             links:  matches.opt_present("links"),
             blocks: matches.opt_present("blocks"),
             group:  matches.opt_present("group"),
+            git:    matches.opt_present("git"),
         })
     }
 
@@ -545,7 +551,7 @@ impl Columns {
 
         if cfg!(feature="git") {
             if let Some(d) = dir {
-                if d.has_git_repo() {
+                if self.git && d.has_git_repo() {
                     columns.push(GitStatus);
                 }
             }

--- a/src/options.rs
+++ b/src/options.rs
@@ -279,6 +279,9 @@ impl View {
         else if matches.opt_present("blocks") {
             Err(Misfire::Useless("blocks", false, "long"))
         }
+        else if cfg!(feature="git") && matches.opt_present("git") {
+            Err(Misfire::Useless("git", false, "long"))
+        }
         else if matches.opt_present("time") {
             Err(Misfire::Useless("time", false, "long"))
         }
@@ -651,6 +654,13 @@ mod test {
     fn just_blocks() {
         let opts = Options::getopts(&[ "--blocks".to_string() ]);
         assert_eq!(opts.unwrap_err(), Misfire::Useless("blocks", false, "long"))
+    }
+
+    #[test]
+    #[cfg(feature="git")]
+    fn just_git() {
+        let opts = Options::getopts(&[ "--git".to_string() ]);
+        assert_eq!(opts.unwrap_err(), Misfire::Useless("git", false, "long"))
     }
 
     #[test]


### PR DESCRIPTION
You need to add the `--git` option if you want to show that git column. It only works if exa was compiled with git as a Cargo feature (default) and the current directory is a git repository.

This is what I described in #47. It is a breaking change for some users.
