### PR TITLE
Add snap support for ease of deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
+parts
+prime
+stage
 target
 
 .vagrant
 ubuntu-xenial-16.04-cloudimg-console.log
+*.snap

--- a/snap/.gitignore
+++ b/snap/.gitignore
@@ -1,0 +1,1 @@
+.snapcraft

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: exa
+version: 'latest'
+summary: Replacement for 'ls' written in Rust
+description: |
+  It uses colours for information by default, helping you distinguish between
+  many types of files, such as whether you are the owner, or in the owning
+  group. It also has extra features not present in the original ls, such as
+  viewing the Git status for a directory, or recursing into directories with a
+  tree view. exa is written in Rust, so it’s small, fast, and portable.
+
+grade: stable
+confinement: classic
+
+apps:
+  exa:
+    command: exa
+
+parts:
+  exa:
+    plugin: rust
+    source: .
+    stage-packages:
+      - libgit2-24
+      - cmake
+      - libz-dev


### PR DESCRIPTION
I left out instructions for how to install since project owner should be the one setting up Snap Store deployment via https://snapcraft.io/.

I have verified that building the snap locally and installing does work as expected.