### PR TITLE
make exa on symlinks to directories show their contents

### DIFF
--- a/src/exa.rs
+++ b/src/exa.rs
@@ -131,7 +131,7 @@ impl<'args, 'w, W: Write + 'w> Exa<'args, 'w, W> {
                     writeln!(stderr(), "{:?}: {}", file_path, e)?;
                 },
                 Ok(f) => {
-                    if f.is_directory() && !self.options.dir_action.treat_dirs_as_files() {
+                    if f.points_to_directory() && !self.options.dir_action.treat_dirs_as_files() {
                         match f.to_dir() {
                             Ok(d) => dirs.push(d),
                             Err(e) => writeln!(stderr(), "{:?}: {}", file_path, e)?,

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -111,6 +111,22 @@ impl<'dir> File<'dir> {
         self.metadata.is_dir()
     }
 
+    /// Whether this file is a directory, or a symlink pointing to a directory.
+    pub fn points_to_directory(&self) -> bool {
+        if self.is_directory() {
+            return true;
+        }
+
+        if self.is_link() {
+            let target = self.link_target();
+            if let FileTarget::Ok(target) = target {
+                return target.points_to_directory();
+            }
+        }
+
+        return false;
+    }
+
     /// If this file is a directory on the filesystem, then clone its
     /// `PathBuf` for use in one of our own `Dir` values, and read a list of
     /// its contents.


### PR DESCRIPTION
right now, `exa foo` and `exa foo/` behave differently, which is
confusing.

fixes https://github.com/ogham/exa/issues/192