### PR TITLE
updated to latest rust nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "datetime 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "git2 0.2.8 (git+https://github.com/alexcrichton/git2-rs.git)",
+ "git2 0.2.9 (git+https://github.com/alexcrichton/git2-rs.git)",
  "locale 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "natord 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -32,8 +32,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "locale 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "pad 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex_macros 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex_macros 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -51,29 +51,29 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.2.8"
-source = "git+https://github.com/alexcrichton/git2-rs.git#1f2cb994360df26a7a84c8ed17dd14929ba7dcd7"
+version = "0.2.9"
+source = "git+https://github.com/alexcrichton/git2-rs.git#f06a248ad1bfd57e3783867b7f54c200ebc8014a"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libgit2-sys 0.2.10 (git+https://github.com/alexcrichton/git2-rs.git)",
+ "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.2.11 (git+https://github.com/alexcrichton/git2-rs.git)",
  "url 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.2.10"
-source = "git+https://github.com/alexcrichton/git2-rs.git#1f2cb994360df26a7a84c8ed17dd14929ba7dcd7"
+version = "0.2.11"
+source = "git+https://github.com/alexcrichton/git2-rs.git#f06a248ad1bfd57e3783867b7f54c200ebc8014a"
 dependencies = [
- "libc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssh2-sys 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssh2-sys 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -87,12 +87,12 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -114,7 +114,7 @@ name = "log"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -143,11 +143,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-sys"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libressl-pnacl-sys 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -169,15 +169,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex_macros"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -199,6 +199,6 @@ name = "users"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -3,7 +3,7 @@ use file::File;
 use super::lines::lines_view;
 
 use std::cmp::max;
-use std::iter::{AdditiveIterator, repeat};
+use std::iter::repeat;
 
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub struct Grid {
@@ -55,7 +55,7 @@ impl Grid {
             }
 
             // If they all fit in the terminal, combined, then success!
-            if column_widths.iter().map(|&x| x).sum() < adjusted_width {
+            if column_widths.iter().map(|&x| x).sum::<usize>() < adjusted_width {
                 return Some((num_lines, column_widths));
             }
         }


### PR DESCRIPTION
This pull requests updates some out dated dependencies causing compile errors and removes the usage of the AdditiveIterator Trait.

Even though the documentation says otherwise the AdditiveIterator has been removed (https://github.com/rust-lang/rust/pull/23293/) which caused an compile error.

I'm using the newest upstream version directly from github. Travis might be a little behind and fail.