### PR TITLE
Don't prepend current path to symlink targets

### DIFF
--- a/xtests/links_1
+++ b/xtests/links_1
@@ -1,4 +1,4 @@
-[36mbroken[0m [31m->[0m [4;31m/testcases/links/nowhere[0m
+[36mbroken[0m [31m->[0m [4;31mnowhere[0m
 [36mforbidden[0m [31m->[0m [4;31m/proc/1/root[0m
 [36mroot[0m [38;5;244m->[0m [1;34m/[0m
 [36musr[0m [38;5;244m->[0m [36m/[1;34musr[0m

--- a/xtests/links_T
+++ b/xtests/links_T
@@ -1,5 +1,5 @@
 [36m/testcases/[1;34mlinks[0m
-[38;5;244m├──[0m [36mbroken[0m [31m->[0m [4;31m/testcases/links/nowhere[0m
+[38;5;244m├──[0m [36mbroken[0m [31m->[0m [4;31mnowhere[0m
 [38;5;244m│  └──[0m [31m<No such file or directory (os error 2)>[0m
 [38;5;244m├──[0m [36mforbidden[0m [31m->[0m [4;31m/proc/1/root[0m
 [38;5;244m│  └──[0m [31m<Permission denied (os error 13)>[0m


### PR DESCRIPTION
It's confusing, and `ls` doesn't do this either. We're not prepending the current path to all of the directory entries, and the user is going to interpret the symlink target as relative to the directory containing the symlink.

Also do a little dance to avoid unnecessarily copying the path buffers.

This is going to conflict with #168, but it's a small conflict, and if you merge one of the two PRs I can update the second accordingly.