### PR TITLE
Display if a file is ignored by git

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ These options are available when running with --long (`-l`):
 - **-u**, **--accessed**: use the accessed timestamp field
 - **-U**, **--created**: use the created timestamp field
 - **-@**, **--extended**: list each file's extended attributes and sizes
-- **--git**: list each file's Git status, if tracked
+- **--git**: list each file's Git status, if tracked or ignored
 - **--time-style**: how to format timestamps
 
 - Valid **--color** options are **always**, **automatic**, and **never**.

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -279,6 +279,7 @@ fn working_tree_status(status: git2::Status) -> f::GitStatus {
         s if s.contains(git2::Status::WT_DELETED)     => f::GitStatus::Deleted,
         s if s.contains(git2::Status::WT_RENAMED)     => f::GitStatus::Renamed,
         s if s.contains(git2::Status::WT_TYPECHANGE)  => f::GitStatus::TypeChange,
+        s if s.contains(git2::Status::IGNORED)        => f::GitStatus::Ignored,
         _                                             => f::GitStatus::NotModified,
     }
 }

--- a/src/fs/fields.rs
+++ b/src/fs/fields.rs
@@ -197,6 +197,9 @@ pub enum GitStatus {
 
     /// A file that’s had its type (such as the file permissions) changed.
     TypeChange,
+
+    /// A file that’s ignored (that matches a line in .gitignore)
+    Ignored,
 }
 
 /// A file’s complete Git status. It’s possible to make changes to a file, add

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -50,7 +50,7 @@ LONG VIEW OPTIONS
   -U, --created      use the created timestamp field
   --time-style       how to format timestamps (default, iso, long-iso, full-iso)"##;
 
-static GIT_HELP:      &str = r##"  --git              list each file's Git status, if tracked"##;
+static GIT_HELP:      &str = r##"  --git              list each file's Git status, if tracked or ignored"##;
 static EXTENDED_HELP: &str = r##"  -@, --extended     list each file's extended attributes and sizes"##;
 
 

--- a/src/output/render/git.rs
+++ b/src/output/render/git.rs
@@ -26,6 +26,7 @@ impl f::GitStatus {
             f::GitStatus::Deleted      => colours.deleted().paint("D"),
             f::GitStatus::Renamed      => colours.renamed().paint("R"),
             f::GitStatus::TypeChange   => colours.type_change().paint("T"),
+            f::GitStatus::Ignored      => colours.ignored().paint("I"),
         }
     }
 }
@@ -38,6 +39,7 @@ pub trait Colours {
     fn deleted(&self) -> Style;
     fn renamed(&self) -> Style;
     fn type_change(&self) -> Style;
+    fn ignored(&self) -> Style;
 }
 
 
@@ -60,6 +62,7 @@ pub mod test {
         fn deleted(&self)      -> Style { Fixed(93).normal() }
         fn renamed(&self)      -> Style { Fixed(94).normal() }
         fn type_change(&self)  -> Style { Fixed(95).normal() }
+        fn ignored(&self)      -> Style { Fixed(96).normal() }
     }
 
 

--- a/src/style/colours.rs
+++ b/src/style/colours.rs
@@ -101,6 +101,7 @@ pub struct Git {
     pub deleted: Style,
     pub renamed: Style,
     pub typechange: Style,
+    pub ignored: Style,
 }
 
 impl Colours {
@@ -177,6 +178,7 @@ impl Colours {
                 deleted:     Red.normal(),
                 renamed:     Yellow.normal(),
                 typechange:  Purple.normal(),
+                ignored:     Style::default().dimmed(),
             },
 
             punctuation:  Fixed(244).normal(),
@@ -326,6 +328,7 @@ impl render::GitColours for Colours {
     fn deleted(&self)       -> Style { self.git.deleted }
     fn renamed(&self)       -> Style { self.git.renamed }
     fn type_change(&self)   -> Style { self.git.typechange }
+    fn ignored(&self)       -> Style { self.git.ignored }
 }
 
 impl render::GroupColours for Colours {
@@ -400,4 +403,3 @@ impl FileNameColours for Colours {
     fn symlink_path(&self)        -> Style { self.symlink_path }
     fn executable_file(&self)     -> Style { self.filekinds.executable }
 }
-


### PR DESCRIPTION
Fix #431 

Display a dimmed `I` on the second column (unstaged status) when the file is ignored by git. Documentation is slightly edited to reflect the change.

Ideally, the screenshot on [the main page](https://the.exa.website/) and [the page on the git feature](https://the.exa.website/features/git) should be updated to reflect this change.