### PR TITLE
Document using `cargo install` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,18 @@ Once you have it set up, a simple `make install` will compile exa and install it
 
 exa depends on [libgit2](https://github.com/alexcrichton/git2-rs) for certain features.
 If you’re unable to compile libgit2, you can opt out of Git support by running `cargo build --release --no-default-features`.
+
+### Cargo Install
+
+If you're using a recent version of Cargo (0.5.0 or higher), you can
+use the `cargo install` command:
+
+    cargo install --git https://github.com/ogham/exa
+
+or:
+
+    cargo install --no-default-features --git https://github.com/ogham/exa
+
+Cargo will clone the repository to a temporary directory, build it
+there and place the `exa` binary to: `$HOME/.cargo` (and can be
+overridden by setting the `--root` option).


### PR DESCRIPTION
Cargo now lets people install binaries by running `cargo install`. This
can be more convenient than cloning and building exa manually.