### PR TITLE
Format with cargo fmt

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,10 +9,9 @@
 ///
 /// - https://stackoverflow.com/q/43753491/3484614
 /// - https://crates.io/crates/vergen
-
 extern crate datetime;
-use std::io::Result as IOResult;
 use std::env;
+use std::io::Result as IOResult;
 
 fn git_hash() -> String {
     use std::process::Command;
@@ -20,8 +19,12 @@ fn git_hash() -> String {
     String::from_utf8_lossy(
         &Command::new("git")
             .args(&["rev-parse", "--short", "HEAD"])
-            .output().unwrap()
-            .stdout).trim().to_string()
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .trim()
+    .to_string()
 }
 
 fn main() {
@@ -51,8 +54,13 @@ fn write_statics() -> IOResult<()> {
     use std::path::PathBuf;
 
     let ver = match is_development_version() {
-        true   => format!("exa v{} ({} built on {})", cargo_version(), git_hash(), build_date()),
-        false  => format!("exa v{}", cargo_version()),
+        true => format!(
+            "exa v{} ({} built on {})",
+            cargo_version(),
+            git_hash(),
+            build_date()
+        ),
+        false => format!("exa v{}", cargo_version()),
     };
 
     let out = PathBuf::from(env::var("OUT_DIR").unwrap());

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,11 +1,10 @@
 extern crate exa;
 use exa::Exa;
 
-use std::ffi::OsString;
 use std::env::{args_os, var_os};
-use std::io::{stdout, stderr, Write, ErrorKind};
+use std::ffi::OsString;
+use std::io::{stderr, stdout, ErrorKind, Write};
 use std::process::exit;
-
 
 fn main() {
     configure_logger();
@@ -21,11 +20,11 @@ fn main() {
                         _ => {
                             eprintln!("{}", e);
                             exit(exits::RUNTIME_ERROR);
-                        },
+                        }
                     };
                 }
             };
-        },
+        }
 
         Err(ref e) if e.is_error() => {
             let mut stderr = stderr();
@@ -36,15 +35,14 @@ fn main() {
             }
 
             exit(exits::OPTIONS_ERROR);
-        },
+        }
 
         Err(ref e) => {
             println!("{}", e);
             exit(exits::SUCCESS);
-        },
+        }
     };
 }
-
 
 /// Sets up a global logger if one is asked for.
 /// The ‘EXA_DEBUG’ environment variable controls whether log messages are
@@ -58,28 +56,26 @@ pub fn configure_logger() {
     extern crate log;
 
     let present = match var_os(exa::vars::EXA_DEBUG) {
-        Some(debug)  => debug.len() > 0,
-        None         => false,
+        Some(debug) => debug.len() > 0,
+        None => false,
     };
 
     let mut logs = env_logger::Builder::new();
     if present {
         logs.filter(None, log::LevelFilter::Debug);
-    }
-    else {
+    } else {
         logs.filter(None, log::LevelFilter::Off);
     }
 
     logs.init()
 }
 
-
 extern crate libc;
 #[allow(trivial_numeric_casts)]
 mod exits {
     use libc::{self, c_int};
 
-    pub const SUCCESS:       c_int = libc::EXIT_SUCCESS;
+    pub const SUCCESS: c_int = libc::EXIT_SUCCESS;
     pub const RUNTIME_ERROR: c_int = libc::EXIT_FAILURE;
     pub const OPTIONS_ERROR: c_int = 3 as c_int;
 }

--- a/src/exa.rs
+++ b/src/exa.rs
@@ -11,31 +11,33 @@ extern crate num_cpus;
 extern crate number_prefix;
 extern crate scoped_threadpool;
 extern crate term_grid;
+extern crate term_size;
 extern crate unicode_width;
 extern crate users;
 extern crate zoneinfo_compiled;
-extern crate term_size;
 
-#[cfg(feature="git")] extern crate git2;
+#[cfg(feature = "git")]
+extern crate git2;
 
-#[macro_use] extern crate lazy_static;
-#[macro_use] extern crate log;
-
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate log;
 
 use std::env::var_os;
 use std::ffi::{OsStr, OsString};
-use std::io::{stderr, Write, Result as IOResult};
+use std::io::{stderr, Result as IOResult, Write};
 use std::path::{Component, PathBuf};
 
 use ansi_term::{ANSIStrings, Style};
 
-use fs::{Dir, File};
-use fs::feature::ignore::IgnoreCache;
 use fs::feature::git::GitCache;
-use options::{Options, Vars};
+use fs::feature::ignore::IgnoreCache;
+use fs::{Dir, File};
 pub use options::vars;
 pub use options::Misfire;
-use output::{escape, lines, grid, grid_details, details, View, Mode};
+use options::{Options, Vars};
+use output::{details, escape, grid, grid_details, lines, Mode, View};
 
 mod fs;
 mod info;
@@ -43,10 +45,8 @@ mod options;
 mod output;
 mod style;
 
-
 /// The main program wrapper.
 pub struct Exa<'args, 'w, W: Write + 'w> {
-
     /// List of command-line options, having been successfully parsed.
     pub options: Options,
 
@@ -84,8 +84,7 @@ impl Vars for LiveVars {
 fn git_options(options: &Options, args: &[&OsStr]) -> Option<GitCache> {
     if options.should_scan_for_git() {
         Some(args.iter().map(PathBuf::from).collect())
-    }
-    else {
+    } else {
         None
     }
 }
@@ -95,13 +94,15 @@ fn ignore_cache(options: &Options) -> Option<IgnoreCache> {
 
     match options.filter.git_ignore {
         GitIgnore::CheckAndIgnore => Some(IgnoreCache::new()),
-        GitIgnore::Off            => None,
+        GitIgnore::Off => None,
     }
 }
 
 impl<'args, 'w, W: Write + 'w> Exa<'args, 'w, W> {
     pub fn new<I>(args: I, writer: &'w mut W) -> Result<Exa<'args, 'w, W>, Misfire>
-    where I: Iterator<Item=&'args OsString> {
+    where
+        I: Iterator<Item = &'args OsString>,
+    {
         Options::parse(args, &LiveVars).map(move |(options, mut args)| {
             debug!("Dir action from arguments: {:#?}", options.dir_action);
             debug!("Filter from arguments: {:#?}", options.filter);
@@ -110,12 +111,18 @@ impl<'args, 'w, W: Write + 'w> Exa<'args, 'w, W> {
             // List the current directory by default, like ls.
             // This has to be done here, otherwise git_options won’t see it.
             if args.is_empty() {
-                args = vec![ OsStr::new(".") ];
+                args = vec![OsStr::new(".")];
             }
 
             let git = git_options(&options, &args);
             let ignore = ignore_cache(&options);
-            Exa { options, writer, args, git, ignore }
+            Exa {
+                options,
+                writer,
+                args,
+                git,
+                ignore,
+            }
         })
     }
 
@@ -129,18 +136,17 @@ impl<'args, 'w, W: Write + 'w> Exa<'args, 'w, W> {
                 Err(e) => {
                     exit_status = 2;
                     writeln!(stderr(), "{:?}: {}", file_path, e)?;
-                },
+                }
                 Ok(f) => {
                     if f.points_to_directory() && !self.options.dir_action.treat_dirs_as_files() {
                         match f.to_dir() {
                             Ok(d) => dirs.push(d),
                             Err(e) => writeln!(stderr(), "{:?}: {}", file_path, e)?,
                         }
-                    }
-                    else {
+                    } else {
                         files.push(f);
                     }
-                },
+                }
             }
         }
 
@@ -157,43 +163,56 @@ impl<'args, 'w, W: Write + 'w> Exa<'args, 'w, W> {
         self.print_dirs(dirs, no_files, is_only_dir, exit_status)
     }
 
-    fn print_dirs(&mut self, dir_files: Vec<Dir>, mut first: bool, is_only_dir: bool, exit_status: i32) -> IOResult<i32> {
+    fn print_dirs(
+        &mut self,
+        dir_files: Vec<Dir>,
+        mut first: bool,
+        is_only_dir: bool,
+        exit_status: i32,
+    ) -> IOResult<i32> {
         for dir in dir_files {
-
             // Put a gap between directories, or between the list of files and
             // the first directory.
             if first {
                 first = false;
-            }
-            else {
+            } else {
                 writeln!(self.writer)?;
             }
 
             if !is_only_dir {
                 let mut bits = Vec::new();
-                escape(dir.path.display().to_string(), &mut bits, Style::default(), Style::default());
+                escape(
+                    dir.path.display().to_string(),
+                    &mut bits,
+                    Style::default(),
+                    Style::default(),
+                );
                 writeln!(self.writer, "{}:", ANSIStrings(&bits))?;
             }
 
             let mut children = Vec::new();
             for file in dir.files(self.options.filter.dot_filter, self.ignore.as_ref()) {
                 match file {
-                    Ok(file)       => children.push(file),
+                    Ok(file) => children.push(file),
                     Err((path, e)) => writeln!(stderr(), "[{}: {}]", path.display(), e)?,
                 }
-            };
+            }
 
             self.options.filter.filter_child_files(&mut children);
             self.options.filter.sort_files(&mut children);
 
             if let Some(recurse_opts) = self.options.dir_action.recurse_options() {
-                let depth = dir.path.components().filter(|&c| c != Component::CurDir).count() + 1;
+                let depth = dir
+                    .path
+                    .components()
+                    .filter(|&c| c != Component::CurDir)
+                    .count()
+                    + 1;
                 if !recurse_opts.tree && !recurse_opts.is_too_deep(depth) {
-
                     let mut child_dirs = Vec::new();
                     for child_dir in children.iter().filter(|f| f.is_directory()) {
                         match child_dir.to_dir() {
-                            Ok(d)  => child_dirs.push(d),
+                            Ok(d) => child_dirs.push(d),
                             Err(e) => writeln!(stderr(), "{}: {}", child_dir.path.display(), e)?,
                         }
                     }
@@ -218,16 +237,29 @@ impl<'args, 'w, W: Write + 'w> Exa<'args, 'w, W> {
     /// printing differently...
     fn print_files(&mut self, dir: Option<&Dir>, files: Vec<File>) -> IOResult<()> {
         if !files.is_empty() {
-            let View { ref mode, ref colours, ref style } = self.options.view;
+            let View {
+                ref mode,
+                ref colours,
+                ref style,
+            } = self.options.view;
 
             match *mode {
                 Mode::Lines => {
-                    let r = lines::Render { files, colours, style };
+                    let r = lines::Render {
+                        files,
+                        colours,
+                        style,
+                    };
                     r.render(self.writer)
                 }
 
                 Mode::Grid(ref opts) => {
-                    let r = grid::Render { files, colours, style, opts };
+                    let r = grid::Render {
+                        files,
+                        colours,
+                        style,
+                        opts,
+                    };
                     r.render(self.writer)
                 }
 
@@ -235,7 +267,15 @@ impl<'args, 'w, W: Write + 'w> Exa<'args, 'w, W> {
                     let filter = &self.options.filter;
                     let recurse = self.options.dir_action.recurse_options();
 
-                    let r = details::Render { dir, files, colours, style, opts, filter, recurse };
+                    let r = details::Render {
+                        dir,
+                        files,
+                        colours,
+                        style,
+                        opts,
+                        filter,
+                        recurse,
+                    };
                     r.render(self.git.as_ref(), self.ignore.as_ref(), self.writer)
                 }
 
@@ -245,12 +285,20 @@ impl<'args, 'w, W: Write + 'w> Exa<'args, 'w, W> {
                     let details = &opts.details;
                     let row_threshold = opts.row_threshold;
 
-                    let r = grid_details::Render { dir, files, colours, style, grid, details, filter, row_threshold };
+                    let r = grid_details::Render {
+                        dir,
+                        files,
+                        colours,
+                        style,
+                        grid,
+                        details,
+                        filter,
+                        row_threshold,
+                    };
                     r.render(self.git.as_ref(), self.writer)
                 }
             }
-        }
-        else {
+        } else {
             Ok(())
         }
     }

--- a/src/fs/dir_action.rs
+++ b/src/fs/dir_action.rs
@@ -21,7 +21,6 @@
 /// directories inline, with their contents immediately underneath.
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub enum DirAction {
-
     /// This directory should be listed along with the regular files, instead
     /// of having its contents queried.
     AsFile,
@@ -37,30 +36,27 @@ pub enum DirAction {
 }
 
 impl DirAction {
-
     /// Gets the recurse options, if this dir action has any.
     pub fn recurse_options(&self) -> Option<RecurseOptions> {
         match *self {
             DirAction::Recurse(o) => Some(o),
-            _                     => None,
+            _ => None,
         }
     }
 
     /// Whether to treat directories as regular files or not.
     pub fn treat_dirs_as_files(&self) -> bool {
         match *self {
-            DirAction::AsFile      => true,
-            DirAction::Recurse(o)  => o.tree,
-            _                      => false,
+            DirAction::AsFile => true,
+            DirAction::Recurse(o) => o.tree,
+            _ => false,
         }
     }
 }
 
-
 /// The options that determine how to recurse into a directory.
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub struct RecurseOptions {
-
     /// Whether recursion should be done as a tree or as multiple individual
     /// views of files.
     pub tree: bool,
@@ -71,12 +67,11 @@ pub struct RecurseOptions {
 }
 
 impl RecurseOptions {
-
     /// Returns whether a directory of the given depth would be too deep.
     pub fn is_too_deep(&self, depth: usize) -> bool {
         match self.max_depth {
-            None    => false,
-            Some(d) => d <= depth
+            None => false,
+            Some(d) => d <= depth,
         }
     }
 }

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -7,13 +7,11 @@ use git2;
 
 use fs::fields as f;
 
-
 /// A **Git cache** is assembled based on the user’s input arguments.
 ///
 /// This uses vectors to avoid the overhead of hashing: it’s not worth it when the
 /// expected number of Git repositories per exa invocation is 0 or 1...
 pub struct GitCache {
-
     /// A list of discovered Git repositories and their paths.
     repos: Vec<GitRepo>,
 
@@ -27,7 +25,8 @@ impl GitCache {
     }
 
     pub fn get(&self, index: &Path, prefix_lookup: bool) -> f::Git {
-        self.repos.iter()
+        self.repos
+            .iter()
             .find(|e| e.has_path(index))
             .map(|repo| repo.search(index, prefix_lookup))
             .unwrap_or_default()
@@ -36,7 +35,7 @@ impl GitCache {
 
 use std::iter::FromIterator;
 impl FromIterator<PathBuf> for GitCache {
-    fn from_iter<I: IntoIterator<Item=PathBuf>>(iter: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = PathBuf>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let mut git = GitCache {
             repos: Vec::with_capacity(iter.size_hint().0),
@@ -46,22 +45,25 @@ impl FromIterator<PathBuf> for GitCache {
         for path in iter {
             if git.misses.contains(&path) {
                 debug!("Skipping {:?} because it already came back Gitless", path);
-            }
-            else if git.repos.iter().any(|e| e.has_path(&path)) {
+            } else if git.repos.iter().any(|e| e.has_path(&path)) {
                 debug!("Skipping {:?} because we already queried it", path);
-            }
-            else {
+            } else {
                 match GitRepo::discover(path) {
                     Ok(r) => {
-                        if let Some(mut r2) = git.repos.iter_mut().find(|e| e.has_workdir(&r.workdir)) {
-                            debug!("Adding to existing repo (workdir matches with {:?})", r2.workdir);
+                        if let Some(mut r2) =
+                            git.repos.iter_mut().find(|e| e.has_workdir(&r.workdir))
+                        {
+                            debug!(
+                                "Adding to existing repo (workdir matches with {:?})",
+                                r2.workdir
+                            );
                             r2.extra_paths.push(r.original_path);
                             continue;
                         }
 
                         debug!("Discovered new Git repo");
                         git.repos.push(r);
-                    },
+                    }
                     Err(miss) => git.misses.push(miss),
                 }
             }
@@ -71,12 +73,8 @@ impl FromIterator<PathBuf> for GitCache {
     }
 }
 
-
-
-
 /// A **Git repository** is one we’ve discovered somewhere on the filesystem.
 pub struct GitRepo {
-
     /// The queryable contents of the repository: either a `git2` repo, or the
     /// cached results from when we queried it last time.
     contents: Mutex<GitContents>,
@@ -97,7 +95,6 @@ pub struct GitRepo {
 
 /// A repository’s queried state.
 enum GitContents {
-
     /// All the interesting Git stuff goes through this.
     Before { repo: git2::Repository },
 
@@ -107,11 +104,10 @@ enum GitContents {
 
     /// The data we’ve extracted from the repository, but only after we’ve
     /// actually done so.
-    After { statuses: Git }
+    After { statuses: Git },
 }
 
 impl GitRepo {
-
     /// Searches through this repository for a path (to a file or directory,
     /// depending on the prefix-lookup flag) and returns its Git status.
     ///
@@ -147,7 +143,8 @@ impl GitRepo {
 
     /// Whether this repository cares about the given path at all.
     fn has_path(&self, path: &Path) -> bool {
-        path.starts_with(&self.original_path) || self.extra_paths.iter().any(|e| path.starts_with(e))
+        path.starts_with(&self.original_path)
+            || self.extra_paths.iter().any(|e| path.starts_with(e))
     }
 
     /// Searches for a Git repository at any point above the given path.
@@ -165,8 +162,13 @@ impl GitRepo {
         match repo.workdir().map(|wd| wd.to_path_buf()) {
             Some(workdir) => {
                 let contents = Mutex::new(GitContents::Before { repo });
-                Ok(GitRepo { contents, workdir, original_path: path, extra_paths: Vec::new() })
-            },
+                Ok(GitRepo {
+                    contents,
+                    workdir,
+                    original_path: path,
+                    extra_paths: Vec::new(),
+                })
+            }
             None => {
                 warn!("Repository has no workdir?");
                 Err(path)
@@ -175,7 +177,6 @@ impl GitRepo {
     }
 }
 
-
 impl GitContents {
     /// Assumes that the repository hasn’t been queried, and extracts it
     /// (consuming the value) if it has. This is needed because the entire
@@ -183,8 +184,7 @@ impl GitContents {
     fn inner_repo(self) -> git2::Repository {
         if let GitContents::Before { repo } = self {
             repo
-        }
-        else {
+        } else {
             unreachable!("Tried to extract a non-Repository")
         }
     }
@@ -205,7 +205,7 @@ fn repo_to_statuses(repo: &git2::Repository, workdir: &Path) -> Git {
                 let elem = (path, e.status());
                 statuses.push(elem);
             }
-        },
+        }
         Err(e) => error!("Error looking up Git statuses: {:?}", e),
     }
 
@@ -220,28 +220,33 @@ fn repo_to_statuses(repo: &git2::Repository, workdir: &Path) -> Git {
 // Even inserting another logging line immediately afterwards doesn't make it
 // look any faster.
 
-
 /// Container of Git statuses for all the files in this folder’s Git repository.
 struct Git {
     statuses: Vec<(PathBuf, git2::Status)>,
 }
 
 impl Git {
-
     /// Get either the file or directory status for the given path.
     /// “Prefix lookup” means that it should report an aggregate status of all
     /// paths starting with the given prefix (in other words, a directory).
     fn status(&self, index: &Path, prefix_lookup: bool) -> f::Git {
-        if prefix_lookup { self.dir_status(index) }
-                    else { self.file_status(index) }
+        if prefix_lookup {
+            self.dir_status(index)
+        } else {
+            self.file_status(index)
+        }
     }
 
     /// Get the status for the file at the given path.
     fn file_status(&self, file: &Path) -> f::Git {
         let path = reorient(file);
-        self.statuses.iter()
+        self.statuses
+            .iter()
             .find(|p| p.0.as_path() == path)
-            .map(|&(_, s)| f::Git { staged: index_status(s), unstaged: working_tree_status(s) })
+            .map(|&(_, s)| f::Git {
+                staged: index_status(s),
+                unstaged: working_tree_status(s),
+            })
             .unwrap_or_default()
     }
 
@@ -250,11 +255,16 @@ impl Git {
     /// directories, which don’t really have an ‘official’ status.
     fn dir_status(&self, dir: &Path) -> f::Git {
         let path = reorient(dir);
-        let s = self.statuses.iter()
-                             .filter(|p| p.0.starts_with(&path))
-                             .fold(git2::Status::empty(), |a, b| a | b.1);
+        let s = self
+            .statuses
+            .iter()
+            .filter(|p| p.0.starts_with(&path))
+            .fold(git2::Status::empty(), |a, b| a | b.1);
 
-        f::Git { staged: index_status(s), unstaged: working_tree_status(s) }
+        f::Git {
+            staged: index_status(s),
+            unstaged: working_tree_status(s),
+        }
     }
 }
 
@@ -266,7 +276,7 @@ fn reorient(path: &Path) -> PathBuf {
     use std::env::current_dir;
     // I’m not 100% on this func tbh
     match current_dir() {
-        Err(_)  => Path::new(".").join(&path),
+        Err(_) => Path::new(".").join(&path),
         Ok(dir) => dir.join(&path),
     }
 }
@@ -274,12 +284,12 @@ fn reorient(path: &Path) -> PathBuf {
 /// The character to display if the file has been modified, but not staged.
 fn working_tree_status(status: git2::Status) -> f::GitStatus {
     match status {
-        s if s.contains(git2::Status::WT_NEW)         => f::GitStatus::New,
-        s if s.contains(git2::Status::WT_MODIFIED)    => f::GitStatus::Modified,
-        s if s.contains(git2::Status::WT_DELETED)     => f::GitStatus::Deleted,
-        s if s.contains(git2::Status::WT_RENAMED)     => f::GitStatus::Renamed,
-        s if s.contains(git2::Status::WT_TYPECHANGE)  => f::GitStatus::TypeChange,
-        _                                             => f::GitStatus::NotModified,
+        s if s.contains(git2::Status::WT_NEW) => f::GitStatus::New,
+        s if s.contains(git2::Status::WT_MODIFIED) => f::GitStatus::Modified,
+        s if s.contains(git2::Status::WT_DELETED) => f::GitStatus::Deleted,
+        s if s.contains(git2::Status::WT_RENAMED) => f::GitStatus::Renamed,
+        s if s.contains(git2::Status::WT_TYPECHANGE) => f::GitStatus::TypeChange,
+        _ => f::GitStatus::NotModified,
     }
 }
 
@@ -287,11 +297,11 @@ fn working_tree_status(status: git2::Status) -> f::GitStatus {
 /// has been staged.
 fn index_status(status: git2::Status) -> f::GitStatus {
     match status {
-        s if s.contains(git2::Status::INDEX_NEW)         => f::GitStatus::New,
-        s if s.contains(git2::Status::INDEX_MODIFIED)    => f::GitStatus::Modified,
-        s if s.contains(git2::Status::INDEX_DELETED)     => f::GitStatus::Deleted,
-        s if s.contains(git2::Status::INDEX_RENAMED)     => f::GitStatus::Renamed,
-        s if s.contains(git2::Status::INDEX_TYPECHANGE)  => f::GitStatus::TypeChange,
-        _                                                => f::GitStatus::NotModified,
+        s if s.contains(git2::Status::INDEX_NEW) => f::GitStatus::New,
+        s if s.contains(git2::Status::INDEX_MODIFIED) => f::GitStatus::Modified,
+        s if s.contains(git2::Status::INDEX_DELETED) => f::GitStatus::Deleted,
+        s if s.contains(git2::Status::INDEX_RENAMED) => f::GitStatus::Renamed,
+        s if s.contains(git2::Status::INDEX_TYPECHANGE) => f::GitStatus::TypeChange,
+        _ => f::GitStatus::NotModified,
     }
 }

--- a/src/fs/feature/mod.rs
+++ b/src/fs/feature/mod.rs
@@ -1,20 +1,20 @@
-pub mod xattr;
 pub mod ignore;
+pub mod xattr;
 
-#[cfg(feature="git")] pub mod git;
+#[cfg(feature = "git")]
+pub mod git;
 
-#[cfg(not(feature="git"))]
+#[cfg(not(feature = "git"))]
 pub mod git {
     use std::iter::FromIterator;
     use std::path::{Path, PathBuf};
 
     use fs::fields as f;
 
-
     pub struct GitCache;
 
     impl FromIterator<PathBuf> for GitCache {
-        fn from_iter<I: IntoIterator<Item=PathBuf>>(_iter: I) -> Self {
+        fn from_iter<I: IntoIterator<Item = PathBuf>>(_iter: I) -> Self {
             GitCache
         }
     }

--- a/src/fs/fields.rs
+++ b/src/fs/fields.rs
@@ -1,4 +1,3 @@
-
 //! Wrapper types for the values returned from `File`s.
 //!
 //! The methods of `File` that return information about the entry on the
@@ -34,7 +33,6 @@ pub type time_t = i64;
 /// The type of a file’s user ID.
 pub type uid_t = u32;
 
-
 /// The file’s base type, which gets displayed in the very first column of the
 /// details output.
 ///
@@ -45,47 +43,52 @@ pub type uid_t = u32;
 /// Its ordering is used when sorting by type.
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub enum Type {
-    Directory, File, Link, Pipe, Socket, CharDevice, BlockDevice, Special,
+    Directory,
+    File,
+    Link,
+    Pipe,
+    Socket,
+    CharDevice,
+    BlockDevice,
+    Special,
 }
 
 impl Type {
     pub fn is_regular_file(&self) -> bool {
         match *self {
-            Type::File  => true,
-            _           => false,
+            Type::File => true,
+            _ => false,
         }
     }
 }
 
-
 /// The file’s Unix permission bitfield, with one entry per bit.
 pub struct Permissions {
-    pub user_read:      bool,
-    pub user_write:     bool,
-    pub user_execute:   bool,
+    pub user_read: bool,
+    pub user_write: bool,
+    pub user_execute: bool,
 
-    pub group_read:     bool,
-    pub group_write:    bool,
-    pub group_execute:  bool,
+    pub group_read: bool,
+    pub group_write: bool,
+    pub group_execute: bool,
 
-    pub other_read:     bool,
-    pub other_write:    bool,
-    pub other_execute:  bool,
+    pub other_read: bool,
+    pub other_write: bool,
+    pub other_execute: bool,
 
-    pub sticky:         bool,
-    pub setgid:         bool,
-    pub setuid:         bool,
+    pub sticky: bool,
+    pub setgid: bool,
+    pub setuid: bool,
 }
 
 /// The three pieces of information that are displayed as a single column in
 /// the details view. These values are fused together to make the output a
 /// little more compressed.
 pub struct PermissionsPlus {
-    pub file_type:   Type,
+    pub file_type: Type,
     pub permissions: Permissions,
-    pub xattrs:      bool,
+    pub xattrs: bool,
 }
-
 
 /// A file’s number of hard links on the filesystem.
 ///
@@ -94,7 +97,6 @@ pub struct PermissionsPlus {
 /// regular file to have a link count greater than 1, so we highlight the
 /// block count specifically for this case.
 pub struct Links {
-
     /// The actual link count.
     pub count: nlink_t,
 
@@ -102,23 +104,19 @@ pub struct Links {
     pub multiple: bool,
 }
 
-
 /// A file’s inode. Every directory entry on a Unix filesystem has an inode,
 /// including directories and links, so this is applicable to everything exa
 /// can deal with.
 pub struct Inode(pub ino_t);
 
-
 /// The number of blocks that a file takes up on the filesystem, if any.
 pub enum Blocks {
-
     /// This file has the given number of blocks.
     Some(blkcnt_t),
 
     /// This file isn’t of a type that can take up blocks.
     None,
 }
-
 
 /// The ID of the user that owns a file. This will only ever be a number;
 /// looking up the username is done in the `display` module.
@@ -127,11 +125,9 @@ pub struct User(pub uid_t);
 /// The ID of the group that a file belongs to.
 pub struct Group(pub gid_t);
 
-
 /// A file’s size, in bytes. This is usually formatted by the `number_prefix`
 /// crate into something human-readable.
 pub enum Size {
-
     /// This file has a defined size.
     Some(u64),
 
@@ -165,7 +161,6 @@ pub struct DeviceIDs {
     pub minor: u8,
 }
 
-
 /// One of a file’s timestamps (created, accessed, or modified).
 #[derive(Copy, Clone)]
 pub struct Time {
@@ -173,12 +168,10 @@ pub struct Time {
     pub nanoseconds: time_t,
 }
 
-
 /// A file’s status in a Git repository. Whether a file is in a repository or
 /// not is handled by the Git module, rather than having a “null” variant in
 /// this enum.
 pub enum GitStatus {
-
     /// This file hasn’t changed since the last commit.
     NotModified,
 
@@ -203,15 +196,17 @@ pub enum GitStatus {
 /// it to the staging area, then make *more* changes, so we need to list each
 /// file’s status for both of these.
 pub struct Git {
-    pub staged:   GitStatus,
+    pub staged: GitStatus,
     pub unstaged: GitStatus,
 }
 
 use std::default::Default;
 impl Default for Git {
-
     /// Create a Git status for a file with nothing done to it.
     fn default() -> Git {
-        Git { staged: GitStatus::NotModified, unstaged: GitStatus::NotModified }
+        Git {
+            staged: GitStatus::NotModified,
+            unstaged: GitStatus::NotModified,
+        }
     }
 }

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -3,12 +3,11 @@
 use std::fs;
 use std::io::Error as IOError;
 use std::io::Result as IOResult;
-use std::os::unix::fs::{MetadataExt, PermissionsExt, FileTypeExt};
+use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 use fs::dir::Dir;
 use fs::fields as f;
-
 
 /// A **File** is a wrapper around one of Rust's Path objects, along with
 /// associated data about the file.
@@ -18,7 +17,6 @@ use fs::fields as f;
 /// information queried at least once, so it makes sense to do all this at the
 /// start and hold on to all the information.
 pub struct File<'dir> {
-
     /// The filename portion of this file’s path, including the extension.
     ///
     /// This is used to compare against certain filenames (such as checking if
@@ -59,17 +57,24 @@ pub struct File<'dir> {
 
 impl<'dir> File<'dir> {
     pub fn new<PD, FN>(path: PathBuf, parent_dir: PD, filename: FN) -> IOResult<File<'dir>>
-    where PD: Into<Option<&'dir Dir>>,
-          FN: Into<Option<String>>
+    where
+        PD: Into<Option<&'dir Dir>>,
+        FN: Into<Option<String>>,
     {
         let parent_dir = parent_dir.into();
-        let name       = filename.into().unwrap_or_else(|| File::filename(&path));
-        let ext        = File::ext(&path);
+        let name = filename.into().unwrap_or_else(|| File::filename(&path));
+        let ext = File::ext(&path);
 
         debug!("Statting file {:?}", &path);
-        let metadata   = fs::symlink_metadata(&path)?;
+        let metadata = fs::symlink_metadata(&path)?;
 
-        Ok(File { path, parent_dir, metadata, ext, name })
+        Ok(File {
+            path,
+            parent_dir,
+            metadata,
+            ext,
+            name,
+        })
     }
 
     /// A file’s name is derived from its string. This needs to handle directories
@@ -78,8 +83,7 @@ impl<'dir> File<'dir> {
     pub fn filename(path: &Path) -> String {
         if let Some(back) = path.components().next_back() {
             back.as_os_str().to_string_lossy().to_string()
-        }
-        else {
+        } else {
             // use the path as fallback
             error!("Path {:?} has no last component", path);
             path.display().to_string()
@@ -97,7 +101,7 @@ impl<'dir> File<'dir> {
     fn ext(path: &Path) -> Option<String> {
         let name = path.file_name().map(|f| f.to_string_lossy().to_string())?;
 
-        name.rfind('.').map(|p| name[p+1..].to_ascii_lowercase())
+        name.rfind('.').map(|p| name[p + 1..].to_ascii_lowercase())
     }
 
     /// Whether this file is a directory on the filesystem.
@@ -170,21 +174,17 @@ impl<'dir> File<'dir> {
         self.metadata.file_type().is_socket()
     }
 
-
     /// Re-prefixes the path pointed to by this file, if it’s a symlink, to
     /// make it an absolute path that can be accessed from whichever
     /// directory exa is being run from.
     fn reorient_target_path(&self, path: &Path) -> PathBuf {
         if path.is_absolute() {
             path.to_path_buf()
-        }
-        else if let Some(dir) = self.parent_dir {
+        } else if let Some(dir) = self.parent_dir {
             dir.join(&*path)
-        }
-        else if let Some(parent) = self.path.parent() {
+        } else if let Some(parent) = self.path.parent() {
             parent.join(&*path)
-        }
-        else {
+        } else {
             self.path.join(&*path)
         }
     }
@@ -200,15 +200,14 @@ impl<'dir> File<'dir> {
     /// existed. If this file cannot be read at all, returns the error that
     /// we got when we tried to read it.
     pub fn link_target(&self) -> FileTarget<'dir> {
-
         // We need to be careful to treat the path actually pointed to by
         // this file — which could be absolute or relative — to the path
         // we actually look up and turn into a `File` — which needs to be
         // absolute to be accessible from any directory.
         debug!("Reading link {:?}", &self.path);
         let path = match fs::read_link(&self.path) {
-            Ok(p)   => p,
-            Err(e)  => return FileTarget::Err(e),
+            Ok(p) => p,
+            Err(e) => return FileTarget::Err(e),
         };
 
         let absolute_path = self.reorient_target_path(&path);
@@ -217,9 +216,15 @@ impl<'dir> File<'dir> {
         // follow links.
         match fs::metadata(&absolute_path) {
             Ok(metadata) => {
-                let ext  = File::ext(&path);
+                let ext = File::ext(&path);
                 let name = File::filename(&path);
-                FileTarget::Ok(Box::new(File { parent_dir: None, path, ext, metadata, name }))
+                FileTarget::Ok(Box::new(File {
+                    parent_dir: None,
+                    path,
+                    ext,
+                    metadata,
+                    name,
+                }))
             }
             Err(e) => {
                 error!("Error following link {:?}: {:#?}", &path, e);
@@ -255,8 +260,7 @@ impl<'dir> File<'dir> {
     pub fn blocks(&self) -> f::Blocks {
         if self.is_file() || self.is_link() {
             f::Blocks::Some(self.metadata.blocks())
-        }
-        else {
+        } else {
             f::Blocks::None
         }
     }
@@ -282,15 +286,13 @@ impl<'dir> File<'dir> {
     pub fn size(&self) -> f::Size {
         if self.is_directory() {
             f::Size::None
-        }
-        else if self.is_char_device() || self.is_block_device() {
+        } else if self.is_char_device() || self.is_block_device() {
             let dev = self.metadata.rdev();
             f::Size::DeviceIDs(f::DeviceIDs {
                 major: (dev / 256) as u8,
                 minor: (dev % 256) as u8,
             })
-        }
-        else {
+        } else {
             f::Size::Some(self.metadata.len())
         }
     }
@@ -298,24 +300,24 @@ impl<'dir> File<'dir> {
     /// This file’s last modified timestamp.
     pub fn modified_time(&self) -> f::Time {
         f::Time {
-            seconds:     self.metadata.mtime(),
-            nanoseconds: self.metadata.mtime_nsec()
+            seconds: self.metadata.mtime(),
+            nanoseconds: self.metadata.mtime_nsec(),
         }
     }
 
     /// This file’s created timestamp.
     pub fn created_time(&self) -> f::Time {
         f::Time {
-            seconds:     self.metadata.ctime(),
-            nanoseconds: self.metadata.ctime_nsec()
+            seconds: self.metadata.ctime(),
+            nanoseconds: self.metadata.ctime_nsec(),
         }
     }
 
     /// This file’s last accessed timestamp.
     pub fn accessed_time(&self) -> f::Time {
         f::Time {
-            seconds:     self.metadata.atime(),
-            nanoseconds: self.metadata.atime_nsec()
+            seconds: self.metadata.atime(),
+            nanoseconds: self.metadata.atime_nsec(),
         }
     }
 
@@ -327,26 +329,19 @@ impl<'dir> File<'dir> {
     pub fn type_char(&self) -> f::Type {
         if self.is_file() {
             f::Type::File
-        }
-        else if self.is_directory() {
+        } else if self.is_directory() {
             f::Type::Directory
-        }
-        else if self.is_pipe() {
+        } else if self.is_pipe() {
             f::Type::Pipe
-        }
-        else if self.is_link() {
+        } else if self.is_link() {
             f::Type::Link
-        }
-        else if self.is_char_device() {
+        } else if self.is_char_device() {
             f::Type::CharDevice
-        }
-        else if self.is_block_device() {
+        } else if self.is_block_device() {
             f::Type::BlockDevice
-        }
-        else if self.is_socket() {
+        } else if self.is_socket() {
             f::Type::Socket
-        }
-        else {
+        } else {
             f::Type::Special
         }
     }
@@ -354,24 +349,24 @@ impl<'dir> File<'dir> {
     /// This file’s permissions, with flags for each bit.
     pub fn permissions(&self) -> f::Permissions {
         let bits = self.metadata.mode();
-        let has_bit = |bit| { bits & bit == bit };
+        let has_bit = |bit| bits & bit == bit;
 
         f::Permissions {
-            user_read:      has_bit(modes::USER_READ),
-            user_write:     has_bit(modes::USER_WRITE),
-            user_execute:   has_bit(modes::USER_EXECUTE),
+            user_read: has_bit(modes::USER_READ),
+            user_write: has_bit(modes::USER_WRITE),
+            user_execute: has_bit(modes::USER_EXECUTE),
 
-            group_read:     has_bit(modes::GROUP_READ),
-            group_write:    has_bit(modes::GROUP_WRITE),
-            group_execute:  has_bit(modes::GROUP_EXECUTE),
+            group_read: has_bit(modes::GROUP_READ),
+            group_write: has_bit(modes::GROUP_WRITE),
+            group_execute: has_bit(modes::GROUP_EXECUTE),
 
-            other_read:     has_bit(modes::OTHER_READ),
-            other_write:    has_bit(modes::OTHER_WRITE),
-            other_execute:  has_bit(modes::OTHER_EXECUTE),
+            other_read: has_bit(modes::OTHER_READ),
+            other_write: has_bit(modes::OTHER_WRITE),
+            other_execute: has_bit(modes::OTHER_EXECUTE),
 
-            sticky:         has_bit(modes::STICKY),
-            setgid:         has_bit(modes::SETGID),
-            setuid:         has_bit(modes::SETUID),
+            sticky: has_bit(modes::STICKY),
+            setgid: has_bit(modes::SETGID),
+            setuid: has_bit(modes::SETUID),
         }
     }
 
@@ -380,8 +375,8 @@ impl<'dir> File<'dir> {
     /// This will always return `false` if the file has no extension.
     pub fn extension_is_one_of(&self, choices: &[&str]) -> bool {
         match self.ext {
-            Some(ref ext)  => choices.contains(&&ext[..]),
-            None           => false,
+            Some(ref ext) => choices.contains(&&ext[..]),
+            None => false,
         }
     }
 
@@ -392,17 +387,14 @@ impl<'dir> File<'dir> {
     }
 }
 
-
 impl<'a> AsRef<File<'a>> for File<'a> {
     fn as_ref(&self) -> &File<'a> {
         self
     }
 }
 
-
 /// The result of following a symlink.
 pub enum FileTarget<'dir> {
-
     /// The symlink pointed at a file that exists.
     Ok(Box<File<'dir>>),
 
@@ -414,24 +406,21 @@ pub enum FileTarget<'dir> {
     /// file isn’t a link to begin with, but also if, say, we don’t have
     /// permission to follow it.
     Err(IOError),
-
     // Err is its own variant, instead of having the whole thing be inside an
     // `IOResult`, because being unable to follow a symlink is not a serious
     // error -- we just display the error message and move on.
 }
 
 impl<'dir> FileTarget<'dir> {
-
     /// Whether this link doesn’t lead to a file, for whatever reason. This
     /// gets used to determine how to highlight the link in grid views.
     pub fn is_broken(&self) -> bool {
         match *self {
-            FileTarget::Ok(_)                           => false,
-            FileTarget::Broken(_) | FileTarget::Err(_)  => true,
+            FileTarget::Ok(_) => false,
+            FileTarget::Broken(_) | FileTarget::Err(_) => true,
         }
     }
 }
-
 
 /// More readable aliases for the permission bits exposed by libc.
 #[allow(trivial_numeric_casts)]
@@ -442,23 +431,22 @@ mod modes {
     // The `libc::mode_t` type’s actual type varies, but the value returned
     // from `metadata.permissions().mode()` is always `u32`.
 
-    pub const USER_READ: Mode     = libc::S_IRUSR as Mode;
-    pub const USER_WRITE: Mode    = libc::S_IWUSR as Mode;
-    pub const USER_EXECUTE: Mode  = libc::S_IXUSR as Mode;
+    pub const USER_READ: Mode = libc::S_IRUSR as Mode;
+    pub const USER_WRITE: Mode = libc::S_IWUSR as Mode;
+    pub const USER_EXECUTE: Mode = libc::S_IXUSR as Mode;
 
-    pub const GROUP_READ: Mode    = libc::S_IRGRP as Mode;
-    pub const GROUP_WRITE: Mode   = libc::S_IWGRP as Mode;
+    pub const GROUP_READ: Mode = libc::S_IRGRP as Mode;
+    pub const GROUP_WRITE: Mode = libc::S_IWGRP as Mode;
     pub const GROUP_EXECUTE: Mode = libc::S_IXGRP as Mode;
 
-    pub const OTHER_READ: Mode    = libc::S_IROTH as Mode;
-    pub const OTHER_WRITE: Mode   = libc::S_IWOTH as Mode;
+    pub const OTHER_READ: Mode = libc::S_IROTH as Mode;
+    pub const OTHER_WRITE: Mode = libc::S_IWOTH as Mode;
     pub const OTHER_EXECUTE: Mode = libc::S_IXOTH as Mode;
 
-    pub const STICKY: Mode        = libc::S_ISVTX as Mode;
-    pub const SETGID: Mode        = libc::S_ISGID as Mode;
-    pub const SETUID: Mode        = libc::S_ISUID as Mode;
+    pub const STICKY: Mode = libc::S_ISVTX as Mode;
+    pub const SETGID: Mode = libc::S_ISGID as Mode;
+    pub const SETUID: Mode = libc::S_ISUID as Mode;
 }
-
 
 #[cfg(test)]
 mod ext_test {
@@ -480,7 +468,6 @@ mod ext_test {
         assert_eq!(None, File::ext(Path::new("jarlsberg")))
     }
 }
-
 
 #[cfg(test)]
 mod filename_test {

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -8,9 +8,8 @@ use std::path::Path;
 use glob;
 use natord;
 
-use fs::File;
 use fs::DotFilter;
-
+use fs::File;
 
 /// The **file filter** processes a list of files before displaying them to
 /// the user, by removing files they don’t want to see, and putting the list
@@ -28,7 +27,6 @@ use fs::DotFilter;
 /// performing the comparison.
 #[derive(PartialEq, Debug, Clone)]
 pub struct FileFilter {
-
     /// Whether directories should be listed first, and other types of file
     /// second. Some users prefer it like this.
     pub list_dirs_first: bool,
@@ -91,7 +89,6 @@ pub struct FileFilter {
     pub git_ignore: GitIgnore,
 }
 
-
 impl FileFilter {
     /// Remove every file in the given vector that does *not* pass the
     /// filter predicate for files found inside a directory.
@@ -118,8 +115,9 @@ impl FileFilter {
 
     /// Sort the files in the given vector based on the sort field option.
     pub fn sort_files<'a, F>(&self, files: &mut Vec<F>)
-    where F: AsRef<File<'a>> {
-
+    where
+        F: AsRef<File<'a>>,
+    {
         files.sort_by(|a, b| self.sort_field.compare_files(a.as_ref(), b.as_ref()));
 
         if self.reverse {
@@ -134,11 +132,9 @@ impl FileFilter {
     }
 }
 
-
 /// User-supplied field to sort by.
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub enum SortField {
-
     /// Don’t apply any sorting. This is usually used as an optimisation in
     /// scripts, where the order doesn’t matter.
     Unsorted,
@@ -215,7 +211,6 @@ pub enum SortField {
 /// effects they have.
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub enum SortCase {
-
     /// Sort files case-sensitively with uppercase first, with ‘A’ coming
     /// before ‘a’.
     ABCabc,
@@ -225,7 +220,6 @@ pub enum SortCase {
 }
 
 impl SortField {
-
     /// Compares two files to determine the order they should be listed in,
     /// depending on the search field.
     ///
@@ -238,41 +232,41 @@ impl SortField {
         use self::SortCase::{ABCabc, AaBbCc};
 
         match self {
-            SortField::Unsorted  => Ordering::Equal,
+            SortField::Unsorted => Ordering::Equal,
 
-            SortField::Name(ABCabc)  => natord::compare(&a.name, &b.name),
-            SortField::Name(AaBbCc)  => natord::compare_ignore_case(&a.name, &b.name),
+            SortField::Name(ABCabc) => natord::compare(&a.name, &b.name),
+            SortField::Name(AaBbCc) => natord::compare_ignore_case(&a.name, &b.name),
 
-            SortField::Size          => a.metadata.len().cmp(&b.metadata.len()),
-            SortField::FileInode     => a.metadata.ino().cmp(&b.metadata.ino()),
-            SortField::ModifiedDate  => a.metadata.mtime().cmp(&b.metadata.mtime()),
-            SortField::AccessedDate  => a.metadata.atime().cmp(&b.metadata.atime()),
-            SortField::CreatedDate   => a.metadata.ctime().cmp(&b.metadata.ctime()),
-            SortField::ModifiedAge   => b.metadata.mtime().cmp(&a.metadata.mtime()),  // flip b and a
+            SortField::Size => a.metadata.len().cmp(&b.metadata.len()),
+            SortField::FileInode => a.metadata.ino().cmp(&b.metadata.ino()),
+            SortField::ModifiedDate => a.metadata.mtime().cmp(&b.metadata.mtime()),
+            SortField::AccessedDate => a.metadata.atime().cmp(&b.metadata.atime()),
+            SortField::CreatedDate => a.metadata.ctime().cmp(&b.metadata.ctime()),
+            SortField::ModifiedAge => b.metadata.mtime().cmp(&a.metadata.mtime()), // flip b and a
 
-            SortField::FileType => match a.type_char().cmp(&b.type_char()) { // todo: this recomputes
-                Ordering::Equal  => natord::compare(&*a.name, &*b.name),
-                order            => order,
+            SortField::FileType => match a.type_char().cmp(&b.type_char()) {
+                // todo: this recomputes
+                Ordering::Equal => natord::compare(&*a.name, &*b.name),
+                order => order,
             },
 
             SortField::Extension(ABCabc) => match a.ext.cmp(&b.ext) {
-                Ordering::Equal  => natord::compare(&*a.name, &*b.name),
-                order            => order,
+                Ordering::Equal => natord::compare(&*a.name, &*b.name),
+                order => order,
             },
 
             SortField::Extension(AaBbCc) => match a.ext.cmp(&b.ext) {
-                Ordering::Equal  => natord::compare_ignore_case(&*a.name, &*b.name),
-                order            => order,
+                Ordering::Equal => natord::compare_ignore_case(&*a.name, &*b.name),
+                order => order,
             },
 
-            SortField::NameMixHidden(ABCabc) => natord::compare(
-                SortField::strip_dot(&a.name),
-                SortField::strip_dot(&b.name)
-            ),
+            SortField::NameMixHidden(ABCabc) => {
+                natord::compare(SortField::strip_dot(&a.name), SortField::strip_dot(&b.name))
+            }
             SortField::NameMixHidden(AaBbCc) => natord::compare_ignore_case(
                 SortField::strip_dot(&a.name),
-                SortField::strip_dot(&b.name)
-            )
+                SortField::strip_dot(&b.name),
+            ),
         }
     }
 
@@ -285,7 +279,6 @@ impl SortField {
     }
 }
 
-
 /// The **ignore patterns** are a list of globs that are tested against
 /// each filename, and if any of them match, that file isn’t displayed.
 /// This lets a user hide, say, text files by ignoring `*.txt`.
@@ -296,23 +289,26 @@ pub struct IgnorePatterns {
 
 impl FromIterator<glob::Pattern> for IgnorePatterns {
     fn from_iter<I: IntoIterator<Item = glob::Pattern>>(iter: I) -> Self {
-        IgnorePatterns { patterns: iter.into_iter().collect() }
+        IgnorePatterns {
+            patterns: iter.into_iter().collect(),
+        }
     }
 }
 
 impl IgnorePatterns {
-
     /// Create a new list from the input glob strings, turning the inputs that
     /// are valid glob patterns into an IgnorePatterns. The inputs that don’t
     /// parse correctly are returned separately.
-    pub fn parse_from_iter<'a, I: IntoIterator<Item = &'a str>>(iter: I) -> (Self, Vec<glob::PatternError>) {
+    pub fn parse_from_iter<'a, I: IntoIterator<Item = &'a str>>(
+        iter: I,
+    ) -> (Self, Vec<glob::PatternError>) {
         let iter = iter.into_iter();
 
         // Almost all glob patterns are valid, so it’s worth pre-allocating
         // the vector with enough space for all of them.
         let mut patterns = match iter.size_hint() {
-            (_, Some(count))  => Vec::with_capacity(count),
-             _                => Vec::new(),
+            (_, Some(count)) => Vec::with_capacity(count),
+            _ => Vec::new(),
         };
 
         // Similarly, assume there won’t be any errors.
@@ -321,7 +317,7 @@ impl IgnorePatterns {
         for input in iter {
             match glob::Pattern::new(input) {
                 Ok(pat) => patterns.push(pat),
-                Err(e)  => errors.push(e),
+                Err(e) => errors.push(e),
             }
         }
 
@@ -330,7 +326,9 @@ impl IgnorePatterns {
 
     /// Create a new empty set of patterns that matches nothing.
     pub fn empty() -> IgnorePatterns {
-        IgnorePatterns { patterns: Vec::new() }
+        IgnorePatterns {
+            patterns: Vec::new(),
+        }
     }
 
     /// Test whether the given file should be hidden from the results.
@@ -347,11 +345,9 @@ impl IgnorePatterns {
     // isn’t probably means it’s in the wrong place
 }
 
-
 /// Whether to ignore or display files that are mentioned in `.gitignore` files.
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub enum GitIgnore {
-
     /// Ignore files that Git would ignore. This means doing a check for a
     /// `.gitignore` file, possibly recursively up the filesystem tree.
     CheckAndIgnore,
@@ -367,8 +363,6 @@ pub enum GitIgnore {
 // > .gitignore, .git/info/exclude and even your global gitignore globs,
 // > usually found in $XDG_CONFIG_HOME/git/ignore.
 
-
-
 #[cfg(test)]
 mod test_ignores {
     use super::*;
@@ -382,23 +376,23 @@ mod test_ignores {
 
     #[test]
     fn ignores_a_glob() {
-        let (pats, fails) = IgnorePatterns::parse_from_iter(vec![ "*.mp3" ]);
+        let (pats, fails) = IgnorePatterns::parse_from_iter(vec!["*.mp3"]);
         assert!(fails.is_empty());
         assert_eq!(false, pats.is_ignored("nothing"));
-        assert_eq!(true,  pats.is_ignored("test.mp3"));
+        assert_eq!(true, pats.is_ignored("test.mp3"));
     }
 
     #[test]
     fn ignores_an_exact_filename() {
-        let (pats, fails) = IgnorePatterns::parse_from_iter(vec![ "nothing" ]);
+        let (pats, fails) = IgnorePatterns::parse_from_iter(vec!["nothing"]);
         assert!(fails.is_empty());
-        assert_eq!(true,  pats.is_ignored("nothing"));
+        assert_eq!(true, pats.is_ignored("nothing"));
         assert_eq!(false, pats.is_ignored("test.mp3"));
     }
 
     #[test]
     fn ignores_both() {
-        let (pats, fails) = IgnorePatterns::parse_from_iter(vec![ "nothing", "*.mp3" ]);
+        let (pats, fails) = IgnorePatterns::parse_from_iter(vec!["nothing", "*.mp3"]);
         assert!(fails.is_empty());
         assert_eq!(true, pats.is_ignored("nothing"));
         assert_eq!(true, pats.is_ignored("test.mp3"));

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -4,7 +4,7 @@ pub use self::dir::{Dir, DotFilter};
 mod file;
 pub use self::file::{File, FileTarget};
 
+pub mod dir_action;
 pub mod feature;
 pub mod fields;
 pub mod filter;
-pub mod dir_action;

--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -9,88 +9,86 @@ use ansi_term::Style;
 use fs::File;
 use output::file_name::FileColours;
 
-
 #[derive(Debug, Default, PartialEq)]
 pub struct FileExtensions;
 
 impl FileExtensions {
-
     /// An “immediate” file is something that can be run or activated somehow
     /// in order to kick off the build of a project. It’s usually only present
     /// in directories full of source code.
     fn is_immediate(&self, file: &File) -> bool {
-        file.name.to_lowercase().starts_with("readme") || file.name_is_one_of( &[
-            "Makefile", "Cargo.toml", "SConstruct", "CMakeLists.txt",
-            "build.gradle", "Rakefile", "Gruntfile.js",
-            "Gruntfile.coffee", "BUILD", "WORKSPACE", "build.xml"
-        ])
+        file.name.to_lowercase().starts_with("readme")
+            || file.name_is_one_of(&[
+                "Makefile",
+                "Cargo.toml",
+                "SConstruct",
+                "CMakeLists.txt",
+                "build.gradle",
+                "Rakefile",
+                "Gruntfile.js",
+                "Gruntfile.coffee",
+                "BUILD",
+                "WORKSPACE",
+                "build.xml",
+            ])
     }
 
     fn is_image(&self, file: &File) -> bool {
-        file.extension_is_one_of( &[
-            "png", "jpeg", "jpg", "gif", "bmp", "tiff", "tif",
-            "ppm", "pgm", "pbm", "pnm", "webp", "raw", "arw",
-            "svg", "stl", "eps", "dvi", "ps", "cbr",
-            "cbz", "xpm", "ico", "cr2", "orf", "nef",
+        file.extension_is_one_of(&[
+            "png", "jpeg", "jpg", "gif", "bmp", "tiff", "tif", "ppm", "pgm", "pbm", "pnm", "webp",
+            "raw", "arw", "svg", "stl", "eps", "dvi", "ps", "cbr", "cbz", "xpm", "ico", "cr2",
+            "orf", "nef",
         ])
     }
 
     fn is_video(&self, file: &File) -> bool {
-        file.extension_is_one_of( &[
-            "avi", "flv", "m2v", "m4v", "mkv", "mov", "mp4", "mpeg",
-            "mpg", "ogm", "ogv", "vob", "wmv", "webm", "m2ts",
+        file.extension_is_one_of(&[
+            "avi", "flv", "m2v", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg", "ogm", "ogv", "vob",
+            "wmv", "webm", "m2ts",
         ])
     }
 
     fn is_music(&self, file: &File) -> bool {
-        file.extension_is_one_of( &[
-            "aac", "m4a", "mp3", "ogg", "wma", "mka", "opus",
-        ])
+        file.extension_is_one_of(&["aac", "m4a", "mp3", "ogg", "wma", "mka", "opus"])
     }
 
     // Lossless music, rather than any other kind of data...
     fn is_lossless(&self, file: &File) -> bool {
-        file.extension_is_one_of( &[
-            "alac", "ape", "flac", "wav",
-        ])
+        file.extension_is_one_of(&["alac", "ape", "flac", "wav"])
     }
 
     fn is_crypto(&self, file: &File) -> bool {
-        file.extension_is_one_of( &[
-            "asc", "enc", "gpg", "pgp", "sig", "signature", "pfx", "p12",
-        ])
+        file.extension_is_one_of(&["asc", "enc", "gpg", "pgp", "sig", "signature", "pfx", "p12"])
     }
 
     fn is_document(&self, file: &File) -> bool {
-        file.extension_is_one_of( &[
-            "djvu", "doc", "docx", "dvi", "eml", "eps", "fotd",
-            "odp", "odt", "pdf", "ppt", "pptx", "rtf",
-            "xls", "xlsx",
+        file.extension_is_one_of(&[
+            "djvu", "doc", "docx", "dvi", "eml", "eps", "fotd", "odp", "odt", "pdf", "ppt", "pptx",
+            "rtf", "xls", "xlsx",
         ])
     }
 
     fn is_compressed(&self, file: &File) -> bool {
-        file.extension_is_one_of( &[
-            "zip", "tar", "Z", "z", "gz", "bz2", "a", "ar", "7z",
-            "iso", "dmg", "tc", "rar", "par", "tgz", "xz", "txz",
-            "lzma", "deb", "rpm", "zst",
+        file.extension_is_one_of(&[
+            "zip", "tar", "Z", "z", "gz", "bz2", "a", "ar", "7z", "iso", "dmg", "tc", "rar", "par",
+            "tgz", "xz", "txz", "lzma", "deb", "rpm", "zst",
         ])
     }
 
     fn is_temp(&self, file: &File) -> bool {
         file.name.ends_with('~')
             || (file.name.starts_with('#') && file.name.ends_with('#'))
-            || file.extension_is_one_of( &[ "tmp", "swp", "swo", "swn", "bak", "bk" ])
+            || file.extension_is_one_of(&["tmp", "swp", "swo", "swn", "bak", "bk"])
     }
 
     fn is_compiled(&self, file: &File) -> bool {
-        if file.extension_is_one_of( &[ "class", "elc", "hi", "o", "pyc" ]) {
+        if file.extension_is_one_of(&["class", "elc", "hi", "o", "pyc"]) {
             true
-        }
-        else if let Some(dir) = file.parent_dir {
-            file.get_source_files().iter().any(|path| dir.contains(path))
-        }
-        else {
+        } else if let Some(dir) = file.parent_dir {
+            file.get_source_files()
+                .iter()
+                .any(|path| dir.contains(path))
+        } else {
             false
         }
     }
@@ -101,17 +99,17 @@ impl FileColours for FileExtensions {
         use ansi_term::Colour::*;
 
         Some(match file {
-            f if self.is_temp(f)        => Fixed(244).normal(),
-            f if self.is_immediate(f)   => Yellow.bold().underline(),
-            f if self.is_image(f)       => Fixed(133).normal(),
-            f if self.is_video(f)       => Fixed(135).normal(),
-            f if self.is_music(f)       => Fixed(92).normal(),
-            f if self.is_lossless(f)    => Fixed(93).normal(),
-            f if self.is_crypto(f)      => Fixed(109).normal(),
-            f if self.is_document(f)    => Fixed(105).normal(),
-            f if self.is_compressed(f)  => Red.normal(),
-            f if self.is_compiled(f)    => Fixed(137).normal(),
-            _                           => return None,
+            f if self.is_temp(f) => Fixed(244).normal(),
+            f if self.is_immediate(f) => Yellow.bold().underline(),
+            f if self.is_image(f) => Fixed(133).normal(),
+            f if self.is_video(f) => Fixed(135).normal(),
+            f if self.is_music(f) => Fixed(92).normal(),
+            f if self.is_lossless(f) => Fixed(93).normal(),
+            f if self.is_crypto(f) => Fixed(109).normal(),
+            f if self.is_document(f) => Fixed(105).normal(),
+            f if self.is_compressed(f) => Red.normal(),
+            f if self.is_compiled(f) => Fixed(137).normal(),
+            _ => return None,
         })
     }
 }

--- a/src/info/sources.rs
+++ b/src/info/sources.rs
@@ -2,9 +2,7 @@ use std::path::PathBuf;
 
 use fs::File;
 
-
 impl<'a> File<'a> {
-
     /// For this file, return a vector of alternate file paths that, if any of
     /// them exist, mean that *this* file should be coloured as “compiled”.
     ///
@@ -34,9 +32,8 @@ impl<'a> File<'a> {
 
                 _ => vec![],  // No source files if none of the above
             }
-        }
-        else {
-            vec![]  // No source files if there's no extension, either!
+        } else {
+            vec![] // No source files if there's no extension, either!
         }
     }
 }

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -1,73 +1,248 @@
-use options::parser::{Arg, Args, Values, TakesValue};
-
+use options::parser::{Arg, Args, TakesValue, Values};
 
 // exa options
-pub static VERSION: Arg = Arg { short: Some(b'v'), long: "version",  takes_value: TakesValue::Forbidden };
-pub static HELP:    Arg = Arg { short: Some(b'?'), long: "help",     takes_value: TakesValue::Forbidden };
+pub static VERSION: Arg = Arg {
+    short: Some(b'v'),
+    long: "version",
+    takes_value: TakesValue::Forbidden,
+};
+pub static HELP: Arg = Arg {
+    short: Some(b'?'),
+    long: "help",
+    takes_value: TakesValue::Forbidden,
+};
 
 // display options
-pub static ONE_LINE: Arg = Arg { short: Some(b'1'), long: "oneline",  takes_value: TakesValue::Forbidden };
-pub static LONG:     Arg = Arg { short: Some(b'l'), long: "long",     takes_value: TakesValue::Forbidden };
-pub static GRID:     Arg = Arg { short: Some(b'G'), long: "grid",     takes_value: TakesValue::Forbidden };
-pub static ACROSS:   Arg = Arg { short: Some(b'x'), long: "across",   takes_value: TakesValue::Forbidden };
-pub static RECURSE:  Arg = Arg { short: Some(b'R'), long: "recurse",  takes_value: TakesValue::Forbidden };
-pub static TREE:     Arg = Arg { short: Some(b'T'), long: "tree",     takes_value: TakesValue::Forbidden };
-pub static CLASSIFY: Arg = Arg { short: Some(b'F'), long: "classify", takes_value: TakesValue::Forbidden };
+pub static ONE_LINE: Arg = Arg {
+    short: Some(b'1'),
+    long: "oneline",
+    takes_value: TakesValue::Forbidden,
+};
+pub static LONG: Arg = Arg {
+    short: Some(b'l'),
+    long: "long",
+    takes_value: TakesValue::Forbidden,
+};
+pub static GRID: Arg = Arg {
+    short: Some(b'G'),
+    long: "grid",
+    takes_value: TakesValue::Forbidden,
+};
+pub static ACROSS: Arg = Arg {
+    short: Some(b'x'),
+    long: "across",
+    takes_value: TakesValue::Forbidden,
+};
+pub static RECURSE: Arg = Arg {
+    short: Some(b'R'),
+    long: "recurse",
+    takes_value: TakesValue::Forbidden,
+};
+pub static TREE: Arg = Arg {
+    short: Some(b'T'),
+    long: "tree",
+    takes_value: TakesValue::Forbidden,
+};
+pub static CLASSIFY: Arg = Arg {
+    short: Some(b'F'),
+    long: "classify",
+    takes_value: TakesValue::Forbidden,
+};
 
-pub static COLOR:  Arg = Arg { short: None, long: "color",  takes_value: TakesValue::Necessary(Some(COLOURS)) };
-pub static COLOUR: Arg = Arg { short: None, long: "colour", takes_value: TakesValue::Necessary(Some(COLOURS)) };
+pub static COLOR: Arg = Arg {
+    short: None,
+    long: "color",
+    takes_value: TakesValue::Necessary(Some(COLOURS)),
+};
+pub static COLOUR: Arg = Arg {
+    short: None,
+    long: "colour",
+    takes_value: TakesValue::Necessary(Some(COLOURS)),
+};
 const COLOURS: &[&str] = &["always", "auto", "never"];
 
-pub static COLOR_SCALE:  Arg = Arg { short: None, long: "color-scale",  takes_value: TakesValue::Forbidden };
-pub static COLOUR_SCALE: Arg = Arg { short: None, long: "colour-scale", takes_value: TakesValue::Forbidden };
+pub static COLOR_SCALE: Arg = Arg {
+    short: None,
+    long: "color-scale",
+    takes_value: TakesValue::Forbidden,
+};
+pub static COLOUR_SCALE: Arg = Arg {
+    short: None,
+    long: "colour-scale",
+    takes_value: TakesValue::Forbidden,
+};
 
 // filtering and sorting options
-pub static ALL:         Arg = Arg { short: Some(b'a'), long: "all",         takes_value: TakesValue::Forbidden };
-pub static LIST_DIRS:   Arg = Arg { short: Some(b'd'), long: "list-dirs",   takes_value: TakesValue::Forbidden };
-pub static LEVEL:       Arg = Arg { short: Some(b'L'), long: "level",       takes_value: TakesValue::Necessary(None) };
-pub static REVERSE:     Arg = Arg { short: Some(b'r'), long: "reverse",     takes_value: TakesValue::Forbidden };
-pub static SORT:        Arg = Arg { short: Some(b's'), long: "sort",        takes_value: TakesValue::Necessary(Some(SORTS)) };
-pub static IGNORE_GLOB: Arg = Arg { short: Some(b'I'), long: "ignore-glob", takes_value: TakesValue::Necessary(None) };
-pub static GIT_IGNORE:  Arg = Arg { short: None, long: "git-ignore",           takes_value: TakesValue::Forbidden };
-pub static DIRS_FIRST:  Arg = Arg { short: None, long: "group-directories-first",  takes_value: TakesValue::Forbidden };
-pub static ONLY_DIRS:   Arg = Arg { short: Some(b'D'), long: "only-dirs", takes_value: TakesValue::Forbidden };
-const SORTS: Values = &[ "name", "Name", "size", "extension",
-                             "Extension", "modified", "accessed",
-                             "created", "inode", "type", "none" ];
+pub static ALL: Arg = Arg {
+    short: Some(b'a'),
+    long: "all",
+    takes_value: TakesValue::Forbidden,
+};
+pub static LIST_DIRS: Arg = Arg {
+    short: Some(b'd'),
+    long: "list-dirs",
+    takes_value: TakesValue::Forbidden,
+};
+pub static LEVEL: Arg = Arg {
+    short: Some(b'L'),
+    long: "level",
+    takes_value: TakesValue::Necessary(None),
+};
+pub static REVERSE: Arg = Arg {
+    short: Some(b'r'),
+    long: "reverse",
+    takes_value: TakesValue::Forbidden,
+};
+pub static SORT: Arg = Arg {
+    short: Some(b's'),
+    long: "sort",
+    takes_value: TakesValue::Necessary(Some(SORTS)),
+};
+pub static IGNORE_GLOB: Arg = Arg {
+    short: Some(b'I'),
+    long: "ignore-glob",
+    takes_value: TakesValue::Necessary(None),
+};
+pub static GIT_IGNORE: Arg = Arg {
+    short: None,
+    long: "git-ignore",
+    takes_value: TakesValue::Forbidden,
+};
+pub static DIRS_FIRST: Arg = Arg {
+    short: None,
+    long: "group-directories-first",
+    takes_value: TakesValue::Forbidden,
+};
+pub static ONLY_DIRS: Arg = Arg {
+    short: Some(b'D'),
+    long: "only-dirs",
+    takes_value: TakesValue::Forbidden,
+};
+const SORTS: Values = &[
+    "name",
+    "Name",
+    "size",
+    "extension",
+    "Extension",
+    "modified",
+    "accessed",
+    "created",
+    "inode",
+    "type",
+    "none",
+];
 
 // display options
-pub static BINARY:     Arg = Arg { short: Some(b'b'), long: "binary",     takes_value: TakesValue::Forbidden };
-pub static BYTES:      Arg = Arg { short: Some(b'B'), long: "bytes",      takes_value: TakesValue::Forbidden };
-pub static GROUP:      Arg = Arg { short: Some(b'g'), long: "group",      takes_value: TakesValue::Forbidden };
-pub static HEADER:     Arg = Arg { short: Some(b'h'), long: "header",     takes_value: TakesValue::Forbidden };
-pub static INODE:      Arg = Arg { short: Some(b'i'), long: "inode",      takes_value: TakesValue::Forbidden };
-pub static LINKS:      Arg = Arg { short: Some(b'H'), long: "links",      takes_value: TakesValue::Forbidden };
-pub static MODIFIED:   Arg = Arg { short: Some(b'm'), long: "modified",   takes_value: TakesValue::Forbidden };
-pub static BLOCKS:     Arg = Arg { short: Some(b'S'), long: "blocks",     takes_value: TakesValue::Forbidden };
-pub static TIME:       Arg = Arg { short: Some(b't'), long: "time",       takes_value: TakesValue::Necessary(Some(TIMES)) };
-pub static ACCESSED:   Arg = Arg { short: Some(b'u'), long: "accessed",   takes_value: TakesValue::Forbidden };
-pub static CREATED:    Arg = Arg { short: Some(b'U'), long: "created",    takes_value: TakesValue::Forbidden };
-pub static TIME_STYLE: Arg = Arg { short: None,       long: "time-style", takes_value: TakesValue::Necessary(Some(TIME_STYLES)) };
+pub static BINARY: Arg = Arg {
+    short: Some(b'b'),
+    long: "binary",
+    takes_value: TakesValue::Forbidden,
+};
+pub static BYTES: Arg = Arg {
+    short: Some(b'B'),
+    long: "bytes",
+    takes_value: TakesValue::Forbidden,
+};
+pub static GROUP: Arg = Arg {
+    short: Some(b'g'),
+    long: "group",
+    takes_value: TakesValue::Forbidden,
+};
+pub static HEADER: Arg = Arg {
+    short: Some(b'h'),
+    long: "header",
+    takes_value: TakesValue::Forbidden,
+};
+pub static INODE: Arg = Arg {
+    short: Some(b'i'),
+    long: "inode",
+    takes_value: TakesValue::Forbidden,
+};
+pub static LINKS: Arg = Arg {
+    short: Some(b'H'),
+    long: "links",
+    takes_value: TakesValue::Forbidden,
+};
+pub static MODIFIED: Arg = Arg {
+    short: Some(b'm'),
+    long: "modified",
+    takes_value: TakesValue::Forbidden,
+};
+pub static BLOCKS: Arg = Arg {
+    short: Some(b'S'),
+    long: "blocks",
+    takes_value: TakesValue::Forbidden,
+};
+pub static TIME: Arg = Arg {
+    short: Some(b't'),
+    long: "time",
+    takes_value: TakesValue::Necessary(Some(TIMES)),
+};
+pub static ACCESSED: Arg = Arg {
+    short: Some(b'u'),
+    long: "accessed",
+    takes_value: TakesValue::Forbidden,
+};
+pub static CREATED: Arg = Arg {
+    short: Some(b'U'),
+    long: "created",
+    takes_value: TakesValue::Forbidden,
+};
+pub static TIME_STYLE: Arg = Arg {
+    short: None,
+    long: "time-style",
+    takes_value: TakesValue::Necessary(Some(TIME_STYLES)),
+};
 const TIMES: Values = &["modified", "accessed", "created"];
 const TIME_STYLES: Values = &["default", "long-iso", "full-iso", "iso"];
 
 // optional feature options
-pub static GIT:       Arg = Arg { short: None,       long: "git",      takes_value: TakesValue::Forbidden };
-pub static EXTENDED:  Arg = Arg { short: Some(b'@'), long: "extended", takes_value: TakesValue::Forbidden };
-
+pub static GIT: Arg = Arg {
+    short: None,
+    long: "git",
+    takes_value: TakesValue::Forbidden,
+};
+pub static EXTENDED: Arg = Arg {
+    short: Some(b'@'),
+    long: "extended",
+    takes_value: TakesValue::Forbidden,
+};
 
 pub static ALL_ARGS: Args = Args(&[
-    &VERSION, &HELP,
-
-    &ONE_LINE, &LONG, &GRID, &ACROSS, &RECURSE, &TREE, &CLASSIFY,
-    &COLOR, &COLOUR, &COLOR_SCALE, &COLOUR_SCALE,
-
-    &ALL, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST,
-    &IGNORE_GLOB, &GIT_IGNORE, &ONLY_DIRS,
-
-    &BINARY, &BYTES, &GROUP, &HEADER, &INODE, &LINKS, &MODIFIED, &BLOCKS,
-    &TIME, &ACCESSED, &CREATED, &TIME_STYLE,
-
-    &GIT, &EXTENDED,
+    &VERSION,
+    &HELP,
+    &ONE_LINE,
+    &LONG,
+    &GRID,
+    &ACROSS,
+    &RECURSE,
+    &TREE,
+    &CLASSIFY,
+    &COLOR,
+    &COLOUR,
+    &COLOR_SCALE,
+    &COLOUR_SCALE,
+    &ALL,
+    &LIST_DIRS,
+    &LEVEL,
+    &REVERSE,
+    &SORT,
+    &DIRS_FIRST,
+    &IGNORE_GLOB,
+    &GIT_IGNORE,
+    &ONLY_DIRS,
+    &BINARY,
+    &BYTES,
+    &GROUP,
+    &HEADER,
+    &INODE,
+    &LINKS,
+    &MODIFIED,
+    &BLOCKS,
+    &TIME,
+    &ACCESSED,
+    &CREATED,
+    &TIME_STYLE,
+    &GIT,
+    &EXTENDED,
 ]);
-

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -1,9 +1,8 @@
 use std::fmt;
 
+use fs::feature::xattr;
 use options::flags;
 use options::parser::MatchedFlags;
-use fs::feature::xattr;
-
 
 static OPTIONS: &str = r##"
   -?, --help         show list of command-line options
@@ -50,16 +49,15 @@ LONG VIEW OPTIONS
   -U, --created      use the created timestamp field
   --time-style       how to format timestamps (default, iso, long-iso, full-iso)"##;
 
-static GIT_HELP:      &str = r##"  --git              list each file's Git status, if tracked"##;
-static EXTENDED_HELP: &str = r##"  -@, --extended     list each file's extended attributes and sizes"##;
-
+static GIT_HELP: &str = r##"  --git              list each file's Git status, if tracked"##;
+static EXTENDED_HELP: &str =
+    r##"  -@, --extended     list each file's extended attributes and sizes"##;
 
 /// All the information needed to display the help text, which depends
 /// on which features are enabled and whether the user only wants to
 /// see one section’s help.
 #[derive(PartialEq, Debug)]
 pub struct HelpString {
-
     /// Only show the help for the long section, not all the help.
     only_long: bool,
 
@@ -71,7 +69,6 @@ pub struct HelpString {
 }
 
 impl HelpString {
-
     /// Determines how to show help, if at all, based on the user’s
     /// command-line arguments. This one works backwards from the other
     /// ‘deduce’ functions, returning Err if help needs to be shown.
@@ -82,18 +79,20 @@ impl HelpString {
     pub fn deduce(matches: &MatchedFlags) -> Result<(), HelpString> {
         if matches.count(&flags::HELP) > 0 {
             let only_long = matches.count(&flags::LONG) > 0;
-            let git       = cfg!(feature="git");
-            let xattrs    = xattr::ENABLED;
-            Err(HelpString { only_long, git, xattrs })
-        }
-        else {
-            Ok(())  // no help needs to be shown
+            let git = cfg!(feature = "git");
+            let xattrs = xattr::ENABLED;
+            Err(HelpString {
+                only_long,
+                git,
+                xattrs,
+            })
+        } else {
+            Ok(()) // no help needs to be shown
         }
     }
 }
 
 impl fmt::Display for HelpString {
-
     /// Format this help options into an actual string of help
     /// text to be displayed to the user.
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
@@ -117,8 +116,6 @@ impl fmt::Display for HelpString {
     }
 }
 
-
-
 #[cfg(test)]
 mod test {
     use options::Options;
@@ -132,14 +129,14 @@ mod test {
 
     #[test]
     fn help() {
-        let args = [ os("--help") ];
+        let args = [os("--help")];
         let opts = Options::parse(&args, &None);
         assert!(opts.is_err())
     }
 
     #[test]
     fn help_with_file() {
-        let args = [ os("--help"), os("me") ];
+        let args = [os("--help"), os("me")];
         let opts = Options::parse(&args, &None);
         assert!(opts.is_err())
     }
@@ -148,6 +145,6 @@ mod test {
     fn unhelpful() {
         let args = [];
         let opts = Options::parse(&args, &None);
-        assert!(opts.is_ok())  // no help when --help isn’t passed
+        assert!(opts.is_ok()) // no help when --help isn’t passed
     }
 }

--- a/src/options/vars.rs
+++ b/src/options/vars.rs
@@ -1,6 +1,5 @@
 use std::ffi::OsString;
 
-
 // General variables
 
 /// Environment variable used to colour files, both by their filesystem type
@@ -38,13 +37,10 @@ pub static EXA_DEBUG: &str = "EXA_DEBUG";
 /// number of rows of output.
 pub static EXA_GRID_ROWS: &str = "EXA_GRID_ROWS";
 
-
-
 /// Mockable wrapper for `std::env::var_os`.
 pub trait Vars {
     fn get(&self, name: &'static str) -> Option<OsString>;
 }
-
 
 // Test impl that just returns the value it has.
 #[cfg(test)]

--- a/src/options/version.rs
+++ b/src/options/version.rs
@@ -7,13 +7,11 @@ use std::fmt;
 use options::flags;
 use options::parser::MatchedFlags;
 
-
 #[derive(PartialEq, Debug)]
 pub struct VersionString;
 // There were options here once, but there aren’t anymore!
 
 impl VersionString {
-
     /// Determines how to show the version, if at all, based on the user’s
     /// command-line arguments. This one works backwards from the other
     /// ‘deduce’ functions, returning Err if help needs to be shown.
@@ -22,19 +20,21 @@ impl VersionString {
     pub fn deduce(matches: &MatchedFlags) -> Result<(), VersionString> {
         if matches.count(&flags::VERSION) > 0 {
             Err(VersionString)
-        }
-        else {
-            Ok(())  // no version needs to be shown
+        } else {
+            Ok(()) // no version needs to be shown
         }
     }
 }
 
 impl fmt::Display for VersionString {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "{}", include!(concat!(env!("OUT_DIR"), "/version_string.txt")))
+        write!(
+            f,
+            "{}",
+            include!(concat!(env!("OUT_DIR"), "/version_string.txt"))
+        )
     }
 }
-
 
 #[cfg(test)]
 mod test {
@@ -49,7 +49,7 @@ mod test {
 
     #[test]
     fn help() {
-        let args = [ os("--version") ];
+        let args = [os("--version")];
         let opts = Options::parse(&args, &None);
         assert!(opts.is_err())
     }

--- a/src/output/cell.rs
+++ b/src/output/cell.rs
@@ -3,9 +3,8 @@
 use std::iter::Sum;
 use std::ops::{Add, Deref, DerefMut};
 
-use ansi_term::{Style, ANSIString, ANSIStrings};
+use ansi_term::{ANSIString, ANSIStrings, Style};
 use unicode_width::UnicodeWidthStr;
-
 
 /// An individual cell that holds text in a table, used in the details and
 /// lines views to store ANSI-terminal-formatted data before it is printed.
@@ -19,7 +18,6 @@ use unicode_width::UnicodeWidthStr;
 /// type by that name too.)
 #[derive(PartialEq, Debug, Clone, Default)]
 pub struct TextCell {
-
     /// The contents of this cell, as a vector of ANSI-styled strings.
     pub contents: TextCellContents,
 
@@ -36,14 +34,13 @@ impl Deref for TextCell {
 }
 
 impl TextCell {
-
     /// Creates a new text cell that holds the given text in the given style,
     /// computing the Unicode width of the text.
     pub fn paint(style: Style, text: String) -> Self {
         let width = DisplayWidth::from(&*text);
 
         TextCell {
-            contents: vec![ style.paint(text) ].into(),
+            contents: vec![style.paint(text)].into(),
             width,
         }
     }
@@ -55,7 +52,7 @@ impl TextCell {
         let width = DisplayWidth::from(text);
 
         TextCell {
-            contents: vec![ style.paint(text) ].into(),
+            contents: vec![style.paint(text)].into(),
             width,
         }
     }
@@ -68,8 +65,8 @@ impl TextCell {
     /// tabular data when there is *something* in each cell.
     pub fn blank(style: Style) -> Self {
         TextCell {
-            contents: vec![ style.paint("-") ].into(),
-            width:    DisplayWidth::from(1),
+            contents: vec![style.paint("-")].into(),
+            width: DisplayWidth::from(1),
         }
     }
 
@@ -98,7 +95,6 @@ impl TextCell {
     }
 }
 
-
 // I’d like to eventually abstract cells so that instead of *every* cell
 // storing a vector, only variable-length cells would, and individual cells
 // would just store an array of a fixed length (which would usually be just 1
@@ -124,7 +120,6 @@ impl TextCell {
 // This would allow us to still hold all the data, but allocate less.
 //
 // But exa still has bugs and I need to fix those first :(
-
 
 /// The contents of a text cell, as a vector of ANSI-styled strings.
 ///
@@ -154,7 +149,6 @@ impl Deref for TextCellContents {
 // above can just access the value directly.
 
 impl TextCellContents {
-
     /// Produces an `ANSIStrings` value that can be used to print the styled
     /// values of this cell as an ANSI-terminal-formatted string.
     pub fn strings(&self) -> ANSIStrings {
@@ -164,7 +158,8 @@ impl TextCellContents {
     /// Calculates the width that a cell with these contents would take up, by
     /// counting the number of characters in each unformatted ANSI string.
     pub fn width(&self) -> DisplayWidth {
-        self.0.iter()
+        self.0
+            .iter()
             .map(|anstr| DisplayWidth::from(anstr.deref()))
             .sum()
     }
@@ -178,7 +173,6 @@ impl TextCellContents {
         }
     }
 }
-
 
 /// The Unicode “display width” of a string.
 ///
@@ -239,11 +233,13 @@ impl Add<usize> for DisplayWidth {
 }
 
 impl Sum for DisplayWidth {
-    fn sum<I>(iter: I) -> Self where I: Iterator<Item=Self> {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = Self>,
+    {
         iter.fold(DisplayWidth(0), Add::add)
     }
 }
-
 
 #[cfg(test)]
 mod width_unit_test {

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -59,26 +59,24 @@
 //! means that we must wait until every row has been added to the table before it
 //! can be displayed, in order to make sure that every column is wide enough.
 
-
-use std::io::{Write, Error as IOError, Result as IOResult};
+use std::io::{Error as IOError, Result as IOResult, Write};
 use std::path::PathBuf;
 use std::vec::IntoIter as VecIntoIter;
 
 use ansi_term::Style;
 
-use fs::{Dir, File};
 use fs::dir_action::RecurseOptions;
-use fs::filter::FileFilter;
-use fs::feature::ignore::IgnoreCache;
 use fs::feature::git::GitCache;
+use fs::feature::ignore::IgnoreCache;
 use fs::feature::xattr::{Attribute, FileAttributes};
-use style::Colours;
+use fs::filter::FileFilter;
+use fs::{Dir, File};
 use output::cell::TextCell;
-use output::tree::{TreeTrunk, TreeParams, TreeDepth};
 use output::file_name::FileStyle;
-use output::table::{Table, Options as TableOptions, Row as TableRow};
+use output::table::{Options as TableOptions, Row as TableRow, Table};
+use output::tree::{TreeDepth, TreeParams, TreeTrunk};
 use scoped_threadpool::Pool;
-
+use style::Colours;
 
 /// With the **Details** view, the output gets formatted into columns, with
 /// each `Column` object showing some piece of information about the file,
@@ -93,7 +91,6 @@ use scoped_threadpool::Pool;
 /// columns for each row.
 #[derive(Debug)]
 pub struct Options {
-
     /// Options specific to drawing a table.
     ///
     /// Directories themselves can pick which columns are *added* to this
@@ -106,8 +103,6 @@ pub struct Options {
     /// Whether to show each file's extended attributes.
     pub xattr: bool,
 }
-
-
 
 pub struct Render<'a> {
     pub dir: Option<&'a Dir>,
@@ -125,13 +120,12 @@ pub struct Render<'a> {
     pub filter: &'a FileFilter,
 }
 
-
 struct Egg<'a> {
     table_row: Option<TableRow>,
-    xattrs:    Vec<Attribute>,
-    errors:    Vec<(IOError, Option<PathBuf>)>,
-    dir:       Option<Dir>,
-    file:      &'a File<'a>,
+    xattrs: Vec<Attribute>,
+    errors: Vec<(IOError, Option<PathBuf>)>,
+    dir: Option<Dir>,
+    file: &'a File<'a>,
 }
 
 impl<'a> AsRef<File<'a>> for Egg<'a> {
@@ -140,18 +134,30 @@ impl<'a> AsRef<File<'a>> for Egg<'a> {
     }
 }
 
-
 impl<'a> Render<'a> {
-    pub fn render<W: Write>(self, mut git: Option<&'a GitCache>, ignore: Option<&'a IgnoreCache>, w: &mut W) -> IOResult<()> {
+    pub fn render<W: Write>(
+        self,
+        mut git: Option<&'a GitCache>,
+        ignore: Option<&'a IgnoreCache>,
+        w: &mut W,
+    ) -> IOResult<()> {
         use num_cpus;
         let mut pool = Pool::new(num_cpus::get() as u32);
         let mut rows = Vec::new();
 
         if let Some(ref table) = self.opts.table {
             match (git, self.dir) {
-                (Some(g), Some(d))  => if !g.has_anything_for(&d.path) { git = None },
-                (Some(g), None)     => if !self.files.iter().any(|f| g.has_anything_for(&f.path)) { git = None },
-                (None,    _)        => {/* Keep Git how it is */},
+                (Some(g), Some(d)) => {
+                    if !g.has_anything_for(&d.path) {
+                        git = None
+                    }
+                }
+                (Some(g), None) => {
+                    if !self.files.iter().any(|f| g.has_anything_for(&f.path)) {
+                        git = None
+                    }
+                }
+                (None, _) => { /* Keep Git how it is */ }
             }
 
             let mut table = Table::new(&table, git, &self.colours);
@@ -165,14 +171,27 @@ impl<'a> Render<'a> {
             // This is weird, but I can’t find a way around it:
             // https://internals.rust-lang.org/t/should-option-mut-t-implement-copy/3715/6
             let mut table = Some(table);
-            self.add_files_to_table(&mut pool, &mut table, &mut rows, &self.files, ignore, TreeDepth::root());
+            self.add_files_to_table(
+                &mut pool,
+                &mut table,
+                &mut rows,
+                &self.files,
+                ignore,
+                TreeDepth::root(),
+            );
 
             for row in self.iterate_with_table(table.unwrap(), rows) {
                 writeln!(w, "{}", row.strings())?
             }
-        }
-        else {
-            self.add_files_to_table(&mut pool, &mut None, &mut rows, &self.files, ignore, TreeDepth::root());
+        } else {
+            self.add_files_to_table(
+                &mut pool,
+                &mut None,
+                &mut rows,
+                &self.files,
+                ignore,
+                TreeDepth::root(),
+            );
 
             for row in self.iterate(rows) {
                 writeln!(w, "{}", row.strings())?
@@ -184,9 +203,17 @@ impl<'a> Render<'a> {
 
     /// Adds files to the table, possibly recursively. This is easily
     /// parallelisable, and uses a pool of threads.
-    fn add_files_to_table<'dir, 'ig>(&self, pool: &mut Pool, table: &mut Option<Table<'a>>, rows: &mut Vec<Row>, src: &[File<'dir>], ignore: Option<&'ig IgnoreCache>, depth: TreeDepth) {
-        use std::sync::{Arc, Mutex};
+    fn add_files_to_table<'dir, 'ig>(
+        &self,
+        pool: &mut Pool,
+        table: &mut Option<Table<'a>>,
+        rows: &mut Vec<Row>,
+        src: &[File<'dir>],
+        ignore: Option<&'ig IgnoreCache>,
+        depth: TreeDepth,
+    ) {
         use fs::feature::xattr;
+        use std::sync::{Arc, Mutex};
 
         let mut file_eggs = Vec::new();
 
@@ -231,15 +258,16 @@ impl<'a> Render<'a> {
                             Err(e) => {
                                 if self.opts.xattr {
                                     errors.push((e, None));
-                                }
-                                else {
+                                } else {
                                     error!("Error looking up xattr for {:?}: {:#?}", file.path, e);
                                 }
                             }
                         }
                     }
 
-                    let table_row = table.as_ref().map(|t| t.row_for_file(&file, !xattrs.is_empty()));
+                    let table_row = table
+                        .as_ref()
+                        .map(|t| t.row_for_file(&file, !xattrs.is_empty()));
 
                     if !self.opts.xattr {
                         xattrs.clear();
@@ -250,13 +278,21 @@ impl<'a> Render<'a> {
                     if let Some(r) = self.recurse {
                         if file.is_directory() && r.tree && !r.is_too_deep(depth.0) {
                             match file.to_dir() {
-                                Ok(d)  => { dir = Some(d); },
-                                Err(e) => { errors.push((e, None)) },
+                                Ok(d) => {
+                                    dir = Some(d);
+                                }
+                                Err(e) => errors.push((e, None)),
                             }
                         }
                     };
 
-                    let egg = Egg { table_row, xattrs, errors, dir, file };
+                    let egg = Egg {
+                        table_row,
+                        xattrs,
+                        errors,
+                        dir,
+                        file,
+                    };
                     file_eggs.lock().unwrap().push(egg);
                 });
             }
@@ -273,11 +309,14 @@ impl<'a> Render<'a> {
             }
 
             let row = Row {
-                tree:   tree_params,
-                cells:  egg.table_row,
-                name:   self.style.for_file(&egg.file, self.colours)
-                                  .with_link_paths()
-                                  .paint().promote(),
+                tree: tree_params,
+                cells: egg.table_row,
+                name: self
+                    .style
+                    .for_file(&egg.file, self.colours)
+                    .with_link_paths()
+                    .paint()
+                    .promote(),
             };
 
             rows.push(row);
@@ -285,8 +324,8 @@ impl<'a> Render<'a> {
             if let Some(ref dir) = egg.dir {
                 for file_to_add in dir.files(self.filter.dot_filter, ignore) {
                     match file_to_add {
-                        Ok(f)          => files.push(f),
-                        Err((path, e)) => errors.push((e, Some(path)))
+                        Ok(f) => files.push(f),
+                        Err((path, e)) => errors.push((e, Some(path))),
                     }
                 }
 
@@ -294,11 +333,17 @@ impl<'a> Render<'a> {
 
                 if !files.is_empty() {
                     for xattr in egg.xattrs {
-                        rows.push(self.render_xattr(&xattr, TreeParams::new(depth.deeper(), false)));
+                        rows.push(
+                            self.render_xattr(&xattr, TreeParams::new(depth.deeper(), false)),
+                        );
                     }
 
                     for (error, path) in errors {
-                        rows.push(self.render_error(&error, TreeParams::new(depth.deeper(), false), path));
+                        rows.push(self.render_error(
+                            &error,
+                            TreeParams::new(depth.deeper(), false),
+                            path,
+                        ));
                     }
 
                     self.add_files_to_table(pool, table, rows, &files, ignore, depth.deeper());
@@ -308,21 +353,28 @@ impl<'a> Render<'a> {
 
             let count = egg.xattrs.len();
             for (index, xattr) in egg.xattrs.into_iter().enumerate() {
-                rows.push(self.render_xattr(&xattr, TreeParams::new(depth.deeper(), errors.is_empty() && index == count - 1)));
+                rows.push(self.render_xattr(
+                    &xattr,
+                    TreeParams::new(depth.deeper(), errors.is_empty() && index == count - 1),
+                ));
             }
 
             let count = errors.len();
             for (index, (error, path)) in errors.into_iter().enumerate() {
-                rows.push(self.render_error(&error, TreeParams::new(depth.deeper(), index == count - 1), path));
+                rows.push(self.render_error(
+                    &error,
+                    TreeParams::new(depth.deeper(), index == count - 1),
+                    path,
+                ));
             }
         }
     }
 
     pub fn render_header(&self, header: TableRow) -> Row {
         Row {
-            tree:     TreeParams::new(TreeDepth::root(), false),
-            cells:    Some(header),
-            name:     TextCell::paint_str(self.colours.header, "Name"),
+            tree: TreeParams::new(TreeDepth::root(), false),
+            cells: Some(header),
+            name: TextCell::paint_str(self.colours.header, "Name"),
         }
     }
 
@@ -331,22 +383,37 @@ impl<'a> Render<'a> {
 
         let error_message = match path {
             Some(path) => format!("<{}: {}>", path.display(), error),
-            None       => format!("<{}>", error),
+            None => format!("<{}>", error),
         };
 
-		// TODO: broken_symlink() doesn’t quite seem like the right name for
-		// the style that’s being used here. Maybe split it in two?
+        // TODO: broken_symlink() doesn’t quite seem like the right name for
+        // the style that’s being used here. Maybe split it in two?
         let name = TextCell::paint(self.colours.broken_symlink(), error_message);
-        Row { cells: None, name, tree }
+        Row {
+            cells: None,
+            name,
+            tree,
+        }
     }
 
     fn render_xattr(&self, xattr: &Attribute, tree: TreeParams) -> Row {
-        let name = TextCell::paint(self.colours.perms.attribute, format!("{} (len {})", xattr.name, xattr.size));
-        Row { cells: None, name, tree }
+        let name = TextCell::paint(
+            self.colours.perms.attribute,
+            format!("{} (len {})", xattr.name, xattr.size),
+        );
+        Row {
+            cells: None,
+            name,
+            tree,
+        }
     }
 
     pub fn render_file(&self, cells: TableRow, name: TextCell, tree: TreeParams) -> Row {
-        Row { cells: Some(cells), name, tree }
+        Row {
+            cells: Some(cells),
+            name,
+            tree,
+        }
     }
 
     pub fn iterate_with_table(&'a self, table: Table<'a>, rows: Vec<Row>) -> TableIter<'a> {
@@ -368,9 +435,7 @@ impl<'a> Render<'a> {
     }
 }
 
-
 pub struct Row {
-
     /// Vector of cells to display.
     ///
     /// Most of the rows will be used to display files' metadata, so this will
@@ -387,14 +452,13 @@ pub struct Row {
     pub tree: TreeParams,
 }
 
-
 pub struct TableIter<'a> {
     inner: VecIntoIter<Row>,
     table: Table<'a>,
 
     total_width: usize,
-    tree_style:  Style,
-    tree_trunk:  TreeTrunk,
+    tree_style: Style,
+    tree_trunk: TreeTrunk,
 }
 
 impl<'a> Iterator for TableIter<'a> {
@@ -402,15 +466,13 @@ impl<'a> Iterator for TableIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(|row| {
-            let mut cell =
-                if let Some(cells) = row.cells {
-                    self.table.render(cells)
-                }
-                else {
-                    let mut cell = TextCell::default();
-                    cell.add_spaces(self.total_width);
-                    cell
-                };
+            let mut cell = if let Some(cells) = row.cells {
+                self.table.render(cells)
+            } else {
+                let mut cell = TextCell::default();
+                cell.add_spaces(self.total_width);
+                cell
+            };
 
             for tree_part in self.tree_trunk.new_row(row.tree) {
                 cell.push(self.tree_style.paint(tree_part.ascii_art()), 4);
@@ -427,7 +489,6 @@ impl<'a> Iterator for TableIter<'a> {
         })
     }
 }
-
 
 pub struct Iter {
     tree_trunk: TreeTrunk,

--- a/src/output/escape.rs
+++ b/src/output/escape.rs
@@ -1,11 +1,9 @@
 use ansi_term::{ANSIString, Style};
 
-
 pub fn escape<'a>(string: String, bits: &mut Vec<ANSIString<'a>>, good: Style, bad: Style) {
     if string.chars().all(|c| c >= 0x20 as char) {
         bits.push(good.paint(string));
-    }
-    else {
+    } else {
         for c in string.chars() {
             // The `escape_default` method on `char` is *almost* what we want here, but
             // it still escapes non-ASCII UTF-8 characters, which are still printable.

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -1,11 +1,10 @@
-use std::io::{Write, Result as IOResult};
+use std::io::{Result as IOResult, Write};
 
 use term_grid as tg;
 
 use fs::File;
-use style::Colours;
 use output::file_name::FileStyle;
-
+use style::Colours;
 
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub struct Options {
@@ -15,11 +14,13 @@ pub struct Options {
 
 impl Options {
     pub fn direction(&self) -> tg::Direction {
-        if self.across { tg::Direction::LeftToRight }
-                  else { tg::Direction::TopToBottom }
+        if self.across {
+            tg::Direction::LeftToRight
+        } else {
+            tg::Direction::TopToBottom
+        }
     }
 }
-
 
 pub struct Render<'a> {
     pub files: Vec<File<'a>>,
@@ -31,8 +32,8 @@ pub struct Render<'a> {
 impl<'a> Render<'a> {
     pub fn render<W: Write>(&self, w: &mut W) -> IOResult<()> {
         let mut grid = tg::Grid::new(tg::GridOptions {
-            direction:  self.opts.direction(),
-            filling:    tg::Filling::Spaces(2),
+            direction: self.opts.direction(),
+            filling: tg::Filling::Spaces(2),
         });
 
         grid.reserve(self.files.len());
@@ -42,15 +43,14 @@ impl<'a> Render<'a> {
             let width = filename.width();
 
             grid.add(tg::Cell {
-                contents:  filename.strings().to_string(),
-                width:     *width,
+                contents: filename.strings().to_string(),
+                width: *width,
             });
         }
 
         if let Some(display) = grid.fit_into_width(self.opts.console_width) {
             write!(w, "{}", display)
-        }
-        else {
+        } else {
             // File names too long for a grid - drop down to just listing them!
             // This isn’t *quite* the same as the lines view, which also
             // displays full link paths.

--- a/src/output/lines.rs
+++ b/src/output/lines.rs
@@ -1,11 +1,10 @@
-use std::io::{Write, Result as IOResult};
+use std::io::{Result as IOResult, Write};
 
 use ansi_term::ANSIStrings;
 
 use fs::File;
 use output::file_name::{FileName, FileStyle};
 use style::Colours;
-
 
 /// The lines view literally just displays each file, line-by-line.
 pub struct Render<'a> {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,13 +1,13 @@
 use output::file_name::FileStyle;
 use style::Colours;
 
-pub use self::cell::{TextCell, TextCellContents, DisplayWidth};
+pub use self::cell::{DisplayWidth, TextCell, TextCellContents};
 pub use self::escape::escape;
 
 pub mod details;
 pub mod file_name;
-pub mod grid_details;
 pub mod grid;
+pub mod grid_details;
 pub mod lines;
 pub mod render;
 pub mod table;
@@ -17,7 +17,6 @@ mod cell;
 mod escape;
 mod tree;
 
-
 /// The **view** contains all information about how to format output.
 #[derive(Debug)]
 pub struct View {
@@ -25,7 +24,6 @@ pub struct View {
     pub colours: Colours,
     pub style: FileStyle,
 }
-
 
 /// The **mode** is the “type” of output.
 #[derive(Debug)]

--- a/src/output/render/blocks.rs
+++ b/src/output/render/blocks.rs
@@ -1,42 +1,41 @@
 use ansi_term::Style;
 
-use output::cell::TextCell;
 use fs::fields as f;
-
+use output::cell::TextCell;
 
 impl f::Blocks {
     pub fn render<C: Colours>(&self, colours: &C) -> TextCell {
         match *self {
-            f::Blocks::Some(ref blk)  => TextCell::paint(colours.block_count(), blk.to_string()),
-            f::Blocks::None           => TextCell::blank(colours.no_blocks()),
+            f::Blocks::Some(ref blk) => TextCell::paint(colours.block_count(), blk.to_string()),
+            f::Blocks::None => TextCell::blank(colours.no_blocks()),
         }
     }
 }
-
 
 pub trait Colours {
     fn block_count(&self) -> Style;
     fn no_blocks(&self) -> Style;
 }
 
-
 #[cfg(test)]
 pub mod test {
-    use ansi_term::Style;
     use ansi_term::Colour::*;
+    use ansi_term::Style;
 
     use super::Colours;
-    use output::cell::TextCell;
     use fs::fields as f;
-
+    use output::cell::TextCell;
 
     struct TestColours;
 
     impl Colours for TestColours {
-        fn block_count(&self) -> Style { Red.blink() }
-        fn no_blocks(&self)   -> Style { Green.italic() }
+        fn block_count(&self) -> Style {
+            Red.blink()
+        }
+        fn no_blocks(&self) -> Style {
+            Green.italic()
+        }
     }
-
 
     #[test]
     fn blocklessness() {
@@ -45,7 +44,6 @@ pub mod test {
 
         assert_eq!(expected, blox.render(&TestColours).into());
     }
-
 
     #[test]
     fn blockfulity() {

--- a/src/output/render/filetype.rs
+++ b/src/output/render/filetype.rs
@@ -2,22 +2,20 @@ use ansi_term::{ANSIString, Style};
 
 use fs::fields as f;
 
-
 impl f::Type {
     pub fn render<C: Colours>(&self, colours: &C) -> ANSIString<'static> {
         match *self {
-            f::Type::File        => colours.normal().paint("."),
-            f::Type::Directory   => colours.directory().paint("d"),
-            f::Type::Pipe        => colours.pipe().paint("|"),
-            f::Type::Link        => colours.symlink().paint("l"),
+            f::Type::File => colours.normal().paint("."),
+            f::Type::Directory => colours.directory().paint("d"),
+            f::Type::Pipe => colours.pipe().paint("|"),
+            f::Type::Link => colours.symlink().paint("l"),
             f::Type::BlockDevice => colours.block_device().paint("b"),
-            f::Type::CharDevice  => colours.char_device().paint("c"),
-            f::Type::Socket      => colours.socket().paint("s"),
-            f::Type::Special     => colours.special().paint("?"),
+            f::Type::CharDevice => colours.char_device().paint("c"),
+            f::Type::Socket => colours.socket().paint("s"),
+            f::Type::Special => colours.special().paint("?"),
         }
     }
 }
-
 
 pub trait Colours {
     fn normal(&self) -> Style;

--- a/src/output/render/git.rs
+++ b/src/output/render/git.rs
@@ -1,35 +1,29 @@
 use ansi_term::{ANSIString, Style};
 
-use output::cell::{TextCell, DisplayWidth};
 use fs::fields as f;
-
+use output::cell::{DisplayWidth, TextCell};
 
 impl f::Git {
     pub fn render(&self, colours: &Colours) -> TextCell {
         TextCell {
             width: DisplayWidth::from(2),
-            contents: vec![
-                self.staged.render(colours),
-                self.unstaged.render(colours),
-            ].into(),
+            contents: vec![self.staged.render(colours), self.unstaged.render(colours)].into(),
         }
     }
 }
-
 
 impl f::GitStatus {
     fn render(&self, colours: &Colours) -> ANSIString<'static> {
         match *self {
-            f::GitStatus::NotModified  => colours.not_modified().paint("-"),
-            f::GitStatus::New          => colours.new().paint("N"),
-            f::GitStatus::Modified     => colours.modified().paint("M"),
-            f::GitStatus::Deleted      => colours.deleted().paint("D"),
-            f::GitStatus::Renamed      => colours.renamed().paint("R"),
-            f::GitStatus::TypeChange   => colours.type_change().paint("T"),
+            f::GitStatus::NotModified => colours.not_modified().paint("-"),
+            f::GitStatus::New => colours.new().paint("N"),
+            f::GitStatus::Modified => colours.modified().paint("M"),
+            f::GitStatus::Deleted => colours.deleted().paint("D"),
+            f::GitStatus::Renamed => colours.renamed().paint("R"),
+            f::GitStatus::TypeChange => colours.type_change().paint("T"),
         }
     }
 }
-
 
 pub trait Colours {
     fn not_modified(&self) -> Style;
@@ -40,61 +34,63 @@ pub trait Colours {
     fn type_change(&self) -> Style;
 }
 
-
 #[cfg(test)]
 pub mod test {
     use super::Colours;
-    use output::cell::{TextCell, DisplayWidth};
     use fs::fields as f;
+    use output::cell::{DisplayWidth, TextCell};
 
     use ansi_term::Colour::*;
     use ansi_term::Style;
 
-
     struct TestColours;
 
     impl Colours for TestColours {
-        fn not_modified(&self) -> Style { Fixed(90).normal() }
-        fn new(&self)          -> Style { Fixed(91).normal() }
-        fn modified(&self)     -> Style { Fixed(92).normal() }
-        fn deleted(&self)      -> Style { Fixed(93).normal() }
-        fn renamed(&self)      -> Style { Fixed(94).normal() }
-        fn type_change(&self)  -> Style { Fixed(95).normal() }
+        fn not_modified(&self) -> Style {
+            Fixed(90).normal()
+        }
+        fn new(&self) -> Style {
+            Fixed(91).normal()
+        }
+        fn modified(&self) -> Style {
+            Fixed(92).normal()
+        }
+        fn deleted(&self) -> Style {
+            Fixed(93).normal()
+        }
+        fn renamed(&self) -> Style {
+            Fixed(94).normal()
+        }
+        fn type_change(&self) -> Style {
+            Fixed(95).normal()
+        }
     }
-
 
     #[test]
     fn git_blank() {
         let stati = f::Git {
-            staged:   f::GitStatus::NotModified,
+            staged: f::GitStatus::NotModified,
             unstaged: f::GitStatus::NotModified,
         };
 
         let expected = TextCell {
             width: DisplayWidth::from(2),
-            contents: vec![
-                Fixed(90).paint("-"),
-                Fixed(90).paint("-"),
-            ].into(),
+            contents: vec![Fixed(90).paint("-"), Fixed(90).paint("-")].into(),
         };
 
         assert_eq!(expected, stati.render(&TestColours).into())
     }
 
-
     #[test]
     fn git_new_changed() {
         let stati = f::Git {
-            staged:   f::GitStatus::New,
+            staged: f::GitStatus::New,
             unstaged: f::GitStatus::Modified,
         };
 
         let expected = TextCell {
             width: DisplayWidth::from(2),
-            contents: vec![
-                Fixed(91).paint("N"),
-                Fixed(92).paint("M"),
-            ].into(),
+            contents: vec![Fixed(91).paint("N"), Fixed(92).paint("M")].into(),
         };
 
         assert_eq!(expected, stati.render(&TestColours).into())

--- a/src/output/render/groups.rs
+++ b/src/output/render/groups.rs
@@ -1,25 +1,25 @@
 use ansi_term::Style;
-use users::{Users, Groups};
+use users::{Groups, Users};
 
 use fs::fields as f;
 use output::cell::TextCell;
 
-
 impl f::Group {
-    pub fn render<C: Colours, U: Users+Groups>(&self, colours: &C, users: &U) -> TextCell {
+    pub fn render<C: Colours, U: Users + Groups>(&self, colours: &C, users: &U) -> TextCell {
         use users::os::unix::GroupExt;
 
         let mut style = colours.not_yours();
 
         let group = match users.get_group_by_gid(self.0) {
             Some(g) => (*g).clone(),
-            None    => return TextCell::paint(style, self.0.to_string()),
+            None => return TextCell::paint(style, self.0.to_string()),
         };
 
         let current_uid = users.get_current_uid();
         if let Some(current_user) = users.get_user_by_uid(current_uid) {
             if current_user.primary_group_id() == group.gid()
-            || group.members().contains(&current_user.name().to_owned()) {
+                || group.members().contains(&current_user.name().to_owned())
+            {
                 style = colours.yours();
             }
         }
@@ -28,12 +28,10 @@ impl f::Group {
     }
 }
 
-
 pub trait Colours {
     fn yours(&self) -> Style;
     fn not_yours(&self) -> Style;
 }
-
 
 #[cfg(test)]
 #[allow(unused_results)]
@@ -42,20 +40,22 @@ pub mod test {
     use fs::fields as f;
     use output::cell::TextCell;
 
-    use users::{User, Group};
-    use users::mock::MockUsers;
-    use users::os::unix::GroupExt;
     use ansi_term::Colour::*;
     use ansi_term::Style;
-
+    use users::mock::MockUsers;
+    use users::os::unix::GroupExt;
+    use users::{Group, User};
 
     struct TestColours;
 
     impl Colours for TestColours {
-        fn yours(&self)     -> Style { Fixed(80).normal() }
-        fn not_yours(&self) -> Style { Fixed(81).normal() }
+        fn yours(&self) -> Style {
+            Fixed(80).normal()
+        }
+        fn not_yours(&self) -> Style {
+            Fixed(81).normal()
+        }
     }
-
 
     #[test]
     fn named() {
@@ -104,6 +104,9 @@ pub mod test {
     fn overflow() {
         let group = f::Group(2_147_483_648);
         let expected = TextCell::paint_str(Fixed(81).normal(), "2147483648");
-        assert_eq!(expected, group.render(&TestColours, &MockUsers::with_current_uid(0)));
+        assert_eq!(
+            expected,
+            group.render(&TestColours, &MockUsers::with_current_uid(0))
+        );
     }
 }

--- a/src/output/render/inode.rs
+++ b/src/output/render/inode.rs
@@ -1,8 +1,7 @@
 use ansi_term::Style;
 
-use output::cell::TextCell;
 use fs::fields as f;
-
+use output::cell::TextCell;
 
 impl f::Inode {
     pub fn render(&self, style: Style) -> TextCell {
@@ -10,14 +9,12 @@ impl f::Inode {
     }
 }
 
-
 #[cfg(test)]
 pub mod test {
-    use output::cell::TextCell;
     use fs::fields as f;
+    use output::cell::TextCell;
 
     use ansi_term::Colour::*;
-
 
     #[test]
     fn blocklessness() {

--- a/src/output/render/links.rs
+++ b/src/output/render/links.rs
@@ -1,87 +1,104 @@
 use ansi_term::Style;
 use locale::Numeric as NumericLocale;
 
-use output::cell::TextCell;
 use fs::fields as f;
-
+use output::cell::TextCell;
 
 impl f::Links {
     pub fn render<C: Colours>(&self, colours: &C, numeric: &NumericLocale) -> TextCell {
-        let style = if self.multiple { colours.multi_link_file() }
-                                else { colours.normal() };
+        let style = if self.multiple {
+            colours.multi_link_file()
+        } else {
+            colours.normal()
+        };
 
         TextCell::paint(style, numeric.format_int(self.count))
     }
 }
-
 
 pub trait Colours {
     fn normal(&self) -> Style;
     fn multi_link_file(&self) -> Style;
 }
 
-
 #[cfg(test)]
 pub mod test {
     use super::Colours;
-    use output::cell::{TextCell, DisplayWidth};
     use fs::fields as f;
+    use output::cell::{DisplayWidth, TextCell};
 
     use ansi_term::Colour::*;
     use ansi_term::Style;
     use locale;
 
-
     struct TestColours;
 
     impl Colours for TestColours {
-        fn normal(&self)           -> Style { Blue.normal() }
-        fn multi_link_file(&self)  -> Style { Blue.on(Red) }
+        fn normal(&self) -> Style {
+            Blue.normal()
+        }
+        fn multi_link_file(&self) -> Style {
+            Blue.on(Red)
+        }
     }
-
 
     #[test]
     fn regular_file() {
         let stati = f::Links {
-            count:    1,
+            count: 1,
             multiple: false,
         };
 
         let expected = TextCell {
             width: DisplayWidth::from(1),
-            contents: vec![ Blue.paint("1") ].into(),
+            contents: vec![Blue.paint("1")].into(),
         };
 
-        assert_eq!(expected, stati.render(&TestColours, &locale::Numeric::english()).into());
+        assert_eq!(
+            expected,
+            stati
+                .render(&TestColours, &locale::Numeric::english())
+                .into()
+        );
     }
 
     #[test]
     fn regular_directory() {
         let stati = f::Links {
-            count:    3005,
+            count: 3005,
             multiple: false,
         };
 
         let expected = TextCell {
             width: DisplayWidth::from(5),
-            contents: vec![ Blue.paint("3,005") ].into(),
+            contents: vec![Blue.paint("3,005")].into(),
         };
 
-        assert_eq!(expected, stati.render(&TestColours, &locale::Numeric::english()).into());
+        assert_eq!(
+            expected,
+            stati
+                .render(&TestColours, &locale::Numeric::english())
+                .into()
+        );
     }
 
     #[test]
     fn popular_file() {
         let stati = f::Links {
-            count:    3005,
+            count: 3005,
             multiple: true,
         };
 
         let expected = TextCell {
             width: DisplayWidth::from(5),
-            contents: vec![ Blue.on(Red).paint("3,005") ].into(),
+            contents: vec![Blue.on(Red).paint("3,005")].into(),
         };
 
-        assert_eq!(expected, stati.render(&TestColours, &locale::Numeric::english()).into());
+        assert_eq!(
+            expected,
+            stati
+                .render(&TestColours, &locale::Numeric::english())
+                .into()
+        );
     }
 }

--- a/src/output/render/permissions.rs
+++ b/src/output/render/permissions.rs
@@ -1,81 +1,91 @@
 use ansi_term::{ANSIString, Style};
 
 use fs::fields as f;
-use output::cell::{TextCell, DisplayWidth};
+use output::cell::{DisplayWidth, TextCell};
 use output::render::FiletypeColours;
 
-
 impl f::PermissionsPlus {
-    pub fn render<C: Colours+FiletypeColours>(&self, colours: &C) -> TextCell {
-        let mut chars = vec![ self.file_type.render(colours) ];
-        chars.extend(self.permissions.render(colours, self.file_type.is_regular_file()));
+    pub fn render<C: Colours + FiletypeColours>(&self, colours: &C) -> TextCell {
+        let mut chars = vec![self.file_type.render(colours)];
+        chars.extend(
+            self.permissions
+                .render(colours, self.file_type.is_regular_file()),
+        );
 
         if self.xattrs {
-           chars.push(colours.attribute().paint("@"));
+            chars.push(colours.attribute().paint("@"));
         }
 
         // As these are all ASCII characters, we can guarantee that they’re
         // all going to be one character wide, and don’t need to compute the
         // cell’s display width.
         TextCell {
-            width:    DisplayWidth::from(chars.len()),
+            width: DisplayWidth::from(chars.len()),
             contents: chars.into(),
         }
     }
 }
 
-
-
 impl f::Permissions {
-    pub fn render<C: Colours>(&self, colours: &C, is_regular_file: bool) -> Vec<ANSIString<'static>> {
-
+    pub fn render<C: Colours>(
+        &self,
+        colours: &C,
+        is_regular_file: bool,
+    ) -> Vec<ANSIString<'static>> {
         let bit = |bit, chr: &'static str, style: Style| {
-            if bit { style.paint(chr) } else { colours.dash().paint("-") }
+            if bit {
+                style.paint(chr)
+            } else {
+                colours.dash().paint("-")
+            }
         };
 
         vec![
-            bit(self.user_read,     "r", colours.user_read()),
-            bit(self.user_write,    "w", colours.user_write()),
+            bit(self.user_read, "r", colours.user_read()),
+            bit(self.user_write, "w", colours.user_write()),
             self.user_execute_bit(colours, is_regular_file),
-            bit(self.group_read,    "r", colours.group_read()),
-            bit(self.group_write,   "w", colours.group_write()),
+            bit(self.group_read, "r", colours.group_read()),
+            bit(self.group_write, "w", colours.group_write()),
             self.group_execute_bit(colours),
-            bit(self.other_read,    "r", colours.other_read()),
-            bit(self.other_write,   "w", colours.other_write()),
-            self.other_execute_bit(colours)
+            bit(self.other_read, "r", colours.other_read()),
+            bit(self.other_write, "w", colours.other_write()),
+            self.other_execute_bit(colours),
         ]
     }
 
-    fn user_execute_bit<C: Colours>(&self, colours: &C, is_regular_file: bool) -> ANSIString<'static> {
+    fn user_execute_bit<C: Colours>(
+        &self,
+        colours: &C,
+        is_regular_file: bool,
+    ) -> ANSIString<'static> {
         match (self.user_execute, self.setuid, is_regular_file) {
-            (false, false, _)      => colours.dash().paint("-"),
-            (true,  false, false)  => colours.user_execute_other().paint("x"),
-            (true,  false, true)   => colours.user_execute_file().paint("x"),
-            (false, true,  _)      => colours.special_other().paint("S"),
-            (true,  true,  false)  => colours.special_other().paint("s"),
-            (true,  true,  true)   => colours.special_user_file().paint("s"),
+            (false, false, _) => colours.dash().paint("-"),
+            (true, false, false) => colours.user_execute_other().paint("x"),
+            (true, false, true) => colours.user_execute_file().paint("x"),
+            (false, true, _) => colours.special_other().paint("S"),
+            (true, true, false) => colours.special_other().paint("s"),
+            (true, true, true) => colours.special_user_file().paint("s"),
         }
     }
 
     fn group_execute_bit<C: Colours>(&self, colours: &C) -> ANSIString<'static> {
         match (self.group_execute, self.setgid) {
-            (false, false)  => colours.dash().paint("-"),
-            (true,  false)  => colours.group_execute().paint("x"),
-            (false, true)   => colours.special_other().paint("S"),
-            (true,  true)   => colours.special_other().paint("s"),
+            (false, false) => colours.dash().paint("-"),
+            (true, false) => colours.group_execute().paint("x"),
+            (false, true) => colours.special_other().paint("S"),
+            (true, true) => colours.special_other().paint("s"),
         }
     }
 
     fn other_execute_bit<C: Colours>(&self, colours: &C) -> ANSIString<'static> {
         match (self.other_execute, self.sticky) {
-            (false, false)  => colours.dash().paint("-"),
-            (true,  false)  => colours.other_execute().paint("x"),
-            (false, true)   => colours.special_other().paint("T"),
-            (true,  true)   => colours.special_other().paint("t"),
+            (false, false) => colours.dash().paint("-"),
+            (true, false) => colours.other_execute().paint("x"),
+            (false, true) => colours.special_other().paint("T"),
+            (true, true) => colours.special_other().paint("t"),
         }
     }
 }
-
 
 pub trait Colours {
     fn dash(&self) -> Style;
@@ -99,104 +109,186 @@ pub trait Colours {
     fn attribute(&self) -> Style;
 }
 
-
 #[cfg(test)]
 #[allow(unused_results)]
 pub mod test {
     use super::Colours;
-    use output::cell::TextCellContents;
     use fs::fields as f;
+    use output::cell::TextCellContents;
 
     use ansi_term::Colour::*;
     use ansi_term::Style;
 
-
     struct TestColours;
 
     impl Colours for TestColours {
-        fn dash(&self)                -> Style { Fixed(11).normal() }
-        fn user_read(&self)           -> Style { Fixed(101).normal() }
-        fn user_write(&self)          -> Style { Fixed(102).normal() }
-        fn user_execute_file(&self)   -> Style { Fixed(103).normal() }
-        fn user_execute_other(&self)  -> Style { Fixed(113).normal() }
-        fn group_read(&self)          -> Style { Fixed(104).normal() }
-        fn group_write(&self)         -> Style { Fixed(105).normal() }
-        fn group_execute(&self)       -> Style { Fixed(106).normal() }
-        fn other_read(&self)          -> Style { Fixed(107).normal() }
-        fn other_write(&self)         -> Style { Fixed(108).normal() }
-        fn other_execute(&self)       -> Style { Fixed(109).normal() }
-        fn special_user_file(&self)   -> Style { Fixed(110).normal() }
-        fn special_other(&self)       -> Style { Fixed(111).normal() }
-        fn attribute(&self)           -> Style { Fixed(112).normal() }
+        fn dash(&self) -> Style {
+            Fixed(11).normal()
+        }
+        fn user_read(&self) -> Style {
+            Fixed(101).normal()
+        }
+        fn user_write(&self) -> Style {
+            Fixed(102).normal()
+        }
+        fn user_execute_file(&self) -> Style {
+            Fixed(103).normal()
+        }
+        fn user_execute_other(&self) -> Style {
+            Fixed(113).normal()
+        }
+        fn group_read(&self) -> Style {
+            Fixed(104).normal()
+        }
+        fn group_write(&self) -> Style {
+            Fixed(105).normal()
+        }
+        fn group_execute(&self) -> Style {
+            Fixed(106).normal()
+        }
+        fn other_read(&self) -> Style {
+            Fixed(107).normal()
+        }
+        fn other_write(&self) -> Style {
+            Fixed(108).normal()
+        }
+        fn other_execute(&self) -> Style {
+            Fixed(109).normal()
+        }
+        fn special_user_file(&self) -> Style {
+            Fixed(110).normal()
+        }
+        fn special_other(&self) -> Style {
+            Fixed(111).normal()
+        }
+        fn attribute(&self) -> Style {
+            Fixed(112).normal()
+        }
     }
-
 
     #[test]
     fn negate() {
         let bits = f::Permissions {
-            user_read:  false,  user_write:  false,  user_execute:  false,  setuid: false,
-            group_read: false,  group_write: false,  group_execute: false,  setgid: false,
-            other_read: false,  other_write: false,  other_execute: false,  sticky: false,
+            user_read: false,
+            user_write: false,
+            user_execute: false,
+            setuid: false,
+            group_read: false,
+            group_write: false,
+            group_execute: false,
+            setgid: false,
+            other_read: false,
+            other_write: false,
+            other_execute: false,
+            sticky: false,
         };
 
         let expected = TextCellContents::from(vec![
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(11).paint("-"),
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(11).paint("-"),
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
         ]);
 
         assert_eq!(expected, bits.render(&TestColours, false).into())
     }
 
-
     #[test]
     fn affirm() {
         let bits = f::Permissions {
-            user_read:  true,  user_write:  true,  user_execute:  true,  setuid: false,
-            group_read: true,  group_write: true,  group_execute: true,  setgid: false,
-            other_read: true,  other_write: true,  other_execute: true,  sticky: false,
+            user_read: true,
+            user_write: true,
+            user_execute: true,
+            setuid: false,
+            group_read: true,
+            group_write: true,
+            group_execute: true,
+            setgid: false,
+            other_read: true,
+            other_write: true,
+            other_execute: true,
+            sticky: false,
         };
 
         let expected = TextCellContents::from(vec![
-            Fixed(101).paint("r"),  Fixed(102).paint("w"),  Fixed(103).paint("x"),
-            Fixed(104).paint("r"),  Fixed(105).paint("w"),  Fixed(106).paint("x"),
-            Fixed(107).paint("r"),  Fixed(108).paint("w"),  Fixed(109).paint("x"),
+            Fixed(101).paint("r"),
+            Fixed(102).paint("w"),
+            Fixed(103).paint("x"),
+            Fixed(104).paint("r"),
+            Fixed(105).paint("w"),
+            Fixed(106).paint("x"),
+            Fixed(107).paint("r"),
+            Fixed(108).paint("w"),
+            Fixed(109).paint("x"),
         ]);
 
         assert_eq!(expected, bits.render(&TestColours, true).into())
     }
-
 
     #[test]
     fn specials() {
         let bits = f::Permissions {
-            user_read:  false,  user_write:  false,  user_execute:  true,  setuid: true,
-            group_read: false,  group_write: false,  group_execute: true,  setgid: true,
-            other_read: false,  other_write: false,  other_execute: true,  sticky: true,
+            user_read: false,
+            user_write: false,
+            user_execute: true,
+            setuid: true,
+            group_read: false,
+            group_write: false,
+            group_execute: true,
+            setgid: true,
+            other_read: false,
+            other_write: false,
+            other_execute: true,
+            sticky: true,
         };
 
         let expected = TextCellContents::from(vec![
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(110).paint("s"),
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(111).paint("s"),
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(111).paint("t"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(110).paint("s"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(111).paint("s"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(111).paint("t"),
         ]);
 
         assert_eq!(expected, bits.render(&TestColours, true).into())
     }
 
-
     #[test]
     fn extra_specials() {
         let bits = f::Permissions {
-            user_read:  false,  user_write:  false,  user_execute:  false,  setuid: true,
-            group_read: false,  group_write: false,  group_execute: false,  setgid: true,
-            other_read: false,  other_write: false,  other_execute: false,  sticky: true,
+            user_read: false,
+            user_write: false,
+            user_execute: false,
+            setuid: true,
+            group_read: false,
+            group_write: false,
+            group_execute: false,
+            setgid: true,
+            other_read: false,
+            other_write: false,
+            other_execute: false,
+            sticky: true,
         };
 
         let expected = TextCellContents::from(vec![
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(111).paint("S"),
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(111).paint("S"),
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(111).paint("T"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(111).paint("S"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(111).paint("S"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(111).paint("T"),
         ]);
 
         assert_eq!(expected, bits.render(&TestColours, true).into())

--- a/src/output/render/size.rs
+++ b/src/output/render/size.rs
@@ -2,39 +2,45 @@ use ansi_term::Style;
 use locale::Numeric as NumericLocale;
 
 use fs::fields as f;
-use output::cell::{TextCell, DisplayWidth};
+use output::cell::{DisplayWidth, TextCell};
 use output::table::SizeFormat;
 
-
-
 impl f::Size {
-    pub fn render<C: Colours>(&self, colours: &C, size_format: SizeFormat, numerics: &NumericLocale) -> TextCell {
+    pub fn render<C: Colours>(
+        &self,
+        colours: &C,
+        size_format: SizeFormat,
+        numerics: &NumericLocale,
+    ) -> TextCell {
         use number_prefix::{binary_prefix, decimal_prefix};
-        use number_prefix::{Prefixed, Standalone, PrefixNames};
+        use number_prefix::{PrefixNames, Prefixed, Standalone};
 
         let size = match *self {
-            f::Size::Some(s)             => s,
-            f::Size::None                => return TextCell::blank(colours.no_size()),
-            f::Size::DeviceIDs(ref ids)  => return ids.render(colours),
+            f::Size::Some(s) => s,
+            f::Size::None => return TextCell::blank(colours.no_size()),
+            f::Size::DeviceIDs(ref ids) => return ids.render(colours),
         };
 
         let result = match size_format {
-            SizeFormat::DecimalBytes  => decimal_prefix(size as f64),
-            SizeFormat::BinaryBytes   => binary_prefix(size as f64),
-            SizeFormat::JustBytes     => {
+            SizeFormat::DecimalBytes => decimal_prefix(size as f64),
+            SizeFormat::BinaryBytes => binary_prefix(size as f64),
+            SizeFormat::JustBytes => {
                 let string = numerics.format_int(size);
                 return TextCell::paint(colours.size(size), string);
-            },
+            }
         };
 
         let (prefix, n) = match result {
-            Standalone(b)  => return TextCell::paint(colours.size(b as u64), b.to_string()),
-            Prefixed(p, n) => (p, n)
+            Standalone(b) => return TextCell::paint(colours.size(b as u64), b.to_string()),
+            Prefixed(p, n) => (p, n),
         };
 
         let symbol = prefix.symbol();
-        let number = if n < 10f64 { numerics.format_float(n, 1) }
-                             else { numerics.format_int(n as isize) };
+        let number = if n < 10f64 {
+            numerics.format_float(n, 1)
+        } else {
+            numerics.format_int(n as isize)
+        };
 
         // The numbers and symbols are guaranteed to be written in ASCII, so
         // we can skip the display width calculation.
@@ -45,11 +51,11 @@ impl f::Size {
             contents: vec![
                 colours.size(size).paint(number),
                 colours.unit().paint(symbol),
-            ].into(),
+            ]
+            .into(),
         }
     }
 }
-
 
 impl f::DeviceIDs {
     fn render<C: Colours>(&self, colours: &C) -> TextCell {
@@ -62,11 +68,11 @@ impl f::DeviceIDs {
                 colours.major().paint(major),
                 colours.comma().paint(","),
                 colours.minor().paint(minor),
-            ].into(),
+            ]
+            .into(),
         }
     }
 }
-
 
 pub trait Colours {
     fn size(&self, size: u64) -> Style;
@@ -78,96 +84,132 @@ pub trait Colours {
     fn minor(&self) -> Style;
 }
 
-
 #[cfg(test)]
 pub mod test {
     use super::Colours;
-    use output::cell::{TextCell, DisplayWidth};
-    use output::table::SizeFormat;
     use fs::fields as f;
+    use output::cell::{DisplayWidth, TextCell};
+    use output::table::SizeFormat;
 
-    use locale::Numeric as NumericLocale;
     use ansi_term::Colour::*;
     use ansi_term::Style;
-
+    use locale::Numeric as NumericLocale;
 
     struct TestColours;
 
     impl Colours for TestColours {
-        fn size(&self, _size: u64) -> Style { Fixed(66).normal() }
-        fn unit(&self)             -> Style { Fixed(77).bold() }
-        fn no_size(&self)          -> Style { Black.italic() }
+        fn size(&self, _size: u64) -> Style {
+            Fixed(66).normal()
+        }
+        fn unit(&self) -> Style {
+            Fixed(77).bold()
+        }
+        fn no_size(&self) -> Style {
+            Black.italic()
+        }
 
-        fn major(&self) -> Style { Blue.on(Red) }
-        fn comma(&self) -> Style { Green.italic() }
-        fn minor(&self) -> Style { Cyan.on(Yellow) }
+        fn major(&self) -> Style {
+            Blue.on(Red)
+        }
+        fn comma(&self) -> Style {
+            Green.italic()
+        }
+        fn minor(&self) -> Style {
+            Cyan.on(Yellow)
+        }
     }
-
 
     #[test]
     fn directory() {
         let directory = f::Size::None;
         let expected = TextCell::blank(Black.italic());
-        assert_eq!(expected, directory.render(&TestColours, SizeFormat::JustBytes, &NumericLocale::english()))
+        assert_eq!(
+            expected,
+            directory.render(
+                &TestColours,
+                SizeFormat::JustBytes,
+                &NumericLocale::english()
+            )
+        )
     }
-
 
     #[test]
     fn file_decimal() {
         let directory = f::Size::Some(2_100_000);
         let expected = TextCell {
             width: DisplayWidth::from(4),
-            contents: vec![
-                Fixed(66).paint("2.1"),
-                Fixed(77).bold().paint("M"),
-            ].into(),
+            contents: vec![Fixed(66).paint("2.1"), Fixed(77).bold().paint("M")].into(),
         };
 
-        assert_eq!(expected, directory.render(&TestColours, SizeFormat::DecimalBytes, &NumericLocale::english()))
+        assert_eq!(
+            expected,
+            directory.render(
+                &TestColours,
+                SizeFormat::DecimalBytes,
+                &NumericLocale::english()
+            )
+        )
     }
-
 
     #[test]
     fn file_binary() {
         let directory = f::Size::Some(1_048_576);
         let expected = TextCell {
             width: DisplayWidth::from(5),
-            contents: vec![
-                Fixed(66).paint("1.0"),
-                Fixed(77).bold().paint("Mi"),
-            ].into(),
+            contents: vec![Fixed(66).paint("1.0"), Fixed(77).bold().paint("Mi")].into(),
         };
 
-        assert_eq!(expected, directory.render(&TestColours, SizeFormat::BinaryBytes, &NumericLocale::english()))
+        assert_eq!(
+            expected,
+            directory.render(
+                &TestColours,
+                SizeFormat::BinaryBytes,
+                &NumericLocale::english()
+            )
+        )
     }
-
 
     #[test]
     fn file_bytes() {
         let directory = f::Size::Some(1048576);
         let expected = TextCell {
             width: DisplayWidth::from(9),
-            contents: vec![
-                Fixed(66).paint("1,048,576"),
-            ].into(),
+            contents: vec![Fixed(66).paint("1,048,576")].into(),
         };
 
-        assert_eq!(expected, directory.render(&TestColours, SizeFormat::JustBytes, &NumericLocale::english()))
+        assert_eq!(
+            expected,
+            directory.render(
+                &TestColours,
+                SizeFormat::JustBytes,
+                &NumericLocale::english()
+            )
+        )
     }
-
 
     #[test]
     fn device_ids() {
-        let directory = f::Size::DeviceIDs(f::DeviceIDs { major: 10, minor: 80 });
+        let directory = f::Size::DeviceIDs(f::DeviceIDs {
+            major: 10,
+            minor: 80,
+        });
         let expected = TextCell {
             width: DisplayWidth::from(5),
             contents: vec![
                 Blue.on(Red).paint("10"),
                 Green.italic().paint(","),
                 Cyan.on(Yellow).paint("80"),
-            ].into(),
+            ]
+            .into(),
         };
 
-        assert_eq!(expected, directory.render(&TestColours, SizeFormat::JustBytes, &NumericLocale::english()))
+        assert_eq!(
+            expected,
+            directory.render(
+                &TestColours,
+                SizeFormat::JustBytes,
+                &NumericLocale::english()
+            )
+        )
     }
 }

--- a/src/output/render/times.rs
+++ b/src/output/render/times.rs
@@ -1,21 +1,16 @@
-use datetime::TimeZone;
 use ansi_term::Style;
+use datetime::TimeZone;
 
 use fs::fields as f;
 use output::cell::TextCell;
 use output::time::TimeFormat;
 
-
 impl f::Time {
-    pub fn render(self, style: Style,
-                        tz: &Option<TimeZone>,
-                        format: &TimeFormat) -> TextCell {
-
+    pub fn render(self, style: Style, tz: &Option<TimeZone>, format: &TimeFormat) -> TextCell {
         if let Some(ref tz) = *tz {
             let datestamp = format.format_zoned(self, tz);
             TextCell::paint(style, datestamp)
-        }
-        else {
+        } else {
             let datestamp = format.format_local(self);
             TextCell::paint(style, datestamp)
         }

--- a/src/output/render/users.rs
+++ b/src/output/render/users.rs
@@ -4,27 +4,26 @@ use users::Users;
 use fs::fields as f;
 use output::cell::TextCell;
 
-
-
 impl f::User {
     pub fn render<C: Colours, U: Users>(&self, colours: &C, users: &U) -> TextCell {
         let user_name = match users.get_user_by_uid(self.0) {
-            Some(user)  => user.name().to_owned(),
-            None        => self.0.to_string(),
+            Some(user) => user.name().to_owned(),
+            None => self.0.to_string(),
         };
 
-        let style =  if users.get_current_uid() == self.0 { colours.you() }
-                                                     else { colours.someone_else() };
+        let style = if users.get_current_uid() == self.0 {
+            colours.you()
+        } else {
+            colours.someone_else()
+        };
         TextCell::paint(style, user_name)
     }
 }
-
 
 pub trait Colours {
     fn you(&self) -> Style;
     fn someone_else(&self) -> Style;
 }
-
 
 #[cfg(test)]
 #[allow(unused_results)]
@@ -33,19 +32,21 @@ pub mod test {
     use fs::fields as f;
     use output::cell::TextCell;
 
-    use users::User;
-    use users::mock::MockUsers;
     use ansi_term::Colour::*;
     use ansi_term::Style;
-
+    use users::mock::MockUsers;
+    use users::User;
 
     struct TestColours;
 
     impl Colours for TestColours {
-        fn you(&self)          -> Style { Red.bold() }
-        fn someone_else(&self) -> Style { Blue.underline() }
+        fn you(&self) -> Style {
+            Red.bold()
+        }
+        fn someone_else(&self) -> Style {
+            Blue.underline()
+        }
     }
-
 
     #[test]
     fn named() {
@@ -80,13 +81,19 @@ pub mod test {
     fn different_unnamed() {
         let user = f::User(1000);
         let expected = TextCell::paint_str(Blue.underline(), "1000");
-        assert_eq!(expected, user.render(&TestColours, &MockUsers::with_current_uid(0)));
+        assert_eq!(
+            expected,
+            user.render(&TestColours, &MockUsers::with_current_uid(0))
+        );
     }
 
     #[test]
     fn overflow() {
         let user = f::User(2_147_483_648);
         let expected = TextCell::paint_str(Blue.underline(), "2147483648");
-        assert_eq!(expected, user.render(&TestColours, &MockUsers::with_current_uid(0)));
+        assert_eq!(
+            expected,
+            user.render(&TestColours, &MockUsers::with_current_uid(0))
+        );
     }
 }

--- a/src/output/time.rs
+++ b/src/output/time.rs
@@ -1,12 +1,11 @@
 //! Timestamp formatting.
 
-use datetime::{LocalDateTime, TimeZone, DatePiece, TimePiece};
 use datetime::fmt::DateFormat;
+use datetime::{DatePiece, LocalDateTime, TimePiece, TimeZone};
 use locale;
 use std::cmp;
 
 use fs::fields::Time;
-
 
 /// Every timestamp in exa needs to be rendered by a **time format**.
 /// Formatting times is tricky, because how a timestamp is rendered can
@@ -26,7 +25,6 @@ use fs::fields::Time;
 /// format string in an environment variable or something. Just these four.
 #[derive(Debug)]
 pub enum TimeFormat {
-
     /// The **default format** uses the user’s locale to print month names,
     /// and specifies the timestamp down to the minute for recent times, and
     /// day for older times.
@@ -54,26 +52,24 @@ impl TimeFormat {
     pub fn format_local(&self, time: Time) -> String {
         match *self {
             TimeFormat::DefaultFormat(ref fmt) => fmt.format_local(time),
-            TimeFormat::ISOFormat(ref iso)     => iso.format_local(time),
-            TimeFormat::LongISO                => long_local(time),
-            TimeFormat::FullISO                => full_local(time),
+            TimeFormat::ISOFormat(ref iso) => iso.format_local(time),
+            TimeFormat::LongISO => long_local(time),
+            TimeFormat::FullISO => full_local(time),
         }
     }
 
     pub fn format_zoned(&self, time: Time, zone: &TimeZone) -> String {
         match *self {
             TimeFormat::DefaultFormat(ref fmt) => fmt.format_zoned(time, zone),
-            TimeFormat::ISOFormat(ref iso)     => iso.format_zoned(time, zone),
-            TimeFormat::LongISO                => long_zoned(time, zone),
-            TimeFormat::FullISO                => full_zoned(time, zone),
+            TimeFormat::ISOFormat(ref iso) => iso.format_zoned(time, zone),
+            TimeFormat::LongISO => long_zoned(time, zone),
+            TimeFormat::FullISO => full_zoned(time, zone),
         }
     }
 }
 
-
 #[derive(Debug, Clone)]
 pub struct DefaultFormat {
-
     /// The year of the current time. This gets used to determine which date
     /// format to use.
     pub current_year: i64,
@@ -92,8 +88,7 @@ impl DefaultFormat {
     pub fn load() -> DefaultFormat {
         use unicode_width::UnicodeWidthStr;
 
-        let locale = locale::Time::load_user_locale()
-                       .unwrap_or_else(|_| locale::Time::english());
+        let locale = locale::Time::load_user_locale().unwrap_or_else(|_| locale::Time::english());
 
         let current_year = LocalDateTime::now().year();
 
@@ -107,18 +102,23 @@ impl DefaultFormat {
         }
 
         let date_and_time = match maximum_month_width {
-            4  => DateFormat::parse("{2>:D} {4<:M} {2>:h}:{02>:m}").unwrap(),
-            5  => DateFormat::parse("{2>:D} {5<:M} {2>:h}:{02>:m}").unwrap(),
-            _  => DateFormat::parse("{2>:D} {:M} {2>:h}:{02>:m}").unwrap(),
+            4 => DateFormat::parse("{2>:D} {4<:M} {2>:h}:{02>:m}").unwrap(),
+            5 => DateFormat::parse("{2>:D} {5<:M} {2>:h}:{02>:m}").unwrap(),
+            _ => DateFormat::parse("{2>:D} {:M} {2>:h}:{02>:m}").unwrap(),
         };
 
         let date_and_year = match maximum_month_width {
             4 => DateFormat::parse("{2>:D} {4<:M} {5>:Y}").unwrap(),
             5 => DateFormat::parse("{2>:D} {5<:M} {5>:Y}").unwrap(),
-            _ => DateFormat::parse("{2>:D} {:M} {5>:Y}").unwrap()
+            _ => DateFormat::parse("{2>:D} {:M} {5>:Y}").unwrap(),
         };
 
-        DefaultFormat { current_year, locale, date_and_time, date_and_year }
+        DefaultFormat {
+            current_year,
+            locale,
+            date_and_time,
+            date_and_year,
+        }
     }
 }
 
@@ -133,8 +133,7 @@ impl DefaultFormat {
 
         if self.is_recent(date) {
             self.date_and_time.format(&date, &self.locale)
-        }
-        else {
+        } else {
             self.date_and_year.format(&date, &self.locale)
         }
     }
@@ -145,37 +144,51 @@ impl DefaultFormat {
 
         if self.is_recent(date) {
             self.date_and_time.format(&date, &self.locale)
-        }
-        else {
+        } else {
             self.date_and_year.format(&date, &self.locale)
         }
     }
 }
 
-
 #[allow(trivial_numeric_casts)]
 fn long_local(time: Time) -> String {
     let date = LocalDateTime::at(time.seconds as i64);
-    format!("{:04}-{:02}-{:02} {:02}:{:02}",
-            date.year(), date.month() as usize, date.day(),
-            date.hour(), date.minute())
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}",
+        date.year(),
+        date.month() as usize,
+        date.day(),
+        date.hour(),
+        date.minute()
+    )
 }
 
 #[allow(trivial_numeric_casts)]
 fn long_zoned(time: Time, zone: &TimeZone) -> String {
     let date = zone.to_zoned(LocalDateTime::at(time.seconds as i64));
-    format!("{:04}-{:02}-{:02} {:02}:{:02}",
-            date.year(), date.month() as usize, date.day(),
-            date.hour(), date.minute())
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}",
+        date.year(),
+        date.month() as usize,
+        date.day(),
+        date.hour(),
+        date.minute()
+    )
 }
-
 
 #[allow(trivial_numeric_casts)]
 fn full_local(time: Time) -> String {
     let date = LocalDateTime::at(time.seconds as i64);
-    format!("{:04}-{:02}-{:02} {:02}:{:02}:{:02}.{:09}",
-            date.year(), date.month() as usize, date.day(),
-            date.hour(), date.minute(), date.second(), time.nanoseconds)
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}:{:02}.{:09}",
+        date.year(),
+        date.month() as usize,
+        date.day(),
+        date.hour(),
+        date.minute(),
+        date.second(),
+        time.nanoseconds
+    )
 }
 
 #[allow(trivial_numeric_casts)]
@@ -185,17 +198,22 @@ fn full_zoned(time: Time, zone: &TimeZone) -> String {
     let local = LocalDateTime::at(time.seconds as i64);
     let date = zone.to_zoned(local);
     let offset = Offset::of_seconds(zone.offset(local) as i32).expect("Offset out of range");
-    format!("{:04}-{:02}-{:02} {:02}:{:02}:{:02}.{:09} {:+03}{:02}",
-            date.year(), date.month() as usize, date.day(),
-            date.hour(), date.minute(), date.second(), time.nanoseconds,
-            offset.hours(), offset.minutes().abs())
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}:{:02}.{:09} {:+03}{:02}",
+        date.year(),
+        date.month() as usize,
+        date.day(),
+        date.hour(),
+        date.minute(),
+        date.second(),
+        time.nanoseconds,
+        offset.hours(),
+        offset.minutes().abs()
+    )
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct ISOFormat {
-
     /// The year of the current time. This gets used to determine which date
     /// format to use.
     pub current_year: i64,
@@ -218,13 +236,20 @@ impl ISOFormat {
         let date = LocalDateTime::at(time.seconds as i64);
 
         if self.is_recent(date) {
-            format!("{:02}-{:02} {:02}:{:02}",
-                    date.month() as usize, date.day(),
-                    date.hour(), date.minute())
-        }
-        else {
-            format!("{:04}-{:02}-{:02}",
-                    date.year(), date.month() as usize, date.day())
+            format!(
+                "{:02}-{:02} {:02}:{:02}",
+                date.month() as usize,
+                date.day(),
+                date.hour(),
+                date.minute()
+            )
+        } else {
+            format!(
+                "{:04}-{:02}-{:02}",
+                date.year(),
+                date.month() as usize,
+                date.day()
+            )
         }
     }
 
@@ -233,13 +258,20 @@ impl ISOFormat {
         let date = zone.to_zoned(LocalDateTime::at(time.seconds as i64));
 
         if self.is_recent(date) {
-            format!("{:02}-{:02} {:02}:{:02}",
-                    date.month() as usize, date.day(),
-                    date.hour(), date.minute())
-        }
-        else {
-            format!("{:04}-{:02}-{:02}",
-                    date.year(), date.month() as usize, date.day())
+            format!(
+                "{:02}-{:02} {:02}:{:02}",
+                date.month() as usize,
+                date.day(),
+                date.hour(),
+                date.minute()
+            )
+        } else {
+            format!(
+                "{:04}-{:02}-{:02}",
+                date.year(),
+                date.month() as usize,
+                date.day()
+            )
         }
     }
 }

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -38,10 +38,8 @@
 //! successfully `stat`ted, we don’t know how many files are going to exist in
 //! each directory)
 
-
 #[derive(PartialEq, Debug, Clone)]
 pub enum TreePart {
-
     /// Rightmost column, *not* the last in the directory.
     Edge,
 
@@ -56,24 +54,21 @@ pub enum TreePart {
 }
 
 impl TreePart {
-
     /// Turn this tree part into ASCII-licious box drawing characters!
     /// (Warning: not actually ASCII)
     pub fn ascii_art(&self) -> &'static str {
         match *self {
-            TreePart::Edge    => "├──",
-            TreePart::Line    => "│  ",
-            TreePart::Corner  => "└──",
-            TreePart::Blank   => "   ",
+            TreePart::Edge => "├──",
+            TreePart::Line => "│  ",
+            TreePart::Corner => "└──",
+            TreePart::Blank => "   ",
         }
     }
 }
 
-
 /// A **tree trunk** builds up arrays of tree parts over multiple depths.
 #[derive(Debug, Default)]
 pub struct TreeTrunk {
-
     /// A stack tracks which tree characters should be printed. It’s
     /// necessary to maintain information about the previously-printed
     /// lines, as the output will change based on any previous entries.
@@ -85,7 +80,6 @@ pub struct TreeTrunk {
 
 #[derive(Debug, Copy, Clone)]
 pub struct TreeParams {
-
     /// How many directories deep into the tree structure this is. Directories
     /// on top have depth 0.
     depth: TreeDepth,
@@ -98,7 +92,6 @@ pub struct TreeParams {
 pub struct TreeDepth(pub usize);
 
 impl TreeTrunk {
-
     /// Calculates the tree parts for an entry at the given depth and
     /// last-ness. The depth is used to determine where in the stack the tree
     /// part should be inserted, and the last-ness is used to determine which
@@ -107,17 +100,24 @@ impl TreeTrunk {
     /// This takes a `&mut self` because the results of each file are stored
     /// and used in future rows.
     pub fn new_row(&mut self, params: TreeParams) -> &[TreePart] {
-
         // If this isn’t our first iteration, then update the tree parts thus
         // far to account for there being another row after it.
         if let Some(last) = self.last_params {
-            self.stack[last.depth.0] = if last.last { TreePart::Blank } else { TreePart::Line };
+            self.stack[last.depth.0] = if last.last {
+                TreePart::Blank
+            } else {
+                TreePart::Line
+            };
         }
 
         // Make sure the stack has enough space, then add or modify another
         // part into it.
         self.stack.resize(params.depth.0 + 1, TreePart::Edge);
-        self.stack[params.depth.0] = if params.last { TreePart::Corner } else { TreePart::Edge };
+        self.stack[params.depth.0] = if params.last {
+            TreePart::Corner
+        } else {
+            TreePart::Edge
+        };
         self.last_params = Some(params);
 
         // Return the tree parts as a slice of the stack.
@@ -159,11 +159,15 @@ impl TreeDepth {
     /// Creates an iterator that, as well as yielding each value, yields a
     /// `TreeParams` with the current depth and last flag filled in.
     pub fn iterate_over<I, T>(self, inner: I) -> Iter<I>
-    where I: ExactSizeIterator+Iterator<Item=T> {
-        Iter { current_depth: self, inner }
+    where
+        I: ExactSizeIterator + Iterator<Item = T>,
+    {
+        Iter {
+            current_depth: self,
+            inner,
+        }
     }
 }
-
 
 pub struct Iter<I> {
     current_depth: TreeDepth,
@@ -171,17 +175,21 @@ pub struct Iter<I> {
 }
 
 impl<I, T> Iterator for Iter<I>
-where I: ExactSizeIterator+Iterator<Item=T> {
+where
+    I: ExactSizeIterator + Iterator<Item = T>,
+{
     type Item = (TreeParams, T);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(|t| {
             // use exact_size_is_empty API soon
-            (TreeParams::new(self.current_depth, self.inner.len() == 0), t)
+            (
+                TreeParams::new(self.current_depth, self.inner.len() == 0),
+                t,
+            )
         })
     }
 }
-
 
 #[cfg(test)]
 mod trunk_test {
@@ -201,27 +209,27 @@ mod trunk_test {
     fn one_child() {
         let mut tt = TreeTrunk::default();
         assert_eq!(tt.new_row(params(0, true)), &[]);
-        assert_eq!(tt.new_row(params(1, true)), &[ TreePart::Corner ]);
+        assert_eq!(tt.new_row(params(1, true)), &[TreePart::Corner]);
     }
 
     #[test]
     fn two_children() {
         let mut tt = TreeTrunk::default();
-        assert_eq!(tt.new_row(params(0, true)),  &[]);
-        assert_eq!(tt.new_row(params(1, false)), &[ TreePart::Edge ]);
-        assert_eq!(tt.new_row(params(1, true)),  &[ TreePart::Corner ]);
+        assert_eq!(tt.new_row(params(0, true)), &[]);
+        assert_eq!(tt.new_row(params(1, false)), &[TreePart::Edge]);
+        assert_eq!(tt.new_row(params(1, true)), &[TreePart::Corner]);
     }
 
     #[test]
     fn two_times_two_children() {
         let mut tt = TreeTrunk::default();
         assert_eq!(tt.new_row(params(0, false)), &[]);
-        assert_eq!(tt.new_row(params(1, false)), &[ TreePart::Edge ]);
-        assert_eq!(tt.new_row(params(1, true)),  &[ TreePart::Corner ]);
+        assert_eq!(tt.new_row(params(1, false)), &[TreePart::Edge]);
+        assert_eq!(tt.new_row(params(1, true)), &[TreePart::Corner]);
 
-        assert_eq!(tt.new_row(params(0, true)),  &[]);
-        assert_eq!(tt.new_row(params(1, false)), &[ TreePart::Edge ]);
-        assert_eq!(tt.new_row(params(1, true)),  &[ TreePart::Corner ]);
+        assert_eq!(tt.new_row(params(0, true)), &[]);
+        assert_eq!(tt.new_row(params(1, false)), &[TreePart::Edge]);
+        assert_eq!(tt.new_row(params(1, true)), &[TreePart::Corner]);
     }
 
     #[test]
@@ -229,17 +237,27 @@ mod trunk_test {
         let mut tt = TreeTrunk::default();
         assert_eq!(tt.new_row(params(0, true)), &[]);
 
-        assert_eq!(tt.new_row(params(1, false)), &[ TreePart::Edge ]);
-        assert_eq!(tt.new_row(params(2, false)), &[ TreePart::Line, TreePart::Edge ]);
-        assert_eq!(tt.new_row(params(2, true)),  &[ TreePart::Line, TreePart::Corner ]);
+        assert_eq!(tt.new_row(params(1, false)), &[TreePart::Edge]);
+        assert_eq!(
+            tt.new_row(params(2, false)),
+            &[TreePart::Line, TreePart::Edge]
+        );
+        assert_eq!(
+            tt.new_row(params(2, true)),
+            &[TreePart::Line, TreePart::Corner]
+        );
 
-        assert_eq!(tt.new_row(params(1, true)),  &[ TreePart::Corner ]);
-        assert_eq!(tt.new_row(params(2, false)), &[ TreePart::Blank, TreePart::Edge ]);
-        assert_eq!(tt.new_row(params(2, true)),  &[ TreePart::Blank, TreePart::Corner ]);
+        assert_eq!(tt.new_row(params(1, true)), &[TreePart::Corner]);
+        assert_eq!(
+            tt.new_row(params(2, false)),
+            &[TreePart::Blank, TreePart::Edge]
+        );
+        assert_eq!(
+            tt.new_row(params(2, true)),
+            &[TreePart::Blank, TreePart::Corner]
+        );
     }
 }
-
-
 
 #[cfg(test)]
 mod iter_test {
@@ -247,7 +265,7 @@ mod iter_test {
 
     #[test]
     fn test_iteration() {
-        let foos = &[ "first", "middle", "last" ];
+        let foos = &["first", "middle", "last"];
         let mut iter = TreeDepth::root().iterate_over(foos.into_iter());
 
         let next = iter.next().unwrap();

--- a/src/style/colours.rs
+++ b/src/style/colours.rs
@@ -1,34 +1,33 @@
+use ansi_term::Colour::{Blue, Cyan, Fixed, Green, Purple, Red, Yellow};
 use ansi_term::Style;
-use ansi_term::Colour::{Red, Green, Yellow, Blue, Cyan, Purple, Fixed};
 
-use output::render;
 use output::file_name::Colours as FileNameColours;
+use output::render;
 
 use style::lsc::Pair;
-
 
 #[derive(Debug, Default, PartialEq)]
 pub struct Colours {
     pub colourful: bool,
     pub scale: bool,
 
-    pub filekinds:  FileKinds,
-    pub perms:      Permissions,
-    pub size:       Size,
-    pub users:      Users,
-    pub links:      Links,
-    pub git:        Git,
+    pub filekinds: FileKinds,
+    pub perms: Permissions,
+    pub size: Size,
+    pub users: Users,
+    pub links: Links,
+    pub git: Git,
 
-    pub punctuation:  Style,
-    pub date:         Style,
-    pub inode:        Style,
-    pub blocks:       Style,
-    pub header:       Style,
+    pub punctuation: Style,
+    pub date: Style,
+    pub inode: Style,
+    pub blocks: Style,
+    pub header: Style,
 
-    pub symlink_path:         Style,
-    pub control_char:         Style,
-    pub broken_symlink:       Style,
-    pub broken_path_overlay:  Style,
+    pub symlink_path: Style,
+    pub control_char: Style,
+    pub broken_symlink: Style,
+    pub broken_path_overlay: Style,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
@@ -46,21 +45,21 @@ pub struct FileKinds {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Permissions {
-    pub user_read:          Style,
-    pub user_write:         Style,
-    pub user_execute_file:  Style,
+    pub user_read: Style,
+    pub user_write: Style,
+    pub user_execute_file: Style,
     pub user_execute_other: Style,
 
-    pub group_read:    Style,
-    pub group_write:   Style,
+    pub group_read: Style,
+    pub group_write: Style,
     pub group_execute: Style,
 
-    pub other_read:    Style,
-    pub other_write:   Style,
+    pub other_read: Style,
+    pub other_write: Style,
     pub other_execute: Style,
 
     pub special_user_file: Style,
-    pub special_other:     Style,
+    pub special_other: Style,
 
     pub attribute: Style,
 }
@@ -114,43 +113,43 @@ impl Colours {
             scale,
 
             filekinds: FileKinds {
-                normal:       Style::default(),
-                directory:    Blue.bold(),
-                symlink:      Cyan.normal(),
-                pipe:         Yellow.normal(),
+                normal: Style::default(),
+                directory: Blue.bold(),
+                symlink: Cyan.normal(),
+                pipe: Yellow.normal(),
                 block_device: Yellow.bold(),
-                char_device:  Yellow.bold(),
-                socket:       Red.bold(),
-                special:      Yellow.normal(),
-                executable:   Green.bold(),
+                char_device: Yellow.bold(),
+                socket: Red.bold(),
+                special: Yellow.normal(),
+                executable: Green.bold(),
             },
 
             perms: Permissions {
-                user_read:           Yellow.bold(),
-                user_write:          Red.bold(),
-                user_execute_file:   Green.bold().underline(),
-                user_execute_other:  Green.bold(),
+                user_read: Yellow.bold(),
+                user_write: Red.bold(),
+                user_execute_file: Green.bold().underline(),
+                user_execute_other: Green.bold(),
 
-                group_read:          Yellow.normal(),
-                group_write:         Red.normal(),
-                group_execute:       Green.normal(),
+                group_read: Yellow.normal(),
+                group_write: Red.normal(),
+                group_execute: Green.normal(),
 
-                other_read:          Yellow.normal(),
-                other_write:         Red.normal(),
-                other_execute:       Green.normal(),
+                other_read: Yellow.normal(),
+                other_write: Red.normal(),
+                other_execute: Green.normal(),
 
-                special_user_file:   Purple.normal(),
-                special_other:       Purple.normal(),
+                special_user_file: Purple.normal(),
+                special_other: Purple.normal(),
 
-                attribute:           Style::default(),
+                attribute: Style::default(),
             },
 
             size: Size {
-                numbers:  Green.bold(),
-                unit:     Green.normal(),
+                numbers: Green.bold(),
+                unit: Green.normal(),
 
-                major:  Green.bold(),
-                minor:  Green.normal(),
+                major: Green.bold(),
+                minor: Green.normal(),
 
                 scale_byte: Fixed(118).normal(),
                 scale_kilo: Fixed(190).normal(),
@@ -160,39 +159,38 @@ impl Colours {
             },
 
             users: Users {
-                user_you:           Yellow.bold(),
-                user_someone_else:  Style::default(),
-                group_yours:        Yellow.bold(),
-                group_not_yours:    Style::default(),
+                user_you: Yellow.bold(),
+                user_someone_else: Style::default(),
+                group_yours: Yellow.bold(),
+                group_not_yours: Style::default(),
             },
 
             links: Links {
-                normal:          Red.bold(),
+                normal: Red.bold(),
                 multi_link_file: Red.on(Yellow),
             },
 
             git: Git {
-                new:         Green.normal(),
-                modified:    Blue.normal(),
-                deleted:     Red.normal(),
-                renamed:     Yellow.normal(),
-                typechange:  Purple.normal(),
+                new: Green.normal(),
+                modified: Blue.normal(),
+                deleted: Red.normal(),
+                renamed: Yellow.normal(),
+                typechange: Purple.normal(),
             },
 
-            punctuation:  Fixed(244).normal(),
-            date:         Blue.normal(),
-            inode:        Purple.normal(),
-            blocks:       Cyan.normal(),
-            header:       Style::default().underline(),
+            punctuation: Fixed(244).normal(),
+            date: Blue.normal(),
+            inode: Purple.normal(),
+            blocks: Cyan.normal(),
+            header: Style::default().underline(),
 
-            symlink_path:         Cyan.normal(),
-            control_char:         Red.normal(),
-            broken_symlink:       Red.normal(),
-            broken_path_overlay:  Style::default().underline(),
+            symlink_path: Cyan.normal(),
+            control_char: Red.normal(),
+            broken_symlink: Red.normal(),
+            broken_path_overlay: Style::default().underline(),
         }
     }
 }
-
 
 /// Some of the styles are **overlays**: although they have the same attribute
 /// set as regular styles (foreground and background colours, bold, underline,
@@ -207,43 +205,61 @@ impl Colours {
 /// “broken link overlay”, the latter of which is just set to override the
 /// underline attribute on the other two.
 fn apply_overlay(mut base: Style, overlay: Style) -> Style {
-    if let Some(fg) = overlay.foreground { base.foreground = Some(fg); }
-    if let Some(bg) = overlay.background { base.background = Some(bg); }
+    if let Some(fg) = overlay.foreground {
+        base.foreground = Some(fg);
+    }
+    if let Some(bg) = overlay.background {
+        base.background = Some(bg);
+    }
 
-    if overlay.is_bold          { base.is_bold          = true; }
-    if overlay.is_dimmed        { base.is_dimmed        = true; }
-    if overlay.is_italic        { base.is_italic        = true; }
-    if overlay.is_underline     { base.is_underline     = true; }
-    if overlay.is_blink         { base.is_blink         = true; }
-    if overlay.is_reverse       { base.is_reverse       = true; }
-    if overlay.is_hidden        { base.is_hidden        = true; }
-    if overlay.is_strikethrough { base.is_strikethrough = true; }
+    if overlay.is_bold {
+        base.is_bold = true;
+    }
+    if overlay.is_dimmed {
+        base.is_dimmed = true;
+    }
+    if overlay.is_italic {
+        base.is_italic = true;
+    }
+    if overlay.is_underline {
+        base.is_underline = true;
+    }
+    if overlay.is_blink {
+        base.is_blink = true;
+    }
+    if overlay.is_reverse {
+        base.is_reverse = true;
+    }
+    if overlay.is_hidden {
+        base.is_hidden = true;
+    }
+    if overlay.is_strikethrough {
+        base.is_strikethrough = true;
+    }
 
     base
 }
 // TODO: move this function to the ansi_term crate
 
-
 impl Colours {
-
     /// Sets a value on this set of colours using one of the keys understood
     /// by the `LS_COLORS` environment variable. Invalid keys set nothing, but
     /// return false.
     pub fn set_ls(&mut self, pair: &Pair) -> bool {
         match pair.key {
-            "di" => self.filekinds.directory    = pair.to_style(),  // DIR
-            "ex" => self.filekinds.executable   = pair.to_style(),  // EXEC
-            "fi" => self.filekinds.normal       = pair.to_style(),  // FILE
-            "pi" => self.filekinds.pipe         = pair.to_style(),  // FIFO
-            "so" => self.filekinds.socket       = pair.to_style(),  // SOCK
-            "bd" => self.filekinds.block_device = pair.to_style(),  // BLK
-            "cd" => self.filekinds.char_device  = pair.to_style(),  // CHR
-            "ln" => self.filekinds.symlink      = pair.to_style(),  // LINK
-            "or" => self.broken_symlink         = pair.to_style(),  // ORPHAN
-             _   => return false,
-             // Codes we don’t do anything with:
-             // MULTIHARDLINK, DOOR, SETUID, SETGID, CAPABILITY,
-             // STICKY_OTHER_WRITABLE, OTHER_WRITABLE, STICKY, MISSING
+            "di" => self.filekinds.directory = pair.to_style(), // DIR
+            "ex" => self.filekinds.executable = pair.to_style(), // EXEC
+            "fi" => self.filekinds.normal = pair.to_style(),    // FILE
+            "pi" => self.filekinds.pipe = pair.to_style(),      // FIFO
+            "so" => self.filekinds.socket = pair.to_style(),    // SOCK
+            "bd" => self.filekinds.block_device = pair.to_style(), // BLK
+            "cd" => self.filekinds.char_device = pair.to_style(), // CHR
+            "ln" => self.filekinds.symlink = pair.to_style(),   // LINK
+            "or" => self.broken_symlink = pair.to_style(),      // ORPHAN
+            _ => return false,
+            // Codes we don’t do anything with:
+            // MULTIHARDLINK, DOOR, SETUID, SETGID, CAPABILITY,
+            // STICKY_OTHER_WRITABLE, OTHER_WRITABLE, STICKY, MISSING
         }
         true
     }
@@ -254,150 +270,239 @@ impl Colours {
     /// so `set_ls` should have been run first.
     pub fn set_exa(&mut self, pair: &Pair) -> bool {
         match pair.key {
-            "ur" => self.perms.user_read          = pair.to_style(),
-            "uw" => self.perms.user_write         = pair.to_style(),
-            "ux" => self.perms.user_execute_file  = pair.to_style(),
+            "ur" => self.perms.user_read = pair.to_style(),
+            "uw" => self.perms.user_write = pair.to_style(),
+            "ux" => self.perms.user_execute_file = pair.to_style(),
             "ue" => self.perms.user_execute_other = pair.to_style(),
-            "gr" => self.perms.group_read         = pair.to_style(),
-            "gw" => self.perms.group_write        = pair.to_style(),
-            "gx" => self.perms.group_execute      = pair.to_style(),
-            "tr" => self.perms.other_read         = pair.to_style(),
-            "tw" => self.perms.other_write        = pair.to_style(),
-            "tx" => self.perms.other_execute      = pair.to_style(),
-            "su" => self.perms.special_user_file  = pair.to_style(),
-            "sf" => self.perms.special_other      = pair.to_style(),
-            "xa" => self.perms.attribute          = pair.to_style(),
+            "gr" => self.perms.group_read = pair.to_style(),
+            "gw" => self.perms.group_write = pair.to_style(),
+            "gx" => self.perms.group_execute = pair.to_style(),
+            "tr" => self.perms.other_read = pair.to_style(),
+            "tw" => self.perms.other_write = pair.to_style(),
+            "tx" => self.perms.other_execute = pair.to_style(),
+            "su" => self.perms.special_user_file = pair.to_style(),
+            "sf" => self.perms.special_other = pair.to_style(),
+            "xa" => self.perms.attribute = pair.to_style(),
 
-            "sn" => self.size.numbers             = pair.to_style(),
-            "sb" => self.size.unit                = pair.to_style(),
-            "df" => self.size.major               = pair.to_style(),
-            "ds" => self.size.minor               = pair.to_style(),
+            "sn" => self.size.numbers = pair.to_style(),
+            "sb" => self.size.unit = pair.to_style(),
+            "df" => self.size.major = pair.to_style(),
+            "ds" => self.size.minor = pair.to_style(),
 
-            "uu" => self.users.user_you           = pair.to_style(),
-            "un" => self.users.user_someone_else  = pair.to_style(),
-            "gu" => self.users.group_yours        = pair.to_style(),
-            "gn" => self.users.group_not_yours    = pair.to_style(),
+            "uu" => self.users.user_you = pair.to_style(),
+            "un" => self.users.user_someone_else = pair.to_style(),
+            "gu" => self.users.group_yours = pair.to_style(),
+            "gn" => self.users.group_not_yours = pair.to_style(),
 
-            "lc" => self.links.normal             = pair.to_style(),
-            "lm" => self.links.multi_link_file    = pair.to_style(),
+            "lc" => self.links.normal = pair.to_style(),
+            "lm" => self.links.multi_link_file = pair.to_style(),
 
-            "ga" => self.git.new                  = pair.to_style(),
-            "gm" => self.git.modified             = pair.to_style(),
-            "gd" => self.git.deleted              = pair.to_style(),
-            "gv" => self.git.renamed              = pair.to_style(),
-            "gt" => self.git.typechange           = pair.to_style(),
+            "ga" => self.git.new = pair.to_style(),
+            "gm" => self.git.modified = pair.to_style(),
+            "gd" => self.git.deleted = pair.to_style(),
+            "gv" => self.git.renamed = pair.to_style(),
+            "gt" => self.git.typechange = pair.to_style(),
 
-            "xx" => self.punctuation              = pair.to_style(),
-            "da" => self.date                     = pair.to_style(),
-            "in" => self.inode                    = pair.to_style(),
-            "bl" => self.blocks                   = pair.to_style(),
-            "hd" => self.header                   = pair.to_style(),
-            "lp" => self.symlink_path             = pair.to_style(),
-            "cc" => self.control_char             = pair.to_style(),
-            "bO" => self.broken_path_overlay      = pair.to_style(),
+            "xx" => self.punctuation = pair.to_style(),
+            "da" => self.date = pair.to_style(),
+            "in" => self.inode = pair.to_style(),
+            "bl" => self.blocks = pair.to_style(),
+            "hd" => self.header = pair.to_style(),
+            "lp" => self.symlink_path = pair.to_style(),
+            "cc" => self.control_char = pair.to_style(),
+            "bO" => self.broken_path_overlay = pair.to_style(),
 
-             _   => return false,
+            _ => return false,
         }
         true
     }
 }
 
-
 impl render::BlocksColours for Colours {
-    fn block_count(&self)  -> Style { self.blocks }
-    fn no_blocks(&self)    -> Style { self.punctuation }
+    fn block_count(&self) -> Style {
+        self.blocks
+    }
+    fn no_blocks(&self) -> Style {
+        self.punctuation
+    }
 }
 
 impl render::FiletypeColours for Colours {
-    fn normal(&self)       -> Style { self.filekinds.normal }
-    fn directory(&self)    -> Style { self.filekinds.directory }
-    fn pipe(&self)         -> Style { self.filekinds.pipe }
-    fn symlink(&self)      -> Style { self.filekinds.symlink }
-    fn block_device(&self) -> Style { self.filekinds.block_device }
-    fn char_device(&self)  -> Style { self.filekinds.char_device }
-    fn socket(&self)       -> Style { self.filekinds.socket }
-    fn special(&self)      -> Style { self.filekinds.special }
+    fn normal(&self) -> Style {
+        self.filekinds.normal
+    }
+    fn directory(&self) -> Style {
+        self.filekinds.directory
+    }
+    fn pipe(&self) -> Style {
+        self.filekinds.pipe
+    }
+    fn symlink(&self) -> Style {
+        self.filekinds.symlink
+    }
+    fn block_device(&self) -> Style {
+        self.filekinds.block_device
+    }
+    fn char_device(&self) -> Style {
+        self.filekinds.char_device
+    }
+    fn socket(&self) -> Style {
+        self.filekinds.socket
+    }
+    fn special(&self) -> Style {
+        self.filekinds.special
+    }
 }
 
 impl render::GitColours for Colours {
-    fn not_modified(&self)  -> Style { self.punctuation }
-    fn new(&self)           -> Style { self.git.new }
-    fn modified(&self)      -> Style { self.git.modified }
-    fn deleted(&self)       -> Style { self.git.deleted }
-    fn renamed(&self)       -> Style { self.git.renamed }
-    fn type_change(&self)   -> Style { self.git.typechange }
+    fn not_modified(&self) -> Style {
+        self.punctuation
+    }
+    fn new(&self) -> Style {
+        self.git.new
+    }
+    fn modified(&self) -> Style {
+        self.git.modified
+    }
+    fn deleted(&self) -> Style {
+        self.git.deleted
+    }
+    fn renamed(&self) -> Style {
+        self.git.renamed
+    }
+    fn type_change(&self) -> Style {
+        self.git.typechange
+    }
 }
 
 impl render::GroupColours for Colours {
-    fn yours(&self)      -> Style { self.users.group_yours }
-    fn not_yours(&self)  -> Style { self.users.group_not_yours }
+    fn yours(&self) -> Style {
+        self.users.group_yours
+    }
+    fn not_yours(&self) -> Style {
+        self.users.group_not_yours
+    }
 }
 
 impl render::LinksColours for Colours {
-    fn normal(&self)           -> Style { self.links.normal }
-    fn multi_link_file(&self)  -> Style { self.links.multi_link_file }
+    fn normal(&self) -> Style {
+        self.links.normal
+    }
+    fn multi_link_file(&self) -> Style {
+        self.links.multi_link_file
+    }
 }
 
 impl render::PermissionsColours for Colours {
-    fn dash(&self)               -> Style { self.punctuation }
-    fn user_read(&self)          -> Style { self.perms.user_read }
-    fn user_write(&self)         -> Style { self.perms.user_write }
-    fn user_execute_file(&self)  -> Style { self.perms.user_execute_file }
-    fn user_execute_other(&self) -> Style { self.perms.user_execute_other }
-    fn group_read(&self)         -> Style { self.perms.group_read }
-    fn group_write(&self)        -> Style { self.perms.group_write }
-    fn group_execute(&self)      -> Style { self.perms.group_execute }
-    fn other_read(&self)         -> Style { self.perms.other_read }
-    fn other_write(&self)        -> Style { self.perms.other_write }
-    fn other_execute(&self)      -> Style { self.perms.other_execute }
-    fn special_user_file(&self)  -> Style { self.perms.special_user_file }
-    fn special_other(&self)      -> Style { self.perms.special_other }
-    fn attribute(&self)          -> Style { self.perms.attribute }
+    fn dash(&self) -> Style {
+        self.punctuation
+    }
+    fn user_read(&self) -> Style {
+        self.perms.user_read
+    }
+    fn user_write(&self) -> Style {
+        self.perms.user_write
+    }
+    fn user_execute_file(&self) -> Style {
+        self.perms.user_execute_file
+    }
+    fn user_execute_other(&self) -> Style {
+        self.perms.user_execute_other
+    }
+    fn group_read(&self) -> Style {
+        self.perms.group_read
+    }
+    fn group_write(&self) -> Style {
+        self.perms.group_write
+    }
+    fn group_execute(&self) -> Style {
+        self.perms.group_execute
+    }
+    fn other_read(&self) -> Style {
+        self.perms.other_read
+    }
+    fn other_write(&self) -> Style {
+        self.perms.other_write
+    }
+    fn other_execute(&self) -> Style {
+        self.perms.other_execute
+    }
+    fn special_user_file(&self) -> Style {
+        self.perms.special_user_file
+    }
+    fn special_other(&self) -> Style {
+        self.perms.special_other
+    }
+    fn attribute(&self) -> Style {
+        self.perms.attribute
+    }
 }
 
 impl render::SizeColours for Colours {
-    fn size(&self, size: u64)  -> Style {
+    fn size(&self, size: u64) -> Style {
         if self.scale {
             if size < 1024 {
                 self.size.scale_byte
-            }
-            else if size < 1024 * 1024 {
+            } else if size < 1024 * 1024 {
                 self.size.scale_kilo
-            }
-            else if size < 1024 * 1024 * 1024 {
+            } else if size < 1024 * 1024 * 1024 {
                 self.size.scale_mega
-            }
-            else if size < 1024 * 1024 * 1024 * 1024 {
+            } else if size < 1024 * 1024 * 1024 * 1024 {
                 self.size.scale_giga
-            }
-            else {
+            } else {
                 self.size.scale_huge
             }
-        }
-        else {
+        } else {
             self.size.numbers
         }
     }
 
-    fn unit(&self)    -> Style { self.size.unit }
-    fn no_size(&self) -> Style { self.punctuation }
-    fn major(&self)   -> Style { self.size.major }
-    fn comma(&self)   -> Style { self.punctuation }
-    fn minor(&self)   -> Style { self.size.minor }
+    fn unit(&self) -> Style {
+        self.size.unit
+    }
+    fn no_size(&self) -> Style {
+        self.punctuation
+    }
+    fn major(&self) -> Style {
+        self.size.major
+    }
+    fn comma(&self) -> Style {
+        self.punctuation
+    }
+    fn minor(&self) -> Style {
+        self.size.minor
+    }
 }
 
 impl render::UserColours for Colours {
-    fn you(&self)           -> Style { self.users.user_you }
-    fn someone_else(&self)  -> Style { self.users.user_someone_else }
+    fn you(&self) -> Style {
+        self.users.user_you
+    }
+    fn someone_else(&self) -> Style {
+        self.users.user_someone_else
+    }
 }
 
 impl FileNameColours for Colours {
-    fn normal_arrow(&self)        -> Style { self.punctuation }
-    fn broken_symlink(&self)      -> Style { self.broken_symlink }
-    fn broken_filename(&self)     -> Style { apply_overlay(self.broken_symlink, self.broken_path_overlay) }
-    fn broken_control_char(&self) -> Style { apply_overlay(self.control_char,   self.broken_path_overlay) }
-    fn control_char(&self)        -> Style { self.control_char }
-    fn symlink_path(&self)        -> Style { self.symlink_path }
-    fn executable_file(&self)     -> Style { self.filekinds.executable }
+    fn normal_arrow(&self) -> Style {
+        self.punctuation
+    }
+    fn broken_symlink(&self) -> Style {
+        self.broken_symlink
+    }
+    fn broken_filename(&self) -> Style {
+        apply_overlay(self.broken_symlink, self.broken_path_overlay)
+    }
+    fn broken_control_char(&self) -> Style {
+        apply_overlay(self.control_char, self.broken_path_overlay)
+    }
+    fn control_char(&self) -> Style {
+        self.control_char
+    }
+    fn symlink_path(&self) -> Style {
+        self.symlink_path
+    }
+    fn executable_file(&self) -> Style {
+        self.filekinds.executable
+    }
 }
-

--- a/src/style/lsc.rs
+++ b/src/style/lsc.rs
@@ -1,8 +1,7 @@
 use std::ops::FnMut;
 
-use ansi_term::{Colour, Style};
 use ansi_term::Colour::*;
-
+use ansi_term::{Colour, Style};
 
 // Parsing the LS_COLORS environment variable into a map of names to Style values.
 //
@@ -21,18 +20,21 @@ use ansi_term::Colour::*;
 // just not worth doing, and there should really be a way to just use slices
 // of the LS_COLORS string without having to parse them.
 
-
 pub struct LSColors<'var>(pub &'var str);
 
 impl<'var> LSColors<'var> {
-    pub fn each_pair<C>(&mut self, mut callback: C) where C: FnMut(Pair<'var>) -> () {
+    pub fn each_pair<C>(&mut self, mut callback: C)
+    where
+        C: FnMut(Pair<'var>) -> (),
+    {
         for next in self.0.split(':') {
-            let bits = next.split('=')
-                           .take(3)
-                           .collect::<Vec<_>>();
+            let bits = next.split('=').take(3).collect::<Vec<_>>();
 
             if bits.len() == 2 && !bits[0].is_empty() && !bits[1].is_empty() {
-                callback(Pair { key: bits[0], value: bits[1] });
+                callback(Pair {
+                    key: bits[0],
+                    value: bits[1],
+                });
             }
         }
     }
@@ -45,7 +47,9 @@ pub struct Pair<'var> {
 
 use std::iter::Peekable;
 fn parse_into_high_colour<'a, I>(iter: &mut Peekable<I>) -> Option<Colour>
-where I: Iterator<Item=&'a str> {
+where
+    I: Iterator<Item = &'a str>,
+{
     match iter.peek() {
         Some(&"5") => {
             let _ = iter.next();
@@ -69,15 +73,17 @@ where I: Iterator<Item=&'a str> {
                         return Some(RGB(r, g, b));
                     }
                 }*/
-                
-                if let (Some(r), Some(g), Some(b)) = (hexes.parse().ok(),
-                                                           iter.next().and_then(|s| s.parse().ok()),
-                                                           iter.next().and_then(|s| s.parse().ok())) {
+
+                if let (Some(r), Some(g), Some(b)) = (
+                    hexes.parse().ok(),
+                    iter.next().and_then(|s| s.parse().ok()),
+                    iter.next().and_then(|s| s.parse().ok()),
+                ) {
                     return Some(RGB(r, g, b));
                 }
             }
         }
-        _ => {},
+        _ => {}
     }
     None
 }
@@ -89,7 +95,6 @@ impl<'var> Pair<'var> {
 
         while let Some(num) = iter.next() {
             match num.trim_left_matches('0') {
-
                 // Bold and italic
                 "1" => style = style.bold(),
                 "2" => style = style.dimmed(),
@@ -110,7 +115,11 @@ impl<'var> Pair<'var> {
                 "35" => style = style.fg(Purple),
                 "36" => style = style.fg(Cyan),
                 "37" => style = style.fg(White),
-                "38" => if let Some(c) = parse_into_high_colour(&mut iter) { style = style.fg(c) },
+                "38" => {
+                    if let Some(c) = parse_into_high_colour(&mut iter) {
+                        style = style.fg(c)
+                    }
+                }
 
                 // Background colours
                 "40" => style = style.on(Black),
@@ -121,16 +130,19 @@ impl<'var> Pair<'var> {
                 "45" => style = style.on(Purple),
                 "46" => style = style.on(Cyan),
                 "47" => style = style.on(White),
-                "48" => if let Some(c) = parse_into_high_colour(&mut iter) { style = style.on(c) },
+                "48" => {
+                    if let Some(c) = parse_into_high_colour(&mut iter) {
+                        style = style.on(c)
+                    }
+                }
 
-                 _    => {/* ignore the error and do nothing */},
+                _ => { /* ignore the error and do nothing */ }
             }
         }
 
         style
     }
 }
-
 
 #[cfg(test)]
 mod ansi_test {
@@ -141,7 +153,14 @@ mod ansi_test {
         ($name:ident: $input:expr => $result:expr) => {
             #[test]
             fn $name() {
-                assert_eq!(Pair { key: "", value: $input }.to_style(), $result);
+                assert_eq!(
+                    Pair {
+                        key: "",
+                        value: $input
+                    }
+                    .to_style(),
+                    $result
+                );
             }
         };
     }
@@ -182,8 +201,6 @@ mod ansi_test {
     test!(toohi: "48;5;999"           => Style::default());
 }
 
-
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -193,7 +210,7 @@ mod test {
             #[test]
             fn $name() {
                 let mut lscs = Vec::new();
-                LSColors($input).each_pair(|p| lscs.push( (p.key.clone(), p.to_style()) ));
+                LSColors($input).each_pair(|p| lscs.push((p.key.clone(), p.to_style())));
                 assert_eq!(lscs, $result.to_vec());
             }
         };


### PR DESCRIPTION
Apologies for the nit PR, but this PR just runs `cargo fmt`.

A majority of other rust projects I've seen with any amount of contributors has all rust code formatted before it's committed. I thought it would be worthwhile to do the same for `exa` (and also so I can keep `format-on-save` on when I'm working on `exa` 😝).

Once this is merged, I'd be happy to put up another PR that checks formatting in the travis builds, perhaps as an "allowed to fail" build, or perhaps not (but I thought that would be good to have in a separate PR)