### PR TITLE
Add support for building snaps via snapcraft

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: exa
+version: git
+summary: "A modern version of ‘ls’"
+description: |
+  exa is a replacement for ls written in Rust..
+
+grade: stable
+confinement: classic
+
+parts:
+  exa:
+    plugin: rust
+    source: ./
+    build-packages:
+      - libgit2-dev
+      - cmake
+    stage-packages:
+      - libhttp-parser2.1
+
+apps:
+  exa:
+    command: bin/exa


### PR DESCRIPTION
I created a snap package of exa so it can be featured to the millions of Linux users installing apps from the [Snap Store](https://snapcraft.io/store). If you're willing to publish this under the exa project name, you just need to [create an account](https://snapcraft.io/snaps) and then [register the exa name](https://snapcraft.io/register-snap).

The snap file created by snapcraft can then be released in the Snap Store with snap push --release stable *.snap. You'll want to install snapcraft (brew install snapcraft, snap install snapcraft, or apt install snapcraft) and login (snapcraft login) first, though.

Once in the snap store, you’ll need to [request classic confinement](https://forum.snapcraft.io/t/process-for-reviewing-classic-confinement-snaps/1460) with a [forum post](https://forum.snapcraft.io/), because exa will need to be unconfined (via classic confinement) so it has access to the entire filesystem.

You may also want to consider using [https://build.snapcraft.io/](https://build.snapcraft.io/) which is a free build service, that can create armhf, amd64, i386, arm64 and other builds of exa, and push them to the store automatically.

Thanks for making exa! :)
