### PR TITLE
Two minor tweaks: one to make exa build, one for tests to build

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -84,7 +84,7 @@ impl Git {
     /// Discover a Git repository on or above this directory, scanning it for
     /// the files' statuses if one is found.
     fn scan(path: &Path) -> Result<Git, git2::Error> {
-        use std::os::unix::OsStrExt;
+        use std::os::unix::ffi::OsStrExt;
         use std::ffi::AsOsStr;
 
         // TODO: libgit2-rs uses the new Path module, but exa still uses the

--- a/src/file.rs
+++ b/src/file.rs
@@ -490,7 +490,7 @@ fn ext<'a>(name: &'a str) -> Option<String> {
 #[cfg(test)]
 pub mod test {
     pub use super::*;
-    pub use super::path_filename;
+    use super::path_filename;
 
     pub use column::{Cell, Column};
     pub use std::old_io as io;


### PR DESCRIPTION
Hi,

I just tried building/testing exa locally, with rust nightly. Apparently osStrExt has moved(?). Also not sure if tests were run prior to previous commit -- or if something has happened wrt visibility, but cargo/rust complained that path_filename wasn't public, but private. With the tweak in the tests, the test build and pass.

It's quite possible that you'd want to reject this pr and make (better?) fixes yourself. Just thought it might be of interest in case others run into the same issues.