### PR TITLE
Use the "install" program to install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ build-no-git:
 INSTALL = $(PREFIX)/bin/exa
 
 $(INSTALL):
-	cp target/release/exa $(PREFIX)/bin/
-	cp contrib/man/*.1 $(PREFIX)/share/man/man1/
+	install -Dsm755 target/release/exa $(PREFIX)/bin/
+	install -Dm644 contrib/man/*.1 -t $(PREFIX)/share/man/man1/
 
 install: build $(INSTALL)
 

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,10 @@ build-no-git:
 INSTALL = $(PREFIX)/bin/exa
 
 $(INSTALL):
-	install -Dsm755 target/release/exa $(PREFIX)/bin/
-	install -Dm644 contrib/man/*.1 -t $(PREFIX)/share/man/man1/
+	# BSD and OSX don't have -D to create leading directories
+	install -dm755 $(PREFIX)/bin/ $(PREFIX)/share/man/man1/
+	install -sm755 target/release/exa $(PREFIX)/bin/
+	install -m644 contrib/man/*.1 $(PREFIX)/share/man/man1/
 
 install: build $(INSTALL)
 


### PR DESCRIPTION
install is better to do the job:
* running exa won't crash
* missing directories are created (which is usually the case with custom PREFIX)