### PR TITLE
Update to Rust 2018

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -18,22 +18,21 @@ dependencies = [
 
 [[package]]
 name = "atty"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "autocfg"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -43,12 +42,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -58,24 +57,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iso8601 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "locale 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "pad 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -84,15 +83,15 @@ version = "0.9.0"
 dependencies = [
  "ansi_term 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "datetime 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "locale 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "natord 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_grid 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -107,11 +106,11 @@ name = "git2"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "libgit2-sys 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -162,7 +161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.51"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -170,8 +169,8 @@ name = "libgit2-sys"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -181,10 +180,10 @@ name = "libz-sys"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -192,15 +191,15 @@ name = "locale"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -210,7 +209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -228,20 +227,23 @@ name = "num-traits"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "num_cpus"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -254,20 +256,20 @@ name = "openssl-src"
 version = "111.3.0+1.1.1c"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.47"
+version = "0.9.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-src 111.3.0+1.1.1c (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -295,32 +297,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.54"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "redox_termios"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "regex"
-version = "1.1.6"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -333,7 +327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -350,26 +344,16 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "termion"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -398,7 +382,7 @@ name = "unicode-normalization"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -421,17 +405,17 @@ name = "users"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "utf8-ranges"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vcpkg"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -490,16 +474,16 @@ dependencies = [
 ]
 
 [metadata]
-"checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
+"checksum aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "36b7aa1ccb7d7ea3f437cf025a2ab1c47cc6c1bc9fc84918ff449def12f5e282"
 "checksum ansi_term 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eaa72766c3585a1f812a3387a7e2c6cab780f899c2f43ff6ea06c8d071fcbb36"
-"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
-"checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
-"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
+"checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
+"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5f3fee5eeb60324c2781f1e41286bdee933850fff9b3c672587fed5ec58c83"
-"checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
+"checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
+"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum datetime 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5c44b6c112860e38412e0c4732172d723458d40db906ee4b9ce87544f022a7b9"
-"checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
+"checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum git2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "924b2e7d2986e625dcad89e8a429a7b3adee3c3d71e585f4a66c4f7e78715e31"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
@@ -507,35 +491,33 @@ dependencies = [
 "checksum iso8601 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "11dc464f8c6f17595d191447c9c6559298b2d023d6f846a4a23ac7ea3c46c477"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
-"checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
+"checksum libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d44e80633f007889c7eff624b709ab43c92d708caad982295768a7b13ca3b5eb"
 "checksum libgit2-sys 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "941a41e23f77323b8c9d2ee118aec9ee39dfc176078c18b4757d3bad049d9ff7"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 "checksum locale 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5fdbe492a9c0238da900a1165c42fc5067161ce292678a6fe80921f30fe307fd"
-"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c275b6ad54070ac2d665eef9197db647b32239c9d244bfb6f041a766d00da5b3"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-"checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
+"checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum natord 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 "checksum nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
-"checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
+"checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
+"checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum number_prefix 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 "checksum openssl-src 111.3.0+1.1.1c (registry+https://github.com/rust-lang/crates.io-index)" = "53ed5f31d294bdf5f7a4ba0a206c2754b0f60e9a63b7e3076babc5317873c797"
-"checksum openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)" = "75bdd6dbbb4958d38e47a1d2348847ad1eb4dc205dc5d37473ae504391865acc"
+"checksum openssl-sys 0.9.48 (registry+https://github.com/rust-lang/crates.io-index)" = "b5ba300217253bcc5dc68bed23d782affa45000193866e025329aa8a7a9f05b8"
 "checksum pad 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9b8de33465981073e32e1d75bb89ade49062bb853e7c97ec2c13439095563a"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
-"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58"
-"checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
+"checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+"checksum regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d9d8297cc20bbb6184f8b45ff61c8ee6a9ac56c156cec8e38c3e5084773c44ad"
+"checksum regex-syntax 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9b01330cce219c1c6b2e209e5ed64ccd587ae5c67bed91c0b49eecf02ae40e21"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
-"checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
+"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum term_grid 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "230d3e804faaed5a39b08319efb797783df2fd9671b39b7596490cb486d702cf"
 "checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
-"checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
-"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
@@ -543,8 +525,8 @@ dependencies = [
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum users 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c72f4267aea0c3ec6d07eaabea6ead7c5ddacfafc5e22bcf8d186706851fb4cf"
-"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
-"checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
+"checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
+"checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "exa"
 version = "0.9.0"
 authors = [ "Benjamin Sago <ogham@bsago.me>" ]
 build = "build.rs"
+edition = "2018"
 
 description = "A modern replacement for ls"
 homepage = "https://the.exa.website/"

--- a/src/exa.rs
+++ b/src/exa.rs
@@ -1,27 +1,6 @@
 #![warn(trivial_casts, trivial_numeric_casts)]
 #![warn(unused_results)]
 
-extern crate ansi_term;
-extern crate datetime;
-extern crate glob;
-extern crate libc;
-extern crate locale;
-extern crate natord;
-extern crate num_cpus;
-extern crate number_prefix;
-extern crate scoped_threadpool;
-extern crate term_grid;
-extern crate unicode_width;
-extern crate users;
-extern crate zoneinfo_compiled;
-extern crate term_size;
-
-#[cfg(feature="git")] extern crate git2;
-
-#[macro_use] extern crate lazy_static;
-#[macro_use] extern crate log;
-
-
 use std::env::var_os;
 use std::ffi::{OsStr, OsString};
 use std::io::{stderr, Write, Result as IOResult};
@@ -29,13 +8,15 @@ use std::path::{Component, PathBuf};
 
 use ansi_term::{ANSIStrings, Style};
 
-use fs::{Dir, File};
-use fs::feature::ignore::IgnoreCache;
-use fs::feature::git::GitCache;
-use options::{Options, Vars};
-pub use options::vars;
-pub use options::Misfire;
-use output::{escape, lines, grid, grid_details, details, View, Mode};
+use log::debug;
+
+use crate::fs::{Dir, File};
+use crate::fs::feature::ignore::IgnoreCache;
+use crate::fs::feature::git::GitCache;
+use crate::options::{Options, Vars};
+pub use crate::options::vars;
+pub use crate::options::Misfire;
+use crate::output::{escape, lines, grid, grid_details, details, View, Mode};
 
 mod fs;
 mod info;
@@ -91,7 +72,7 @@ fn git_options(options: &Options, args: &[&OsStr]) -> Option<GitCache> {
 }
 
 fn ignore_cache(options: &Options) -> Option<IgnoreCache> {
-    use fs::filter::GitIgnore;
+    use crate::fs::filter::GitIgnore;
 
     match options.filter.git_ignore {
         GitIgnore::CheckAndIgnore => Some(IgnoreCache::new()),

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -3,8 +3,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::slice::Iter as SliceIter;
 
-use fs::File;
-use fs::feature::ignore::IgnoreCache;
+use log::info;
+
+use crate::fs::File;
+use crate::fs::feature::ignore::IgnoreCache;
 
 
 /// A **Dir** provides a cached list of the file paths in a directory that's

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -4,8 +4,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use git2;
+use log::{debug, error, info, warn};
 
-use fs::fields as f;
+use crate::fs::fields as f;
 
 
 /// A **Git cache** is assembled based on the user’s input arguments.

--- a/src/fs/feature/ignore.rs
+++ b/src/fs/feature/ignore.rs
@@ -8,7 +8,9 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
-use fs::filter::IgnorePatterns;
+use log::debug;
+
+use crate::fs::filter::IgnorePatterns;
 
 
 /// An **ignore cache** holds sets of glob patterns paired with the

--- a/src/fs/feature/mod.rs
+++ b/src/fs/feature/mod.rs
@@ -8,7 +8,7 @@ pub mod git {
     use std::iter::FromIterator;
     use std::path::{Path, PathBuf};
 
-    use fs::fields as f;
+    use crate::fs::fields as f;
 
 
     pub struct GitCache;

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -7,9 +7,11 @@ use std::os::unix::fs::{MetadataExt, PermissionsExt, FileTypeExt};
 use std::path::{Path, PathBuf};
 use std::time::{UNIX_EPOCH, Duration};
 
-use fs::dir::Dir;
-use fs::fields as f;
-use options::Misfire;
+use log::{debug, error};
+
+use crate::fs::dir::Dir;
+use crate::fs::fields as f;
+use crate::options::Misfire;
 
 
 /// A **File** is a wrapper around one of Rust's Path objects, along with

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -8,8 +8,8 @@ use std::path::Path;
 use glob;
 use natord;
 
-use fs::File;
-use fs::DotFilter;
+use crate::fs::File;
+use crate::fs::DotFilter;
 
 
 /// The **file filter** processes a list of files before displaying them to

--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -6,9 +6,9 @@
 
 use ansi_term::Style;
 
-use fs::File;
-use output::file_name::FileColours;
-use output::icons::FileIcon;
+use crate::fs::File;
+use crate::output::file_name::FileColours;
+use crate::output::icons::FileIcon;
 
 
 #[derive(Debug, Default, PartialEq)]
@@ -119,7 +119,7 @@ impl FileColours for FileExtensions {
 
 impl FileIcon for FileExtensions {
     fn icon_file(&self, file: &File) -> Option<char> {
-        use output::icons::Icons;
+        use crate::output::icons::Icons;
 
         Some(match file {
             f if self.is_music(f) || self.is_lossless(f) => Icons::Audio.value(),

--- a/src/info/sources.rs
+++ b/src/info/sources.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use fs::File;
+use crate::fs::File;
 
 
 impl<'a> File<'a> {

--- a/src/options/dir_action.rs
+++ b/src/options/dir_action.rs
@@ -1,9 +1,9 @@
 //! Parsing the options for `DirAction`.
 
-use options::parser::MatchedFlags;
-use options::{flags, Misfire};
+use crate::options::parser::MatchedFlags;
+use crate::options::{flags, Misfire};
 
-use fs::dir_action::{DirAction, RecurseOptions};
+use crate::fs::dir_action::{DirAction, RecurseOptions};
 
 
 impl DirAction {
@@ -71,16 +71,16 @@ impl RecurseOptions {
 #[cfg(test)]
 mod test {
     use super::*;
-    use options::flags;
-    use options::parser::Flag;
+    use crate::options::flags;
+    use crate::options::parser::Flag;
 
     macro_rules! test {
         ($name:ident: $type:ident <- $inputs:expr; $stricts:expr => $result:expr) => {
             #[test]
             fn $name() {
-                use options::parser::Arg;
-                use options::test::parse_for_test;
-                use options::test::Strictnesses::*;
+                use crate::options::parser::Arg;
+                use crate::options::test::parse_for_test;
+                use crate::options::test::Strictnesses::*;
 
                 static TEST_ARGS: &[&Arg] = &[&flags::RECURSE, &flags::LIST_DIRS, &flags::TREE, &flags::LEVEL ];
                 for result in parse_for_test($inputs.as_ref(), TEST_ARGS, $stricts, |mf| $type::deduce(mf)) {

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -1,10 +1,10 @@
 //! Parsing the options for `FileFilter`.
 
-use fs::{DotFilter, PlatformMetadata};
-use fs::filter::{FileFilter, SortField, SortCase, IgnorePatterns, GitIgnore};
+use crate::fs::{DotFilter, PlatformMetadata};
+use crate::fs::filter::{FileFilter, SortField, SortCase, IgnorePatterns, GitIgnore};
 
-use options::{flags, Misfire};
-use options::parser::MatchedFlags;
+use crate::options::{flags, Misfire};
+use crate::options::parser::MatchedFlags;
 
 
 impl FileFilter {
@@ -198,16 +198,16 @@ impl GitIgnore {
 mod test {
     use super::*;
     use std::ffi::OsString;
-    use options::flags;
-    use options::parser::Flag;
+    use crate::options::flags;
+    use crate::options::parser::Flag;
 
     macro_rules! test {
         ($name:ident: $type:ident <- $inputs:expr; $stricts:expr => $result:expr) => {
             #[test]
             fn $name() {
-                use options::parser::Arg;
-                use options::test::parse_for_test;
-                use options::test::Strictnesses::*;
+                use crate::options::parser::Arg;
+                use crate::options::test::parse_for_test;
+                use crate::options::test::Strictnesses::*;
 
                 static TEST_ARGS: &[&Arg] = &[ &flags::SORT, &flags::ALL, &flags::TREE, &flags::IGNORE_GLOB, &flags::GIT_IGNORE ];
                 for result in parse_for_test($inputs.as_ref(), TEST_ARGS, $stricts, |mf| $type::deduce(mf)) {

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -1,4 +1,4 @@
-use options::parser::{Arg, Args, Values, TakesValue};
+use crate::options::parser::{Arg, Args, Values, TakesValue};
 
 
 // exa options

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use options::flags;
-use options::parser::MatchedFlags;
-use fs::feature::xattr;
+use crate::options::flags;
+use crate::options::parser::MatchedFlags;
+use crate::fs::feature::xattr;
 
 
 static OPTIONS: &str = r##"
@@ -122,7 +122,7 @@ impl fmt::Display for HelpString {
 
 #[cfg(test)]
 mod test {
-    use options::Options;
+    use crate::options::Options;
     use std::ffi::OsString;
 
     fn os(input: &'static str) -> OsString {

--- a/src/options/misfire.rs
+++ b/src/options/misfire.rs
@@ -4,8 +4,8 @@ use std::num::ParseIntError;
 
 use glob;
 
-use options::{flags, HelpString, VersionString};
-use options::parser::{Arg, Flag, ParseError};
+use crate::options::{flags, HelpString, VersionString};
+use crate::options::parser::{Arg, Flag, ParseError};
 
 
 /// A **misfire** is a thing that can happen instead of listing files -- a
@@ -73,7 +73,7 @@ impl From<glob::PatternError> for Misfire {
 
 impl fmt::Display for Misfire {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use options::parser::TakesValue;
+        use crate::options::parser::TakesValue;
         use self::Misfire::*;
 
         match *self {

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -71,9 +71,9 @@
 
 use std::ffi::{OsStr, OsString};
 
-use fs::dir_action::DirAction;
-use fs::filter::FileFilter;
-use output::{View, Mode, details, grid_details};
+use crate::fs::dir_action::DirAction;
+use crate::fs::filter::FileFilter;
+use crate::output::{View, Mode, details, grid_details};
 
 mod style;
 mod dir_action;
@@ -122,7 +122,7 @@ impl Options {
     pub fn parse<'args, I, V>(args: I, vars: &V) -> Result<(Options, Vec<&'args OsStr>), Misfire>
     where I: IntoIterator<Item=&'args OsString>,
           V: Vars {
-        use options::parser::{Matches, Strictness};
+        use crate::options::parser::{Matches, Strictness};
 
         let strictness = match vars.get(vars::EXA_STRICT) {
             None                         => Strictness::UseLastArguments,
@@ -169,7 +169,7 @@ impl Options {
 #[cfg(test)]
 pub mod test {
     use super::{Options, Misfire, flags};
-    use options::parser::{Arg, MatchedFlags};
+    use crate::options::parser::{Arg, MatchedFlags};
     use std::ffi::OsString;
 
     #[derive(PartialEq, Debug)]
@@ -189,7 +189,7 @@ pub mod test {
     where F: Fn(&MatchedFlags) -> T
     {
         use self::Strictnesses::*;
-        use options::parser::{Args, Strictness};
+        use crate::options::parser::{Args, Strictness};
 
         let bits = inputs.into_iter().map(|&o| os(o)).collect::<Vec<OsString>>();
         let mut result = Vec::new();

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -31,7 +31,7 @@
 use std::ffi::{OsStr, OsString};
 use std::fmt;
 
-use options::Misfire;
+use crate::options::Misfire;
 
 
 /// A **short argument** is a single ASCII character.

--- a/src/options/style.rs
+++ b/src/options/style.rs
@@ -1,11 +1,11 @@
 use ansi_term::Style;
 use glob;
 
-use fs::File;
-use options::{flags, Vars, Misfire};
-use options::parser::MatchedFlags;
-use output::file_name::{FileStyle, Classify};
-use style::Colours;
+use crate::fs::File;
+use crate::options::{flags, Vars, Misfire};
+use crate::options::parser::MatchedFlags;
+use crate::output::file_name::{FileStyle, Classify};
+use crate::style::Colours;
 
 
 /// Under what circumstances we should display coloured, rather than plain,
@@ -82,8 +82,8 @@ impl Styles {
     pub fn deduce<V, TW>(matches: &MatchedFlags, vars: &V, widther: TW) -> Result<Self, Misfire>
     where TW: Fn() -> Option<usize>, V: Vars {
         use self::TerminalColours::*;
-        use info::filetype::FileExtensions;
-        use output::file_name::NoFileColours;
+        use crate::info::filetype::FileExtensions;
+        use crate::output::file_name::NoFileColours;
 
         let classify = Classify::deduce(matches)?;
 
@@ -123,8 +123,10 @@ impl Styles {
 /// Also returns if the EXA_COLORS variable should reset the existing file
 /// type mappings or not. The `reset` code needs to be the first one.
 fn parse_color_vars<V: Vars>(vars: &V, colours: &mut Colours) -> (ExtensionMappings, bool) {
-    use options::vars;
-    use style::LSColors;
+    use log::warn;
+    
+    use crate::options::vars;
+    use crate::style::LSColors;
 
     let mut exts = ExtensionMappings::default();
 
@@ -172,7 +174,7 @@ struct ExtensionMappings {
 // Loop through backwards so that colours specified later in the list override
 // colours specified earlier, like we do with options and strict mode
 
-use output::file_name::FileColours;
+use crate::output::file_name::FileColours;
 impl FileColours for ExtensionMappings {
     fn colour_file(&self, file: &File) -> Option<Style> {
         self.mappings
@@ -210,11 +212,11 @@ impl Classify {
 mod terminal_test {
     use super::*;
     use std::ffi::OsString;
-    use options::flags;
-    use options::parser::{Flag, Arg};
+    use crate::options::flags;
+    use crate::options::parser::{Flag, Arg};
 
-    use options::test::parse_for_test;
-    use options::test::Strictnesses::*;
+    use crate::options::test::parse_for_test;
+    use crate::options::test::Strictnesses::*;
 
     static TEST_ARGS: &[&Arg] = &[ &flags::COLOR, &flags::COLOUR ];
 
@@ -272,11 +274,11 @@ mod terminal_test {
 #[cfg(test)]
 mod colour_test {
     use super::*;
-    use options::flags;
-    use options::parser::{Flag, Arg};
+    use crate::options::flags;
+    use crate::options::parser::{Flag, Arg};
 
-    use options::test::parse_for_test;
-    use options::test::Strictnesses::*;
+    use crate::options::test::parse_for_test;
+    use crate::options::test::Strictnesses::*;
 
     static TEST_ARGS: &[&Arg] = &[ &flags::COLOR,       &flags::COLOUR,
                                    &flags::COLOR_SCALE, &flags::COLOUR_SCALE ];
@@ -341,7 +343,7 @@ mod customs_test {
     use std::ffi::OsString;
 
     use super::*;
-    use options::Vars;
+    use crate::options::Vars;
 
     use ansi_term::Colour::*;
 
@@ -405,7 +407,7 @@ mod customs_test {
     // Test impl that just returns the value it has.
     impl Vars for MockVars {
         fn get(&self, name: &'static str) -> Option<OsString> {
-            use options::vars;
+            use crate::options::vars;
 
             if name == vars::LS_COLORS && !self.ls.is_empty() {
                 OsString::from(self.ls.clone()).into()

--- a/src/options/version.rs
+++ b/src/options/version.rs
@@ -4,8 +4,8 @@
 
 use std::fmt;
 
-use options::flags;
-use options::parser::MatchedFlags;
+use crate::options::flags;
+use crate::options::parser::MatchedFlags;
 
 
 #[derive(PartialEq, Debug)]
@@ -38,7 +38,7 @@ impl fmt::Display for VersionString {
 
 #[cfg(test)]
 mod test {
-    use options::Options;
+    use crate::options::Options;
     use std::ffi::OsString;
 
     fn os(input: &'static str) -> OsString {

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -1,20 +1,21 @@
-use output::{View, Mode, grid, details, lines};
-use output::grid_details::{self, RowThreshold};
-use output::table::{TimeTypes, Environment, SizeFormat, Columns, Options as TableOptions};
-use output::time::TimeFormat;
+use lazy_static::lazy_static;
 
-use options::{flags, Misfire, Vars};
-use options::parser::MatchedFlags;
+use crate::options::{flags, Misfire, Vars};
+use crate::options::parser::MatchedFlags;
+use crate::output::{View, Mode, grid, details, lines};
+use crate::output::grid_details::{self, RowThreshold};
+use crate::output::table::{TimeTypes, Environment, SizeFormat, Columns, Options as TableOptions};
+use crate::output::time::TimeFormat;
 
-use fs::PlatformMetadata;
-use fs::feature::xattr;
+use crate::fs::PlatformMetadata;
+use crate::fs::feature::xattr;
 
 
 impl View {
 
     /// Determine which view to use and all of that view’s arguments.
     pub fn deduce<V: Vars>(matches: &MatchedFlags, vars: &V) -> Result<View, Misfire> {
-        use options::style::Styles;
+        use crate::options::style::Styles;
 
         let mode = Mode::deduce(matches, vars)?;
         let Styles { colours, style } = Styles::deduce(matches, vars, || *TERM_WIDTH)?;
@@ -27,7 +28,7 @@ impl Mode {
 
     /// Determine the mode from the command-line arguments.
     pub fn deduce<V: Vars>(matches: &MatchedFlags, vars: &V) -> Result<Mode, Misfire> {
-        use options::misfire::Misfire::*;
+        use crate::options::misfire::Misfire::*;
 
         let long = || {
             if matches.has(&flags::ACROSS)? && !matches.has(&flags::GRID)? {
@@ -159,7 +160,7 @@ impl TerminalWidth {
     ///
     /// Returns an error if a requested width doesn’t parse to an integer.
     fn deduce<V: Vars>(vars: &V) -> Result<TerminalWidth, Misfire> {
-        use options::vars;
+        use crate::options::vars;
 
         if let Some(columns) = vars.get(vars::COLUMNS).and_then(|s| s.into_string().ok()) {
             match columns.parse() {
@@ -190,7 +191,7 @@ impl RowThreshold {
     /// Determine whether to use a row threshold based on the given
     /// environment variables.
     fn deduce<V: Vars>(vars: &V) -> Result<RowThreshold, Misfire> {
-        use options::vars;
+        use crate::options::vars;
 
         if let Some(columns) = vars.get(vars::EXA_GRID_ROWS).and_then(|s| s.into_string().ok()) {
             match columns.parse() {
@@ -257,12 +258,12 @@ impl TimeFormat {
 
     /// Determine how time should be formatted in timestamp columns.
     fn deduce<V: Vars>(matches: &MatchedFlags, vars: &V) -> Result<TimeFormat, Misfire> {
-        pub use output::time::{DefaultFormat, ISOFormat};
+        pub use crate::output::time::{DefaultFormat, ISOFormat};
 
         let word = match matches.get(&flags::TIME_STYLE)? {
             Some(w) => w.to_os_string(),
             None    => {
-                use options::vars;
+                use crate::options::vars;
                 match vars.get(vars::TIME_STYLE) {
                     Some(ref t) if !t.is_empty() => t.clone(),
                     _                            => return Ok(TimeFormat::DefaultFormat(DefaultFormat::load()))
@@ -379,11 +380,11 @@ lazy_static! {
 mod test {
     use super::*;
     use std::ffi::OsString;
-    use options::flags;
-    use options::parser::{Flag, Arg};
+    use crate::options::flags;
+    use crate::options::parser::{Flag, Arg};
 
-    use options::test::parse_for_test;
-    use options::test::Strictnesses::*;
+    use crate::options::test::parse_for_test;
+    use crate::options::test::Strictnesses::*;
 
     static TEST_ARGS: &[&Arg] = &[ &flags::BINARY, &flags::BYTES,    &flags::TIME_STYLE,
                                    &flags::TIME,   &flags::MODIFIED, &flags::CHANGED,
@@ -569,8 +570,10 @@ mod test {
 
     mod views {
         use super::*;
-        use output::grid::Options as GridOptions;
-        use output::lines::Options as LineOptions;
+
+        use crate::output::grid::Options as GridOptions;
+        use crate::output::lines::Options as LineOptions;
+
 
         // Default
         test!(empty:         Mode <- [], None;            Both => like Ok(Mode::Grid(_)));

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -66,18 +66,19 @@ use std::vec::IntoIter as VecIntoIter;
 
 use ansi_term::{ANSIGenericString, Style};
 
-use fs::{Dir, File};
-use fs::dir_action::RecurseOptions;
-use fs::filter::FileFilter;
-use fs::feature::ignore::IgnoreCache;
-use fs::feature::git::GitCache;
-use fs::feature::xattr::{Attribute, FileAttributes};
-use style::Colours;
-use output::cell::TextCell;
-use output::tree::{TreeTrunk, TreeParams, TreeDepth};
-use output::file_name::FileStyle;
-use output::table::{Table, Options as TableOptions, Row as TableRow};
-use output::icons::painted_icon;
+use crate::fs::{Dir, File};
+use crate::fs::dir_action::RecurseOptions;
+use crate::fs::filter::FileFilter;
+use crate::fs::feature::ignore::IgnoreCache;
+use crate::fs::feature::git::GitCache;
+use crate::fs::feature::xattr::{Attribute, FileAttributes};
+use crate::style::Colours;
+use crate::output::cell::TextCell;
+use crate::output::tree::{TreeTrunk, TreeParams, TreeDepth};
+use crate::output::file_name::FileStyle;
+use crate::output::table::{Table, Options as TableOptions, Row as TableRow};
+use crate::output::icons::painted_icon;
+
 use scoped_threadpool::Pool;
 
 
@@ -190,7 +191,8 @@ impl<'a> Render<'a> {
     /// parallelisable, and uses a pool of threads.
     fn add_files_to_table<'dir, 'ig>(&self, pool: &mut Pool, table: &mut Option<Table<'a>>, rows: &mut Vec<Row>, src: &[File<'dir>], ignore: Option<&'ig IgnoreCache>, depth: TreeDepth) {
         use std::sync::{Arc, Mutex};
-        use fs::feature::xattr;
+        use log::error;
+        use crate::fs::feature::xattr;
 
         let mut file_eggs = Vec::new();
 
@@ -343,7 +345,7 @@ impl<'a> Render<'a> {
     }
 
     fn render_error(&self, error: &IOError, tree: TreeParams, path: Option<PathBuf>) -> Row {
-        use output::file_name::Colours;
+        use crate::output::file_name::Colours;
 
         let error_message = match path {
             Some(path) => format!("<{}: {}>", path.display(), error),

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -2,10 +2,10 @@ use std::path::Path;
 
 use ansi_term::{ANSIString, Style};
 
-use fs::{File, FileTarget};
-use output::escape;
-use output::cell::TextCellContents;
-use output::render::FiletypeColours;
+use crate::fs::{File, FileTarget};
+use crate::output::escape;
+use crate::output::cell::TextCellContents;
+use crate::output::render::FiletypeColours;
 
 
 /// Basically a file name factory.

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -2,11 +2,11 @@ use std::io::{Write, Result as IOResult};
 
 use term_grid as tg;
 
-use fs::File;
-use style::Colours;
-use output::file_name::FileStyle;
-use output::icons::painted_icon;
-use output::cell::DisplayWidth;
+use crate::fs::File;
+use crate::style::Colours;
+use crate::output::file_name::FileStyle;
+use crate::output::icons::painted_icon;
+use crate::output::cell::DisplayWidth;
 
 
 #[derive(PartialEq, Debug, Copy, Clone)]

--- a/src/output/grid_details.rs
+++ b/src/output/grid_details.rs
@@ -5,19 +5,20 @@ use std::io::{Write, Result as IOResult};
 use ansi_term::{ANSIGenericString, ANSIStrings};
 use term_grid as grid;
 
-use fs::{Dir, File};
-use fs::feature::git::GitCache;
-use fs::feature::xattr::FileAttributes;
-use fs::filter::FileFilter;
+use crate::fs::{Dir, File};
+use crate::fs::feature::git::GitCache;
+use crate::fs::feature::xattr::FileAttributes;
+use crate::fs::filter::FileFilter;
 
-use style::Colours;
-use output::cell::TextCell;
-use output::details::{Options as DetailsOptions, Row as DetailsRow, Render as DetailsRender};
-use output::grid::Options as GridOptions;
-use output::file_name::FileStyle;
-use output::table::{Table, Row as TableRow, Options as TableOptions};
-use output::tree::{TreeParams, TreeDepth};
-use output::icons::painted_icon;
+use crate::style::Colours;
+use crate::output::cell::TextCell;
+use crate::output::details::{Options as DetailsOptions, Row as DetailsRow, Render as DetailsRender};
+use crate::output::grid::Options as GridOptions;
+use crate::output::file_name::FileStyle;
+use crate::output::table::{Table, Row as TableRow, Options as TableOptions};
+use crate::output::tree::{TreeParams, TreeDepth};
+use crate::output::icons::painted_icon;
+
 
 #[derive(Debug)]
 pub struct Options {

--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -1,7 +1,8 @@
 use ansi_term::Style;
-use fs::File;
-use info::filetype::FileExtensions;
-use output::file_name::FileStyle;
+
+use crate::fs::File;
+use crate::info::filetype::FileExtensions;
+use crate::output::file_name::FileStyle;
 
 pub trait FileIcon {
     fn icon_file(&self, file: &File) -> Option<char>;

--- a/src/output/lines.rs
+++ b/src/output/lines.rs
@@ -2,11 +2,11 @@ use std::io::{Write, Result as IOResult};
 
 use ansi_term::{ANSIStrings, ANSIGenericString};
 
-use fs::File;
-use output::file_name::{FileName, FileStyle};
-use style::Colours;
-use output::icons::painted_icon;
-use output::cell::TextCell;
+use crate::fs::File;
+use crate::output::file_name::{FileName, FileStyle};
+use crate::style::Colours;
+use crate::output::icons::painted_icon;
+use crate::output::cell::TextCell;
 
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub struct Options {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,5 +1,5 @@
-use output::file_name::FileStyle;
-use style::Colours;
+use crate::output::file_name::FileStyle;
+use crate::style::Colours;
 
 pub use self::cell::{TextCell, TextCellContents, DisplayWidth};
 pub use self::escape::escape;

--- a/src/output/render/blocks.rs
+++ b/src/output/render/blocks.rs
@@ -1,7 +1,7 @@
 use ansi_term::Style;
 
-use output::cell::TextCell;
-use fs::fields as f;
+use crate::output::cell::TextCell;
+use crate::fs::fields as f;
 
 
 impl f::Blocks {
@@ -26,8 +26,8 @@ pub mod test {
     use ansi_term::Colour::*;
 
     use super::Colours;
-    use output::cell::TextCell;
-    use fs::fields as f;
+    use crate::output::cell::TextCell;
+    use crate::fs::fields as f;
 
 
     struct TestColours;

--- a/src/output/render/filetype.rs
+++ b/src/output/render/filetype.rs
@@ -1,6 +1,6 @@
 use ansi_term::{ANSIString, Style};
 
-use fs::fields as f;
+use crate::fs::fields as f;
 
 
 impl f::Type {

--- a/src/output/render/git.rs
+++ b/src/output/render/git.rs
@@ -1,7 +1,7 @@
 use ansi_term::{ANSIString, Style};
 
-use output::cell::{TextCell, DisplayWidth};
-use fs::fields as f;
+use crate::output::cell::{TextCell, DisplayWidth};
+use crate::fs::fields as f;
 
 
 impl f::Git {
@@ -46,8 +46,8 @@ pub trait Colours {
 #[cfg(test)]
 pub mod test {
     use super::Colours;
-    use output::cell::{TextCell, DisplayWidth};
-    use fs::fields as f;
+    use crate::output::cell::{TextCell, DisplayWidth};
+    use crate::fs::fields as f;
 
     use ansi_term::Colour::*;
     use ansi_term::Style;

--- a/src/output/render/groups.rs
+++ b/src/output/render/groups.rs
@@ -1,8 +1,8 @@
 use ansi_term::Style;
 use users::{Users, Groups};
 
-use fs::fields as f;
-use output::cell::TextCell;
+use crate::fs::fields as f;
+use crate::output::cell::TextCell;
 
 
 impl f::Group {
@@ -39,8 +39,8 @@ pub trait Colours {
 #[allow(unused_results)]
 pub mod test {
     use super::Colours;
-    use fs::fields as f;
-    use output::cell::TextCell;
+    use crate::fs::fields as f;
+    use crate::output::cell::TextCell;
 
     use users::{User, Group};
     use users::mock::MockUsers;

--- a/src/output/render/inode.rs
+++ b/src/output/render/inode.rs
@@ -1,7 +1,7 @@
 use ansi_term::Style;
 
-use output::cell::TextCell;
-use fs::fields as f;
+use crate::output::cell::TextCell;
+use crate::fs::fields as f;
 
 
 impl f::Inode {
@@ -13,8 +13,8 @@ impl f::Inode {
 
 #[cfg(test)]
 pub mod test {
-    use output::cell::TextCell;
-    use fs::fields as f;
+    use crate::output::cell::TextCell;
+    use crate::fs::fields as f;
 
     use ansi_term::Colour::*;
 

--- a/src/output/render/links.rs
+++ b/src/output/render/links.rs
@@ -1,8 +1,8 @@
 use ansi_term::Style;
 use locale::Numeric as NumericLocale;
 
-use output::cell::TextCell;
-use fs::fields as f;
+use crate::output::cell::TextCell;
+use crate::fs::fields as f;
 
 
 impl f::Links {
@@ -24,8 +24,8 @@ pub trait Colours {
 #[cfg(test)]
 pub mod test {
     use super::Colours;
-    use output::cell::{TextCell, DisplayWidth};
-    use fs::fields as f;
+    use crate::output::cell::{TextCell, DisplayWidth};
+    use crate::fs::fields as f;
 
     use ansi_term::Colour::*;
     use ansi_term::Style;

--- a/src/output/render/permissions.rs
+++ b/src/output/render/permissions.rs
@@ -1,8 +1,8 @@
 use ansi_term::{ANSIString, Style};
 
-use fs::fields as f;
-use output::cell::{TextCell, DisplayWidth};
-use output::render::FiletypeColours;
+use crate::fs::fields as f;
+use crate::output::cell::{TextCell, DisplayWidth};
+use crate::output::render::FiletypeColours;
 
 
 impl f::PermissionsPlus {
@@ -104,8 +104,8 @@ pub trait Colours {
 #[allow(unused_results)]
 pub mod test {
     use super::Colours;
-    use output::cell::TextCellContents;
-    use fs::fields as f;
+    use crate::output::cell::TextCellContents;
+    use crate::fs::fields as f;
 
     use ansi_term::Colour::*;
     use ansi_term::Style;

--- a/src/output/render/size.rs
+++ b/src/output/render/size.rs
@@ -1,9 +1,9 @@
 use ansi_term::Style;
 use locale::Numeric as NumericLocale;
 
-use fs::fields as f;
-use output::cell::{TextCell, DisplayWidth};
-use output::table::SizeFormat;
+use crate::fs::fields as f;
+use crate::output::cell::{TextCell, DisplayWidth};
+use crate::output::table::SizeFormat;
 
 
 
@@ -81,9 +81,9 @@ pub trait Colours {
 #[cfg(test)]
 pub mod test {
     use super::Colours;
-    use output::cell::{TextCell, DisplayWidth};
-    use output::table::SizeFormat;
-    use fs::fields as f;
+    use crate::output::cell::{TextCell, DisplayWidth};
+    use crate::output::table::SizeFormat;
+    use crate::fs::fields as f;
 
     use locale::Numeric as NumericLocale;
     use ansi_term::Colour::*;

--- a/src/output/render/times.rs
+++ b/src/output/render/times.rs
@@ -1,8 +1,8 @@
 use datetime::TimeZone;
 use ansi_term::Style;
 
-use output::cell::TextCell;
-use output::time::TimeFormat;
+use crate::output::cell::TextCell;
+use crate::output::time::TimeFormat;
 
 
 pub trait Render {

--- a/src/output/render/users.rs
+++ b/src/output/render/users.rs
@@ -1,8 +1,8 @@
 use ansi_term::Style;
 use users::Users;
 
-use fs::fields as f;
-use output::cell::TextCell;
+use crate::fs::fields as f;
+use crate::output::cell::TextCell;
 
 
 
@@ -30,8 +30,8 @@ pub trait Colours {
 #[allow(unused_results)]
 pub mod test {
     use super::Colours;
-    use fs::fields as f;
-    use output::cell::TextCell;
+    use crate::fs::fields as f;
+    use crate::output::cell::TextCell;
 
     use users::User;
     use users::mock::MockUsers;

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -8,14 +8,16 @@ use zoneinfo_compiled::{CompiledData, Result as TZResult};
 
 use locale;
 
+use log::debug;
+
 use users::UsersCache;
 
-use style::Colours;
-use output::cell::TextCell;
-use output::render::TimeRender;
-use output::time::TimeFormat;
-use fs::{File, fields as f};
-use fs::feature::git::GitCache;
+use crate::style::Colours;
+use crate::output::cell::TextCell;
+use crate::output::render::TimeRender;
+use crate::output::time::TimeFormat;
+use crate::fs::{File, fields as f};
+use crate::fs::feature::git::GitCache;
 
 
 /// Options for displaying a table.
@@ -338,7 +340,7 @@ impl<'a, 'f> Table<'a> {
     }
 
     fn display(&self, file: &File, column: &Column, xattrs: bool) -> TextCell {
-        use output::table::TimeType::*;
+        use crate::output::table::TimeType::*;
 
         match *column {
             Column::Permissions    => self.permissions_plus(file, xattrs).render(self.colours),

--- a/src/style/colours.rs
+++ b/src/style/colours.rs
@@ -1,10 +1,10 @@
 use ansi_term::Style;
 use ansi_term::Colour::{Red, Green, Yellow, Blue, Cyan, Purple, Fixed};
 
-use output::render;
-use output::file_name::Colours as FileNameColours;
+use crate::output::render;
+use crate::output::file_name::Colours as FileNameColours;
 
-use style::lsc::Pair;
+use crate::style::lsc::Pair;
 
 
 #[derive(Debug, Default, PartialEq)]


### PR DESCRIPTION
Brief summary:
* Extern crates are no longer needed.
* Absolute paths begin with a crate name, where the keyword crate refers to the current crate.
* Import macros with use, rather than a `#[macro_use]` attribute.
