### PR TITLE
Fix clippy warnings and explicitely ignore a few, fix future deprecation

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -11,7 +11,7 @@ fn main() {
     configure_logger();
 
     let args: Vec<OsString> = args_os().skip(1).collect();
-    match Exa::new(args.iter(), &mut stdout()) {
+    match Exa::from_args(args.iter(), &mut stdout()) {
         Ok(mut exa) => {
             match exa.run() {
                 Ok(exit_status) => exit(exit_status),

--- a/src/exa.rs
+++ b/src/exa.rs
@@ -100,7 +100,7 @@ fn ignore_cache(options: &Options) -> Option<IgnoreCache> {
 }
 
 impl<'args, 'w, W: Write + 'w> Exa<'args, 'w, W> {
-    pub fn new<I>(args: I, writer: &'w mut W) -> Result<Exa<'args, 'w, W>, Misfire>
+    pub fn from_args<I>(args: I, writer: &'w mut W) -> Result<Exa<'args, 'w, W>, Misfire>
     where I: Iterator<Item=&'args OsString> {
         Options::parse(args, &LiveVars).map(move |(options, mut args)| {
             debug!("Dir action from arguments: {:#?}", options.dir_action);
@@ -125,7 +125,7 @@ impl<'args, 'w, W: Write + 'w> Exa<'args, 'w, W> {
         let mut exit_status = 0;
 
         for file_path in &self.args {
-            match File::new(PathBuf::from(file_path), None, None) {
+            match File::from_args(PathBuf::from(file_path), None, None) {
                 Err(e) => {
                     exit_status = 2;
                     writeln!(stderr(), "{:?}: {}", file_path, e)?;

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -82,7 +82,7 @@ pub struct Files<'dir, 'ig> {
 
     /// Whether the `.` or `..` directories should be produced first, before
     /// any files have been listed.
-    dots: Dots,
+    dots: DotsNext,
 
     ignore: Option<&'ig IgnoreCache>,
 }
@@ -109,7 +109,7 @@ impl<'dir, 'ig> Files<'dir, 'ig> {
                     if i.is_ignored(path) { continue }
                 }
 
-                return Some(File::new(path.clone(), self.dir, filename)
+                return Some(File::from_args(path.clone(), self.dir, filename)
                                  .map_err(|e| (path.clone(), e)))
             }
             else {
@@ -121,16 +121,16 @@ impl<'dir, 'ig> Files<'dir, 'ig> {
 
 /// The dot directories that need to be listed before actual files, if any.
 /// If these aren’t being printed, then `FilesNext` is used to skip them.
-enum Dots {
+enum DotsNext {
 
     /// List the `.` directory next.
-    DotNext,
+    Dot,
 
     /// List the `..` directory next.
-    DotDotNext,
+    DotDot,
 
     /// Forget about the dot directories and just list files.
-    FilesNext,
+    Files,
 }
 
 
@@ -138,18 +138,18 @@ impl<'dir, 'ig> Iterator for Files<'dir, 'ig> {
     type Item = Result<File<'dir>, (PathBuf, io::Error)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Dots::DotNext = self.dots {
-            self.dots = Dots::DotDotNext;
-            Some(File::new(self.dir.path.to_path_buf(), self.dir, String::from("."))
-                      .map_err(|e| (Path::new(".").to_path_buf(), e)))
-        }
-        else if let Dots::DotDotNext = self.dots {
-            self.dots = Dots::FilesNext;
-            Some(File::new(self.parent(), self.dir, String::from(".."))
-                      .map_err(|e| (self.parent(), e)))
-        }
-        else {
-            self.next_visible_file()
+        match self.dots {
+            DotsNext::Dot => {
+                self.dots = DotsNext::DotDot;
+                Some(File::from_args(self.dir.path.to_path_buf(), self.dir, String::from("."))
+                          .map_err(|e| (Path::new(".").to_path_buf(), e)))
+            },
+            DotsNext::DotDot => {
+                self.dots = DotsNext::Files;
+                Some(File::from_args(self.parent(), self.dir, String::from(".."))
+                          .map_err(|e| (self.parent(), e)))
+            },
+            DotsNext::Files => self.next_visible_file(),
         }
     }
 }
@@ -189,11 +189,11 @@ impl DotFilter {
     }
 
     /// Whether this filter should add dot directories to a listing.
-    fn dots(self) -> Dots {
+    fn dots(self) -> DotsNext {
         match self {
-            DotFilter::JustFiles       => Dots::FilesNext,
-            DotFilter::Dotfiles        => Dots::FilesNext,
-            DotFilter::DotfilesAndDots => Dots::DotNext,
+            DotFilter::JustFiles       => DotsNext::Files,
+            DotFilter::Dotfiles        => DotsNext::Files,
+            DotFilter::DotfilesAndDots => DotsNext::Dot,
         }
     }
 }

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -58,7 +58,7 @@ pub struct File<'dir> {
 }
 
 impl<'dir> File<'dir> {
-    pub fn new<PD, FN>(path: PathBuf, parent_dir: PD, filename: FN) -> IOResult<File<'dir>>
+    pub fn from_args<PD, FN>(path: PathBuf, parent_dir: PD, filename: FN) -> IOResult<File<'dir>>
     where PD: Into<Option<&'dir Dir>>,
           FN: Into<Option<String>>
     {
@@ -118,7 +118,7 @@ impl<'dir> File<'dir> {
             }
         }
 
-        return false;
+        false
     }
 
     /// If this file is a directory on the filesystem, then clone its

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -334,8 +334,8 @@ impl<'a> Render<'a> {
             None       => format!("<{}>", error),
         };
 
-		// TODO: broken_symlink() doesn’t quite seem like the right name for
-		// the style that’s being used here. Maybe split it in two?
+        // TODO: broken_symlink() doesn’t quite seem like the right name for
+        // the style that’s being used here. Maybe split it in two?
         let name = TextCell::paint(self.colours.broken_symlink(), error_message);
         Row { cells: None, name, tree }
     }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -29,6 +29,7 @@ pub struct View {
 
 /// The **mode** is the “type” of output.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum Mode {
     Grid(grid::Options),
     Details(details::Options),

--- a/src/style/colours.rs
+++ b/src/style/colours.rs
@@ -323,6 +323,7 @@ impl render::FiletypeColours for Colours {
 
 impl render::GitColours for Colours {
     fn not_modified(&self)  -> Style { self.punctuation }
+    #[allow(clippy::new_ret_no_self)]
     fn new(&self)           -> Style { self.git.new }
     fn modified(&self)      -> Style { self.git.modified }
     fn deleted(&self)       -> Style { self.git.deleted }

--- a/src/style/lsc.rs
+++ b/src/style/lsc.rs
@@ -69,7 +69,7 @@ where I: Iterator<Item=&'a str> {
                         return Some(RGB(r, g, b));
                     }
                 }*/
-                
+
                 if let (Some(r), Some(g), Some(b)) = (hexes.parse().ok(),
                                                            iter.next().and_then(|s| s.parse().ok()),
                                                            iter.next().and_then(|s| s.parse().ok())) {
@@ -88,7 +88,7 @@ impl<'var> Pair<'var> {
         let mut iter = self.value.split(';').peekable();
 
         while let Some(num) = iter.next() {
-            match num.trim_left_matches('0') {
+            match num.trim_start_matches('0') {
 
                 // Bold and italic
                 "1" => style = style.bold(),


### PR DESCRIPTION
Now, clippy doesn’t show any warning.