### PR TITLE
Use more accurate time (fix inconsistent sorting)

### DIFF
--- a/src/fs/fields.rs
+++ b/src/fs/fields.rs
@@ -167,7 +167,7 @@ pub struct DeviceIDs {
 
 
 /// One of a file’s timestamps (created, accessed, or modified).
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Time {
     pub seconds: time_t,
     pub nanoseconds: time_t,

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -245,10 +245,10 @@ impl SortField {
 
             SortField::Size          => a.metadata.len().cmp(&b.metadata.len()),
             SortField::FileInode     => a.metadata.ino().cmp(&b.metadata.ino()),
-            SortField::ModifiedDate  => a.metadata.mtime().cmp(&b.metadata.mtime()),
-            SortField::AccessedDate  => a.metadata.atime().cmp(&b.metadata.atime()),
-            SortField::CreatedDate   => a.metadata.ctime().cmp(&b.metadata.ctime()),
-            SortField::ModifiedAge   => b.metadata.mtime().cmp(&a.metadata.mtime()),  // flip b and a
+            SortField::ModifiedDate  => a.modified_time().cmp(&b.modified_time()),
+            SortField::AccessedDate  => a.accessed_time().cmp(&b.accessed_time()),
+            SortField::CreatedDate   => a.created_time().cmp(&b.created_time()),
+            SortField::ModifiedAge   => b.modified_time().cmp(&a.modified_time()),  // flip b and a
 
             SortField::FileType => match a.type_char().cmp(&b.type_char()) { // todo: this recomputes
                 Ordering::Equal  => natord::compare(&*a.name, &*b.name),


### PR DESCRIPTION
Fix #411 

Sort based on `mtime` and `mtime_nsec()` instead of `mtime()` only, same for `atime()` and `ctime`.