### PR TITLE
Makefile: Fix ZSH completions install path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 endef
 
 $(eval $(call compdir,BASHDIR,bash-completion,$(PREFIX)/etc/bash_completion.d))
-ZSHDIR  = /usr/share/zsh/vendor-completions
+ZSHDIR  = /usr/share/zsh/site-functions
 $(eval $(call compdir,FISHDIR,fish,$(PREFIX)/share/fish/vendor_completions.d))
 
 FEATURES ?= default


### PR DESCRIPTION
I believe the correct location for ZSH completions is `/usr/share/zsh/site-functions`, not  `/usr/share/zsh/vendor-completions`. This seems to be consistent with other projects I've referenced, e.g.:

- [pacaur](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=pacaur#n31)
- [hub](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=hub-git#n33)