### PR TITLE
fix compile errors if git support is disabled

### DIFF
--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -45,18 +45,19 @@ impl Attribute {
 #[cfg(feature="git")] pub use self::git::Git;
 
 #[cfg(not(feature="git"))] pub struct Git;
-#[cfg(not(feature="git"))] use std::old_path::posix::Path;
+#[cfg(not(feature="git"))] use std::path::Path;
+#[cfg(not(feature="git"))] use file::fields;
 #[cfg(not(feature="git"))]
 impl Git {
     pub fn scan(_: &Path) -> Result<Git, ()> {
         Err(())
     }
 
-    pub fn status(&self, _: &Path) -> String {
+    pub fn status(&self, _: &Path) -> fields::Git {
         panic!("Tried to access a Git repo without Git support!");
     }
 
-    pub fn dir_status(&self, path: &Path) -> String {
+    pub fn dir_status(&self, path: &Path) -> fields::Git {
         self.status(path)
     }
 }


### PR DESCRIPTION
The following compile error occurs if exa is compiled with the flag `--no-default-features`:
```
src/feature/mod.rs:48:32: 48:58 error: unresolved import `std::old_path::posix::Path`. Could not find `old_path` in `std`
src/feature/mod.rs:48 #[cfg(not(feature="git"))] use std::old_path::posix::Path;
                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~
```
Rust version: rustc 1.2.0-nightly (0cc99f9cc 2015-05-17) (built 2015-05-17)

Additionally the function return types of the stubbed `Git` implementation differ from the actual implementation.

This PR fixes these errors.