### PR TITLE
Add legal values to error messages

### DIFF
--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -218,7 +218,10 @@ impl SortField {
                 "cr"   | "created"    => Ok(SortField::CreatedDate),
                 "none"                => Ok(SortField::Unsorted),
                 "inode"               => Ok(SortField::FileInode),
-                field                 => Err(Misfire::bad_argument("sort", field))
+                field                 => Err(Misfire::bad_argument("sort", field, &[
+                                            "name", "Name", "size", "extension", "Extension",
+                                            "modified", "accessed", "created", "inode", "none"]
+                ))
             }
         }
         else {

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -13,7 +13,9 @@ FILTERING AND SORTING OPTIONS
   -a, --all                  show dot-files
   -d, --list-dirs            list directories as regular files
   -r, --reverse              reverse order of files
-  -s, --sort WORD            field to sort by
+  -s, --sort SORT_FIELD      field to sort by. Choices: name,
+                                 size, extension, modified,
+                                 accessed, created, inode, none
   --group-directories-first  list directories before other files
 "##;
 
@@ -28,7 +30,8 @@ LONG VIEW OPTIONS
   -L, --level DEPTH  maximum depth of recursion
   -m, --modified     display timestamp of most recent modification
   -S, --blocks       show number of file system blocks
-  -t, --time WORD    which timestamp to show for a file
+  -t, --time FIELD   which timestamp to show for a file. Choices:
+                         modified, accessed, created
   -u, --accessed     display timestamp of last access for a file
   -U, --created      display timestamp of creation for a file
 "##;

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -297,7 +297,8 @@ impl TimeTypes {
                 "mod" | "modified"  => Ok(TimeTypes { accessed: false, modified: true,  created: false }),
                 "acc" | "accessed"  => Ok(TimeTypes { accessed: true,  modified: false, created: false }),
                 "cr"  | "created"   => Ok(TimeTypes { accessed: false, modified: false, created: true  }),
-                otherwise           => Err(Misfire::bad_argument("time", otherwise)),
+                otherwise           => Err(Misfire::bad_argument("time", otherwise,
+                                                                 &["modified", "accessed", "created"])),
             }
         }
         else if modified || created || accessed {
@@ -345,7 +346,8 @@ impl TerminalColours {
                 "always"              => Ok(TerminalColours::Always),
                 "auto" | "automatic"  => Ok(TerminalColours::Automatic),
                 "never"               => Ok(TerminalColours::Never),
-                otherwise             => Err(Misfire::bad_argument("color", otherwise))
+                otherwise             => Err(Misfire::bad_argument("color", otherwise,
+                                                                   &["always", "auto", "never"]))
             }
         }
         else {


### PR DESCRIPTION
Now when you do `--sort time` instead of saying "unknown option --sort
time" it will say "unknown options '--sort time' (choices: name...)"
with all legal options.

This also adds the legal values to the default help text.

With this, running exa with bad options looks like:

```
$ target/debug/exa -s blah src
Unrecognized option: '--sort blah'. (choices: name Name size extension Extension modified accessed created inode none)
$ target/debug/exa -lt blah src
Unrecognized option: '--time blah'. (choices: modified accessed created)
$ target/debug/exa --color blah src
Unrecognized option: '--color blah'. (choices: always auto never)
```