### PR TITLE
Exit with a non-zero status on error

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -10,13 +10,18 @@ fn main() {
     let mut stdout = stdout();
 
     match Exa::new(&args, &mut stdout) {
-        Ok(mut exa) => if let Err(e) = exa.run() {
-            match e.kind() {
-                ErrorKind::BrokenPipe => exit(0),
-                _ => {
-                    writeln!(stderr(), "{}", e).unwrap();
-                    exit(1);
-                },
+        Ok(mut exa) => {
+            match exa.run() {
+                Ok(exit_status) => exit(exit_status),
+                Err(e) => {
+                    match e.kind() {
+                        ErrorKind::BrokenPipe => exit(0),
+                        _ => {
+                            writeln!(stderr(), "{}", e).unwrap();
+                            exit(1);
+                        },
+                    };
+                }
             };
         },
         Err(e) => {


### PR DESCRIPTION
With `ls` from Debian coreutils 8.26-2

```
ls /bad/path
echo $? # => 2
```

Reproduced same behaviour with exa

Fix https://github.com/ogham/exa/issues/135
Compilation depend on https://github.com/ogham/exa/pull/145