### PR TITLE
Fix building without default features

### DIFF
--- a/src/fs/feature/mod.rs
+++ b/src/fs/feature/mod.rs
@@ -8,7 +8,7 @@ pub mod xattr;
 
 #[cfg(not(feature="git"))] pub struct Git;
 #[cfg(not(feature="git"))] use std::path::Path;
-#[cfg(not(feature="git"))] use file::fields;
+#[cfg(not(feature="git"))] use fs::fields;
 
 #[cfg(not(feature="git"))]
 impl Git {


### PR DESCRIPTION
this makes it possible to build with `--no-default-features` again