### PR TITLE
Add extra types to compressed filetype filter.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -168,6 +168,9 @@ Vagrant.configure(2) do |config|
         touch "#{test_dir}/file-names-exts/COMPRESSED.ZIP"
         touch "#{test_dir}/file-names-exts/compressed.tar.gz"
         touch "#{test_dir}/file-names-exts/compressed.tgz"
+        touch "#{test_dir}/file-names-exts/compressed.tar.xz"
+        touch "#{test_dir}/file-names-exts/compressed.txz"
+        touch "#{test_dir}/file-names-exts/compressed.deb"
 
         touch "#{test_dir}/file-names-exts/backup~"
         touch "#{test_dir}/file-names-exts/#SAVEFILE#"

--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -69,8 +69,9 @@ impl FileExtensions {
 
     pub fn is_compressed(&self, file: &File) -> bool {
         file.extension_is_one_of( &[
-            "zip", "tar", "Z", "gz", "bz2", "a", "ar", "7z",
-            "iso", "dmg", "tc", "rar", "par", "tgz",
+            "zip", "tar", "Z", "z", "gz", "bz2", "a", "ar", "7z",
+            "iso", "dmg", "tc", "rar", "par", "tgz", "xz", "txz",
+            "lzma", "deb", "rpm"
         ])
     }
 

--- a/xtests/file-names-exts
+++ b/xtests/file-names-exts
@@ -4,8 +4,11 @@
 compiled.coffee
 [38;5;137mcompiled.js[0m
 [38;5;137mcompiled.o[0m
+[31mcompressed.deb[0m
 [31mcompressed.tar.gz[0m
+[31mcompressed.tar.xz[0m
 [31mcompressed.tgz[0m
+[31mcompressed.txz[0m
 [31mCOMPRESSED.ZIP[0m
 [38;5;109mcrypto.asc[0m
 [38;5;109mcrypto.signature[0m

--- a/xtests/file-names-exts-case
+++ b/xtests/file-names-exts-case
@@ -10,8 +10,11 @@
 compiled.coffee
 [38;5;137mcompiled.js[0m
 [38;5;137mcompiled.o[0m
+[31mcompressed.deb[0m
 [31mcompressed.tar.gz[0m
+[31mcompressed.tar.xz[0m
 [31mcompressed.tgz[0m
+[31mcompressed.txz[0m
 [38;5;109mcrypto.asc[0m
 [38;5;109mcrypto.signature[0m
 [38;5;105mdocument.pdf[0m

--- a/xtests/file-names-exts-ext
+++ b/xtests/file-names-exts-ext
@@ -5,6 +5,7 @@
 [38;5;135mVIDEO.AVI[0m
 [38;5;137mcompiled.class[0m
 compiled.coffee
+[31mcompressed.deb[0m
 [38;5;93mlossless.flac[0m
 [31mcompressed.tar.gz[0m
 [38;5;137mcompiled.js[0m
@@ -17,7 +18,9 @@ compiled.coffee
 [38;5;133mimage.svg[0m
 [31mcompressed.tgz[0m
 [38;5;244mfile.tmp[0m
+[31mcompressed.txz[0m
 [38;5;93mlossless.wav[0m
 [38;5;135mvideo.wmv[0m
 [38;5;105mDOCUMENT.XLSX[0m
+[31mcompressed.tar.xz[0m
 [31mCOMPRESSED.ZIP[0m

--- a/xtests/file-names-exts-ext-case
+++ b/xtests/file-names-exts-ext-case
@@ -5,6 +5,7 @@
 [38;5;135mVIDEO.AVI[0m
 [38;5;137mcompiled.class[0m
 compiled.coffee
+[31mcompressed.deb[0m
 [38;5;93mlossless.flac[0m
 [31mcompressed.tar.gz[0m
 [38;5;137mcompiled.js[0m
@@ -17,7 +18,9 @@ compiled.coffee
 [38;5;133mimage.svg[0m
 [31mcompressed.tgz[0m
 [38;5;244mfile.tmp[0m
+[31mcompressed.txz[0m
 [38;5;93mlossless.wav[0m
 [38;5;135mvideo.wmv[0m
 [38;5;105mDOCUMENT.XLSX[0m
+[31mcompressed.tar.xz[0m
 [31mCOMPRESSED.ZIP[0m


### PR DESCRIPTION
This adds a few more common compressed filetypes to the is_compressed
fuction. Notably, xz, and two common package file formats, deb and rpm.

Arch Linux's default `dircolors` sets all of the following extensions to be colored with `01;31` for bold red. They represent compressed files or other archives. They are `tar tgz arc arj taz lha lz4 lzh lzma tlz txz tzo t7z zip z Z dz gz lrz lz lzo xz zst tzst bz2 bz tbz tbz2 tz deb rpm jar war ear sar rar alz ace zoo cpio 7z rz cab wim swm dwm esd`. I thought that I would bring exa more in line with this as it was surprising when an `xz` archive was not colored.