### PR TITLE
Remove trivial casts

### DIFF
--- a/src/feature/xattr.rs
+++ b/src/feature/xattr.rs
@@ -216,7 +216,7 @@ mod lister {
             };
 
             unsafe {
-                listxattr(c_path.as_ptr() as *const _, ptr::null_mut(), 0)
+                listxattr(c_path.as_ptr(), ptr::null_mut(), 0)
             }
         }
 
@@ -228,7 +228,7 @@ mod lister {
 
             unsafe {
                 listxattr(
-                    c_path.as_ptr() as *const _,
+                    c_path.as_ptr(),
                     buf.as_mut_ptr() as *mut c_char,
                     bufsize as size_t
                 )
@@ -243,7 +243,7 @@ mod lister {
 
             unsafe {
                 getxattr(
-                    c_path.as_ptr() as *const _,
+                    c_path.as_ptr(),
                     buf.as_ptr() as *const c_char,
                     ptr::null_mut(), 0
                 )


### PR DESCRIPTION
Remove the trivial casts as reported in these warnings by the compiler (reported in 1.5 stable and 1.6 beta)
```
   Compiling exa v0.4.0 (file:///home/vm/workspace/exa)
src/feature/xattr.rs:219:27: 219:54 warning: trivial cast: `*const i8` as `*const i8`. Cast can be replaced by coercion, this might require type ascription or a temporary variable
src/feature/xattr.rs:219                 listxattr(c_path.as_ptr() as *const _, ptr::null_mut(), 0)
                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/main.rs:1:9: 1:22 note: lint level defined here
src/main.rs:1 #![warn(trivial_casts, trivial_numeric_casts)]
                      ^~~~~~~~~~~~~
src/feature/xattr.rs:231:21: 231:48 warning: trivial cast: `*const i8` as `*const i8`. Cast can be replaced by coercion, this might require type ascription or a temporary variable
src/feature/xattr.rs:231                     c_path.as_ptr() as *const _,
                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/main.rs:1:9: 1:22 note: lint level defined here
src/main.rs:1 #![warn(trivial_casts, trivial_numeric_casts)]
                      ^~~~~~~~~~~~~
src/feature/xattr.rs:246:21: 246:48 warning: trivial cast: `*const i8` as `*const i8`. Cast can be replaced by coercion, this might require type ascription or a temporary variable
src/feature/xattr.rs:246                     c_path.as_ptr() as *const _,
                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/main.rs:1:9: 1:22 note: lint level defined here
src/main.rs:1 #![warn(trivial_casts, trivial_numeric_casts)]
                      ^~~~~~~~~~~~~
```