### PR TITLE
Replace fixed colors by named ones so that it works well with any color scheme

### DIFF
--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -107,16 +107,16 @@ impl FileColours for FileExtensions {
         use ansi_term::Colour::*;
 
         Some(match file {
-            f if self.is_temp(f)        => Fixed(244).normal(),
+            f if self.is_temp(f)        => White.normal(),
             f if self.is_immediate(f)   => Yellow.bold().underline(),
-            f if self.is_image(f)       => Fixed(133).normal(),
-            f if self.is_video(f)       => Fixed(135).normal(),
-            f if self.is_music(f)       => Fixed(92).normal(),
-            f if self.is_lossless(f)    => Fixed(93).normal(),
-            f if self.is_crypto(f)      => Fixed(109).normal(),
-            f if self.is_document(f)    => Fixed(105).normal(),
+            f if self.is_image(f)       => Purple.normal(),
+            f if self.is_video(f)       => Purple.bold(),
+            f if self.is_music(f)       => Cyan.normal(),
+            f if self.is_lossless(f)    => Cyan.bold(),
+            f if self.is_crypto(f)      => Green.bold(),
+            f if self.is_document(f)    => Green.normal(),
             f if self.is_compressed(f)  => Red.normal(),
-            f if self.is_compiled(f)    => Fixed(137).normal(),
+            f if self.is_compiled(f)    => Yellow.normal(),
             _                           => return None,
         })
     }

--- a/src/theme/default_theme.rs
+++ b/src/theme/default_theme.rs
@@ -66,7 +66,7 @@ impl UiStyles {
                 conflicted:  Red.normal(),
             },
 
-            punctuation:  Fixed(244).normal(),
+            punctuation:  Black.bold(),
             date:         Blue.normal(),
             inode:        Purple.normal(),
             blocks:       Cyan.normal(),
@@ -114,17 +114,17 @@ impl Size {
             major:  Green.bold(),
             minor:  Green.normal(),
 
-            number_byte: Fixed(118).normal(),
-            number_kilo: Fixed(190).normal(),
-            number_mega: Fixed(226).normal(),
-            number_giga: Fixed(220).normal(),
-            number_huge: Fixed(214).normal(),
+            number_byte: Green.normal(),
+            number_kilo: Green.bold(),
+            number_mega: Yellow.normal(),
+            number_giga: Red.normal(),
+            number_huge: Purple.normal(),
 
             unit_byte: Green.normal(),
-            unit_kilo: Green.normal(),
-            unit_mega: Green.normal(),
-            unit_giga: Green.normal(),
-            unit_huge: Green.normal(),
+            unit_kilo: Green.bold(),
+            unit_mega: Yellow.normal(),
+            unit_giga: Red.normal(),
+            unit_huge: Purple.normal(),
         }
     }
 }


### PR DESCRIPTION
fix #359 (when using `--colo[u]r-scale`)
fix #338 
fix #363

For `--colo[u]r-scale`, I used distinct values a bit like [k zsh script](https://github.com/supercrabtree/k#file-weight-colours)., it’s much more readable and so useful.