### PR TITLE
Fix integer length error on 32bit environment

### DIFF
--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -582,7 +582,7 @@ impl<U> Table<U> where U: Users {
     }
 
     fn render_time(&self, timestamp: f::Time) -> Cell {
-        let date = self.tz.at(LocalDateTime::at(timestamp.0));
+        let date = self.tz.at(LocalDateTime::at(timestamp.0 as i64));
 
         let format = if date.year() == self.current_year {
                 DateFormat::parse("{2>:D} {:M} {2>:h}:{02>:m}").unwrap()


### PR DESCRIPTION
This PR fixes below type mismatch error in 32bit Environment.

```
src/output/details.rs:585:49: 585:60 error: mismatched types:
 expected `i64`,
    found `i32`
(expected i64,
    found i32) [E0308]
src/output/details.rs:585         let date = self.tz.at(LocalDateTime::at(timestamp.0));
                                                                          ^~~~~~~~~~~
src/output/details.rs:585:49: 585:60 help: run `rustc --explain E0308` to see a detailed explanation
error: aborting due to previous error
Could not compile `exa`.
```

My environment:
- Rust nightly 7bf4c885f
- Ubuntu Linux 32bit