### PR TITLE
Minor fixes for FreeBSD

### DIFF
--- a/src/feature/xattr.rs
+++ b/src/feature/xattr.rs
@@ -3,7 +3,6 @@ extern crate libc;
 
 use std::io;
 use std::path::Path;
-use std::ffi::CString;
 
 pub const ENABLED: bool = cfg!(feature="git") && cfg!(any(target_os="macos", target_os="linux"));
 
@@ -51,6 +50,8 @@ pub struct Attribute {
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 pub fn list_attrs(lister: lister::Lister, path: &Path) -> io::Result<Vec<Attribute>> {
+    use std::ffi::CString;
+
     let c_path = match path.to_str().and_then(|s| { CString::new(s).ok() }) {
         Some(cstring) => cstring,
         None => return Err(io::Error::new(io::ErrorKind::Other, "Error: path somehow contained a NUL?")),

--- a/src/options.rs
+++ b/src/options.rs
@@ -727,9 +727,8 @@ LONG VIEW OPTIONS
   -U, --created      display timestamp of creation for a file
 "##;
 
-static GIT_HELP:      &'static str = r##"  -@, --extended     display extended attribute keys and sizes"##;
-static EXTENDED_HELP: &'static str = r##"  --git              show git status for files"##;
-
+static GIT_HELP:      &'static str = r##"  --git              show git status for files"##;
+static EXTENDED_HELP: &'static str = r##"  -@, --extended     display extended attribute keys and sizes"##;
 
 #[cfg(test)]
 mod test {

--- a/src/term.rs
+++ b/src/term.rs
@@ -22,7 +22,13 @@ struct Winsize {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 static TIOCGWINSZ: c_ulong = 0x5413;
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "dragonfly"))]
+#[cfg(any(target_os = "macos",
+          target_os = "ios",
+          target_os = "bitrig",
+          target_os = "dragonfly",
+          target_os = "freebsd",
+          target_os = "netbsd",
+          target_os = "openbsd"))]
 static TIOCGWINSZ: c_ulong = 0x40087468;
 
 extern {


### PR DESCRIPTION
ioctl() command as integer was also tested on NetBSD and OpenBSD under qemu.
```c
#include <sys/ttycom.h>
#include <stdint.h>
#include <stdio.h>

int main() {
  printf("%#jx\n", (intmax_t)TIOCGWINSZ);
}
```
```sh
$ ./a.out
0x40087468
```