### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ exa’s options are almost, but not quite, entirely unlike `ls`'s.
 - **-r**, **--reverse**: reverse the sort order
 - **-s**, **--sort=(field)**: which field to sort by
 - **--group-directories-first**: list directories before other files
+- **-D**, **--only-dirs**: list only directories
 - **--git-ignore**: ignore files mentioned in `.gitignore`
 - **-I**, **--ignore-glob=(globs)**: glob patterns (pipe-separated) of files to ignore
 

--- a/contrib/man/exa.1
+++ b/contrib/man/exa.1
@@ -74,6 +74,11 @@ list directories like regular files
 .RS
 .RE
 .TP
+.B \-L, \-\-level=\f[I]DEPTH\f[]
+limit the depth of recursion
+.RS
+.RE
+.TP
 .B \-r, \-\-reverse
 reverse the sort order
 .RS
@@ -134,11 +139,6 @@ list each file\[aq]s number of hard links
 .TP
 .B \-i, \-\-inode
 list each file\[aq]s inode number
-.RS
-.RE
-.TP
-.B \-L, \-\-level=\f[I]DEPTH\f[]
-limit the depth of recursion
 .RS
 .RE
 .TP

--- a/contrib/man/exa.1
+++ b/contrib/man/exa.1
@@ -107,6 +107,11 @@ ignore files mentioned in '.gitignore'
 list directories before other files
 .RS
 .RE
+.TP
+.B \-D, \-\-only\-dirs
+list only directories
+.RS
+.RE
 .SH LONG VIEW OPTIONS
 .PP
 These options are available when running with \f[C]\-\-long\f[]

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -27,6 +27,7 @@ FILTERING AND SORTING OPTIONS
   -r, --reverse              reverse the sort order
   -s, --sort SORT_FIELD      which field to sort by
   --group-directories-first  list directories before other files
+  -D, --only-dirs            list only directories
   -I, --ignore-glob GLOBS    glob patterns (pipe-separated) of files to ignore
   --git-ignore               Ignore files mentioned in '.gitignore'
   Valid sort fields:         name, Name, extension, Extension, size, type,

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -23,6 +23,7 @@ DISPLAY OPTIONS
 FILTERING AND SORTING OPTIONS
   -a, --all                  show hidden and 'dot' files
   -d, --list-dirs            list directories like regular files
+  -L, --level DEPTH          limit the depth of recursion
   -r, --reverse              reverse the sort order
   -s, --sort SORT_FIELD      which field to sort by
   --group-directories-first  list directories before other files
@@ -41,7 +42,6 @@ LONG VIEW OPTIONS
   -h, --header       add a header row to each column
   -H, --links        list each file's number of hard links
   -i, --inode        list each file's inode number
-  -L, --level DEPTH  limit the depth of recursion
   -m, --modified     use the modified timestamp field
   -S, --blocks       show number of file system blocks
   -t, --time FIELD   which timestamp field to list (modified, accessed, created)


### PR DESCRIPTION
Moves --level option to the filtering group in help and manpage and documents --only-dirs (#405).