### PR TITLE
Add support for Apple's M4V format

### DIFF
--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -37,7 +37,7 @@ impl FileExtensions {
 
     fn is_video(&self, file: &File) -> bool {
         file.extension_is_one_of( &[
-            "avi", "flv", "m2v", "mkv", "mov", "mp4", "mpeg",
+            "avi", "flv", "m2v", "m4v", "mkv", "mov", "mp4", "mpeg",
             "mpg", "ogm", "ogv", "vob", "wmv", "webm", "m2ts",
         ])
     }


### PR DESCRIPTION
Closes https://github.com/ogham/exa/issues/417

This commit makes it so `.m4v` files are recognized as proper video files.
![exa2](https://user-images.githubusercontent.com/27262868/46331819-9d2eb000-c5e7-11e8-86c7-26f2afb579d3.png)

The first command is before the commit, and the second is from after.
All tests pass.