### PR TITLE
Add Sorting Flag `canonical`

### DIFF
--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -191,6 +191,9 @@ pub enum SortField {
     /// bad, even though that’s kind of nonsensical. So it’s its own variant
     /// that can be reversed like usual.
     ModifiedAge,
+
+    /// Sort canonically to `ls`.
+    Canonical,
 }
 
 /// Whether a field should be sorted case-sensitively or case-insensitively.
@@ -251,6 +254,11 @@ impl SortField {
 
             SortField::Extension(AaBbCc) => match a.ext.cmp(&b.ext) {
                 Ordering::Equal  => natord::compare_ignore_case(&*a.name, &*b.name),
+                order            => order,
+            },
+
+            SortField::Canonical => match a.name.cmp(&b.name) {
+                Ordering::Equal  => natord::compare(&*a.name, &*b.name),
                 order            => order,
             },
         }

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -231,6 +231,7 @@ impl SortField {
 
         match *self {
             SortField::Unsorted  => Ordering::Equal,
+            SortField::Canonical => a.name.cmp(&b.name),
 
             SortField::Name(ABCabc)  => natord::compare(&a.name, &b.name),
             SortField::Name(AaBbCc)  => natord::compare_ignore_case(&a.name, &b.name),
@@ -254,11 +255,6 @@ impl SortField {
 
             SortField::Extension(AaBbCc) => match a.ext.cmp(&b.ext) {
                 Ordering::Equal  => natord::compare_ignore_case(&*a.name, &*b.name),
-                order            => order,
-            },
-
-            SortField::Canonical => match a.name.cmp(&b.name) {
-                Ordering::Equal  => natord::compare(&*a.name, &*b.name),
                 order            => order,
             },
         }

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -78,6 +78,9 @@ impl SortField {
         else if word == "none" {
             Ok(SortField::Unsorted)
         }
+        else if word == "canonical" {
+            Ok(SortField::Canonical)
+        }
         else {
             Err(Misfire::BadArgument(&flags::SORT, word.into()))
         }
@@ -217,22 +220,23 @@ mod test {
         use super::*;
 
         // Default behaviour
-        test!(empty:         SortField <- [];                  Both => Ok(SortField::default()));
+        test!(empty:         SortField <- [];                      Both => Ok(SortField::default()));
 
         // Sort field arguments
-        test!(one_arg:       SortField <- ["--sort=cr"];       Both => Ok(SortField::CreatedDate));
-        test!(one_long:      SortField <- ["--sort=size"];     Both => Ok(SortField::Size));
-        test!(one_short:     SortField <- ["-saccessed"];      Both => Ok(SortField::AccessedDate));
-        test!(lowercase:     SortField <- ["--sort", "name"];  Both => Ok(SortField::Name(SortCase::AaBbCc)));
-        test!(uppercase:     SortField <- ["--sort", "Name"];  Both => Ok(SortField::Name(SortCase::ABCabc)));
-        test!(old:           SortField <- ["--sort", "new"];   Both => Ok(SortField::ModifiedDate));
-        test!(oldest:        SortField <- ["--sort=newest"];   Both => Ok(SortField::ModifiedDate));
-        test!(new:           SortField <- ["--sort", "old"];   Both => Ok(SortField::ModifiedAge));
-        test!(newest:        SortField <- ["--sort=oldest"];   Both => Ok(SortField::ModifiedAge));
-        test!(age:           SortField <- ["-sage"];           Both => Ok(SortField::ModifiedAge));
+        test!(one_arg:       SortField <- ["--sort=cr"];           Both => Ok(SortField::CreatedDate));
+        test!(one_long:      SortField <- ["--sort=size"];         Both => Ok(SortField::Size));
+        test!(one_short:     SortField <- ["-saccessed"];          Both => Ok(SortField::AccessedDate));
+        test!(lowercase:     SortField <- ["--sort", "name"];      Both => Ok(SortField::Name(SortCase::AaBbCc)));
+        test!(uppercase:     SortField <- ["--sort", "Name"];      Both => Ok(SortField::Name(SortCase::ABCabc)));
+        test!(old:           SortField <- ["--sort", "new"];       Both => Ok(SortField::ModifiedDate));
+        test!(oldest:        SortField <- ["--sort=newest"];       Both => Ok(SortField::ModifiedDate));
+        test!(new:           SortField <- ["--sort", "old"];       Both => Ok(SortField::ModifiedAge));
+        test!(newest:        SortField <- ["--sort=oldest"];       Both => Ok(SortField::ModifiedAge));
+        test!(age:           SortField <- ["-sage"];               Both => Ok(SortField::ModifiedAge));
+        test!(canonical:     SortField <- ["--sort", "canonical"]; Both => Ok(SortField::Canonical));
 
         // Errors
-        test!(error:         SortField <- ["--sort=colour"];   Both => Err(Misfire::BadArgument(&flags::SORT, OsString::from("colour"))));
+        test!(error:         SortField <- ["--sort=colour"];       Both => Err(Misfire::BadArgument(&flags::SORT, OsString::from("colour"))));
 
         // Overriding
         test!(overridden:    SortField <- ["--sort=cr",       "--sort", "mod"];     Last => Ok(SortField::ModifiedDate));

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -31,8 +31,9 @@ pub static IGNORE_GLOB: Arg = Arg { short: Some(b'I'), long: "ignore-glob", take
 pub static GIT_IGNORE:  Arg = Arg { short: None, long: "git-ignore",           takes_value: TakesValue::Forbidden };
 pub static DIRS_FIRST:  Arg = Arg { short: None, long: "group-directories-first",  takes_value: TakesValue::Forbidden };
 const SORTS: Values = &[ "name", "Name", "size", "extension",
-                             "Extension", "modified", "accessed",
-                             "created", "inode", "type", "none" ];
+                         "Extension", "modified", "accessed",
+                         "created", "inode", "type", "canonical", 
+                         "none" ];
 
 // display options
 pub static BINARY:     Arg = Arg { short: Some(b'b'), long: "binary",     takes_value: TakesValue::Forbidden };


### PR DESCRIPTION
Add option to disable natural sorting #293.

This PR adds the `canonical` sorting flag which aims to sort the output of `exa -l` similarly to the way `ls -l` sorts its list.

From the examples shown in #293:

```bash
$  ls -l
total 72
-rw-rw-r-- 1 joshleeb joshleeb 0 Oct 24 15:02 16
-rw-rw-r-- 1 joshleeb joshleeb 0 Oct 24 14:41 20151104-172114.nav
-rw-rw-r-- 1 joshleeb joshleeb 0 Oct 24 14:41 20151104-172114_TOW322807-322854.las_converted
-rw-rw-r-- 1 joshleeb joshleeb 0 Oct 24 14:41 20151104-172114_TOW322814-324313.las_converted
-rw-rw-r-- 1 joshleeb joshleeb 0 Oct 24 15:02 26
-rw-rw-r-- 1 joshleeb joshleeb 0 Oct 24 15:02 36
-rw-rw-r-- 1 joshleeb joshleeb 0 Oct 24 14:40 366be5b7-3d54-469a-bf75-79dd7da29207.cesium
-rw-rw-r-- 1 joshleeb joshleeb 0 Oct 24 14:41 366be5b7-3d54-469a-bf75-79dd7da29207.entwine
-rw-rw-r-- 1 joshleeb joshleeb 0 Oct 24 15:02 46

$  exa -l -s canonical
.rw-rw-r-- 0 joshleeb 24 Oct 15:02 16
.rw-rw-r-- 0 joshleeb 24 Oct 14:41 20151104-172114.nav
.rw-rw-r-- 0 joshleeb 24 Oct 14:41 20151104-172114_TOW322807-322854.las_converted
.rw-rw-r-- 0 joshleeb 24 Oct 14:41 20151104-172114_TOW322814-324313.las_converted
.rw-rw-r-- 0 joshleeb 24 Oct 15:02 26
.rw-rw-r-- 0 joshleeb 24 Oct 15:02 36
.rw-rw-r-- 0 joshleeb 24 Oct 14:40 366be5b7-3d54-469a-bf75-79dd7da29207.cesium
.rw-rw-r-- 0 joshleeb 24 Oct 14:41 366be5b7-3d54-469a-bf75-79dd7da29207.entwine
.rw-rw-r-- 0 joshleeb 24 Oct 15:02 46
```