### PR TITLE
Flag for only showing directories

### DIFF
--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -41,7 +41,7 @@ pub struct FileFilter {
     /// ones, depending on the sort field.
     pub reverse: bool,
 
-    /// Whether to only show directories
+    /// Whether to only show directories.
     pub only_dirs: bool,
 
     /// Which invisible “dot” files to include when listing a directory.

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -41,6 +41,9 @@ pub struct FileFilter {
     /// ones, depending on the sort field.
     pub reverse: bool,
 
+    /// Whether to only show directories
+    pub only_dirs: bool,
+
     /// Which invisible “dot” files to include when listing a directory.
     ///
     /// Files starting with a single “.” are used to determine “system” or
@@ -94,6 +97,10 @@ impl FileFilter {
     /// filter predicate for files found inside a directory.
     pub fn filter_child_files(&self, files: &mut Vec<File>) {
         files.retain(|f| !self.ignore_patterns.is_ignored(&f.name));
+
+        if self.only_dirs {
+            files.retain(|f| f.is_directory());
+        }
     }
 
     /// Remove every file in the given vector that does *not* pass the

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -14,6 +14,7 @@ impl FileFilter {
         Ok(FileFilter {
             list_dirs_first: matches.has(&flags::DIRS_FIRST)?,
             reverse:         matches.has(&flags::REVERSE)?,
+            only_dirs:       matches.has(&flags::ONLY_DIRS)?,
             sort_field:      SortField::deduce(matches)?,
             dot_filter:      DotFilter::deduce(matches)?,
             ignore_patterns: IgnorePatterns::deduce(matches)?,

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -30,6 +30,7 @@ pub static SORT:        Arg = Arg { short: Some(b's'), long: "sort",        take
 pub static IGNORE_GLOB: Arg = Arg { short: Some(b'I'), long: "ignore-glob", takes_value: TakesValue::Necessary(None) };
 pub static GIT_IGNORE:  Arg = Arg { short: None, long: "git-ignore",           takes_value: TakesValue::Forbidden };
 pub static DIRS_FIRST:  Arg = Arg { short: None, long: "group-directories-first",  takes_value: TakesValue::Forbidden };
+pub static ONLY_DIRS:   Arg = Arg { short: None, long: "only-dirs", takes_value: TakesValue::Forbidden };
 const SORTS: Values = &[ "name", "Name", "size", "extension",
                              "Extension", "modified", "accessed",
                              "created", "inode", "type", "none" ];
@@ -62,7 +63,7 @@ pub static ALL_ARGS: Args = Args(&[
     &COLOR, &COLOUR, &COLOR_SCALE, &COLOUR_SCALE,
 
     &ALL, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST,
-    &IGNORE_GLOB, &GIT_IGNORE,
+    &IGNORE_GLOB, &GIT_IGNORE, &ONLY_DIRS,
 
     &BINARY, &BYTES, &GROUP, &HEADER, &INODE, &LINKS, &MODIFIED, &BLOCKS,
     &TIME, &ACCESSED, &CREATED, &TIME_STYLE,

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -30,7 +30,7 @@ pub static SORT:        Arg = Arg { short: Some(b's'), long: "sort",        take
 pub static IGNORE_GLOB: Arg = Arg { short: Some(b'I'), long: "ignore-glob", takes_value: TakesValue::Necessary(None) };
 pub static GIT_IGNORE:  Arg = Arg { short: None, long: "git-ignore",           takes_value: TakesValue::Forbidden };
 pub static DIRS_FIRST:  Arg = Arg { short: None, long: "group-directories-first",  takes_value: TakesValue::Forbidden };
-pub static ONLY_DIRS:   Arg = Arg { short: None, long: "only-dirs", takes_value: TakesValue::Forbidden };
+pub static ONLY_DIRS:   Arg = Arg { short: Some(b'D'), long: "only-dirs", takes_value: TakesValue::Forbidden };
 const SORTS: Values = &[ "name", "Name", "size", "extension",
                              "Extension", "modified", "accessed",
                              "created", "inode", "type", "none" ];


### PR DESCRIPTION
Implement a filter and associated short and long flags ('-D', '--only-dirs')
to only show directories. The goal was to get this to work in the tree
view, but it was easiest to implement it globally.

Closes #401 