### PR TITLE
Don't treat .ts as a video file extension

### DIFF
--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -39,7 +39,6 @@ impl FileExtensions {
         file.extension_is_one_of( &[
             "avi", "flv", "m2v", "mkv", "mov", "mp4", "mpeg",
             "mpg", "ogm", "ogv", "vob", "wmv", "webm", "m2ts",
-            "ts",
         ])
     }
 


### PR DESCRIPTION
It was originally added in #224, where the TypeScript concern was already brought up. Given the target audience of `exa`, my guess is that it's more likely the user will be dealing with TypeScript files rather than `.ts` video files. In the most recent [Stack Overflow developer survey](https://insights.stackoverflow.com/survey/2018#most-loved-dreaded-and-wanted), TypeScript was the number 4 most loved language and number 5 most wanted. It's hard to draw conclusions from that, but I think it's fair to say that it's not an obscure technology.

Thanks for making `exa`, by the way! I love the colors. :rainbow: 