### PR TITLE
Convert manpages to mdoc(7) and split color info into own page.

### DIFF
--- a/contrib/man/exa-colors.5
+++ b/contrib/man/exa-colors.5
@@ -1,0 +1,333 @@
+.Dd December 23, 2018
+.Dt EXA-COLORS 5
+.Os
+.Sh NAME
+.Nm exa-colors
+.Nd configuration 
+.Sh SYNOPSIS
+.Sm off
+.Ev LS_COLORS = Qo di = Ar 01 ; 34 : No *.mp4 = Ar 01 ; 35 : No ... Qc
+.Pp
+.Ev EXA_COLORS = Qo tx = Ar 01 ; 32 : No gm = Ar 01 ; 31 : No ... Qc
+.Sm on
+.Sh DESCRIPTION
+.Ev LS_COLORS
+is the traditional way of customising the colours used by
+.Xr ls 1 .
+You can use
+.Xr dircolors 1
+to generate a script that sets
+.Ev LS_COLORS
+from a
+.Xr dir_colors 5
+file. It has the following structure:
+.Pp
+.Sm off
+.Dl Sy key No = Ar color Op : Sy key No = Ar color : No " " ...
+.Sm on
+.Pp
+.Sy key
+can be either be a two letter code or a file
+.Xr glob 7 .
+Anything that is not a valid code will be treated as a glob, including keys
+that happen to be two letters long.
+.Pp
+.Ar color
+is a sequence of valid SGR codes (specified in ECMA-48) separated by semicolons
+.Pq Sq \&; .
+It can be in the following common formats:
+.Bl -tag -width Ds
+.It 4-bit colors
+ECMA-48 specifies 8 colors for foreground and background text:
+.Bl -column -offset indent "color" "9"
+.It black Ta 0
+.It red Ta 1
+.It green Ta 2
+.It yellow Ta 3
+.It blue Ta 4
+.It magenta Ta 5
+.It cyan Ta 6
+.It white Ta 7
+.El
+.Pp
+Foreground color codes start at 30 and background codes start at 40
+.Po
+e.g. green foreground is
+.Sq Ar 32 ,
+white background is
+.Sq Ar 47
+.Pc .
+This can be combined with the increased intensity/boldface code
+.Sq Ar 1
+to display brighter text, thus allowing for a 16 color pallette.
+.It
+.El
+.Pp
+.Ev LS_COLORS
+can use these ten codes:
+.Bl -bullet
+.It
+.Ql di ,
+directories
+.It
+.Ql ex ,
+executable files
+.It
+.Ql fi ,
+regular files
+.It
+.Ql pi ,
+named pipes
+.It
+.Ql so ,
+sockets
+.It
+.Ql bd ,
+block devices
+.It
+.Ql cd ,
+character devices
+.It
+.Ql ln ,
+symlinks
+.It
+.Ql or ,
+symlinks with no target
+.El
+.Pp
+.Ev EXA_COLORS
+can use many more:
+.Bl -bullet
+.It
+.Ql ur ,
+the user-read permission bit.
+.It
+.Ql uw ,
+the user-write permission bit.
+.It
+.Ql ux ,
+the user-execute permission bit for regular files.
+.It
+.Ql ue ,
+the user-execute for other file kinds.
+.It
+.Ql gr ,
+the group-read permission bit.
+.It 
+.Ql gw ,
+the group-write permission bit.
+.It
+.Ql gx ,
+the group-execute permission bit.
+.It
+.Ql tr ,
+the others-read permission bit.
+.It
+.Ql tw ,
+the others-write permission bit.
+.It
+.Ql tx ,
+the others-execute permission bit.
+.It
+.Ql su ,
+setuid, setgid, and sticky permission bits for files.
+.It
+.Ql sf ,
+setuid, setgid, and sticky for other file kinds.
+.It
+.Ql xa ,
+the extended attribute indicator.
+.It
+.Ql sn ,
+the numbers of a file's size.
+.It
+.Ql sb ,
+the units of a file's size.
+.It
+.Ql df ,
+a device's major ID.
+.It
+.Ql ds ,
+a device's minor ID.
+.It
+.Ql uu ,
+a user that's you.
+.It
+.Ql un ,
+a user that's someone else.
+.It
+.Ql gu ,
+a group that you belong to.
+.It
+.Ql gn ,
+a group you aren't a member of.
+.It
+.Ql lc ,
+a number of hard links.
+.It
+.Ql lm ,
+a number of hard links for a regular file with at least two.
+.It
+.Ql ga ,
+a new flag in Git.
+.It
+.Ql gm ,
+a modified flag in Git.
+.It
+.Ql gd ,
+a deleted flag in Git.
+.It
+.Ql gv ,
+a renamed flag in Git.
+.It
+.Ql gt ,
+a modified metadata flag in Git.
+.It
+.Ql xx ,
+.Qq punctuation
+including many background UI elements.
+.It
+.Ql da ,
+a file's date.
+.It
+.Ql in ,
+a file's inode number.
+.It
+.Ql bl ,
+a file's number of blocks.
+.It
+.Ql hd ,
+the header row of a table.
+.It
+.Ql lp ,
+the path of a symlink.
+.It
+.Ql cc ,
+an escaped character in a filename.
+.It
+.Ql b0 ,
+the overlay style for broken symlink paths.
+.El
+.Pp
+Values in
+.Ev EXA_COLORS
+override those given in
+.Ev LS_COLORS ,
+so you don't need to rewrite an existing
+.Ev LS_COLORS
+variable with proprietary extensions.
+.Pp
+Unlike some versions of
+.Xr ls 1 ,
+the given ANSI values must be valid colour codes:
+.Nm
+won't just print out whichever characters are given. Accepted codes are
+.Bl -bullet
+.It
+.Ql 1 ,
+for bold
+.It
+.Ql 4 ,
+for underline
+.It
+.Ql 31 ,
+for red text
+.It
+.Ql 32 ,
+for green text
+.It
+.Ql 33 ,
+for yellow text
+.It
+.Ql 34 ,
+for blue text
+.It
+.Ql 35 ,
+for purple text
+.It
+.Ql 36 ,
+for cyan text
+.It
+.Ql 37 ,
+for white text
+.It
+.Ql 38;5; Ns Ar nnn ,
+for colored text where
+.Ar nnn
+is a colour from 0 to 255.
+.El
+.Pp
+Many terminals will treat bolded text as a different colour, or at least
+provide the option to.
+.Pp
+.Nm
+provides its own builtin set of file extension mappings that cover a large
+range of common file extensions, including documents, archives, media, and
+temporary files. Any mappings in the environment variables will override
+this default set: running
+.Nm
+with
+.Ev LS_COLORS Ns = Ns Qq *.zip Ns = Ns Ar 32
+will turn zip files green but leave the colours of other compressed files
+alone.
+.Pp
+You can also disable this builtin set entirely by including a reset entry
+at the beginning of
+.Ev EXA_COLORS :
+.Dl Ev EXA_COLORS Ns = Ns Qq reset Ns : Ns *.txt Ns = Ns Ar 31
+will highlight only text files,
+.Dl Ev EXA_COLORS Ns = Ns Qq reset
+will highlight nothing.
+.Ss BUILTIN EXTENSIONS
+.Bl -bullet
+.It
+"Immediate" files are the files you should look at when downloading and
+building a project for the first time: READMEs, Makefiles, Cargo.toml,
+and others.
+They[aq]re highlighted in yellow and underlined.
+.It
+Images (png, jpeg, gif) are purple.
+.It
+Videos (mp4, ogv, m2ts) are a slightly purpler purple.
+.It
+Music (mp3, m4a, ogg) is a deeper purple.
+.It
+Lossless music (flac, alac, wav) is deeper than  purple.
+In general, most media files are some shade of purple.
+.It
+Cryptographic files (asc, enc, p12) are a faint blue.
+.It
+Documents (pdf, doc, dvi) are a less faint blue.
+.It
+Compressed files (zip, tgz, Z) are red.
+.It
+Temporary files (tmp, swp, ~) are grey.
+.It
+Compiled files (class, o, pyc) are faint orange.
+A file is also counted as compiled if it uses a common extension and is
+in the same directory as one of its source files: [aq]styles.css[aq]
+will count as compiled when next to [aq]styles.less[aq] or
+[aq]styles.sass[aq], and [aq]scripts.js[aq] when next to
+[aq]scripts.ts[aq] or [aq]scripts.coffee[aq].
+.El
+.Sh EXAMPLES
+.Bl -bullet
+.It
+Disable the "current user" highlighting: 
+.It
+Turn the date column green: 
+.It
+Highlight Vagrantfiles: 
+.It
+Override the existing zip colour: 
+.It
+Markdown files a shade of green, log files a shade of grey:
+.El
+.Sh SEE ALSO
+.Rs
+.%I Ecma
+.%D 1991
+.%R ECMA-48
+.%T Control Functions for Coded Character Sets
+.%P 61
+.Re

--- a/contrib/man/exa-colors.5
+++ b/contrib/man/exa-colors.5
@@ -1,9 +1,12 @@
+'\" e
 .Dd December 23, 2018
 .Dt EXA-COLORS 5
 .Os
 .Sh NAME
 .Nm exa-colors
-.Nd configuration 
+.Nd configure colors for
+.Nm exa
+entries
 .Sh SYNOPSIS
 .Sm off
 .Ev LS_COLORS = Qo di = Ar 01 ; 34 : No *.mp4 = Ar 01 ; 35 : No ... Qc
@@ -11,6 +14,11 @@
 .Ev EXA_COLORS = Qo tx = Ar 01 ; 32 : No gm = Ar 01 ; 31 : No ... Qc
 .Sm on
 .Sh DESCRIPTION
+By default
+.Nm exa
+will color entries to distinguish between filetypes.
+These colors are defined
+.Sh SYNTAX
 .Ev LS_COLORS
 is the traditional way of customising the colours used by
 .Xr ls 1 .
@@ -20,7 +28,8 @@ to generate a script that sets
 .Ev LS_COLORS
 from a
 .Xr dir_colors 5
-file. It has the following structure:
+file.
+It has the following structure:
 .Pp
 .Sm off
 .Dl Sy key No = Ar color Op : Sy key No = Ar color : No " " ...
@@ -32,239 +41,145 @@ can be either be a two letter code or a file
 Anything that is not a valid code will be treated as a glob, including keys
 that happen to be two letters long.
 .Pp
-.Ar color
-is a sequence of valid SGR codes (specified in ECMA-48) separated by semicolons
-.Pq Sq \&; .
-It can be in the following common formats:
-.Bl -tag -width Ds
-.It 4-bit colors
-ECMA-48 specifies 8 colors for foreground and background text:
-.Bl -column -offset indent "color" "9"
-.It black Ta 0
-.It red Ta 1
-.It green Ta 2
-.It yellow Ta 3
-.It blue Ta 4
-.It magenta Ta 5
-.It cyan Ta 6
-.It white Ta 7
-.El
-.Pp
-Foreground color codes start at 30 and background codes start at 40
-.Po
-e.g. green foreground is
-.Sq Ar 32 ,
-white background is
-.Sq Ar 47
-.Pc .
-This can be combined with the increased intensity/boldface code
-.Sq Ar 1
-to display brighter text, thus allowing for a 16 color pallette.
-.It
-.El
-.Pp
 .Ev LS_COLORS
 can use these ten codes:
-.Bl -bullet
-.It
-.Ql di ,
-directories
-.It
-.Ql ex ,
-executable files
-.It
-.Ql fi ,
-regular files
-.It
-.Ql pi ,
-named pipes
-.It
-.Ql so ,
-sockets
-.It
-.Ql bd ,
-block devices
-.It
-.Ql cd ,
-character devices
-.It
-.Ql ln ,
-symlinks
-.It
-.Ql or ,
-symlinks with no target
+.Bl -column -offset indent "xx" "description of the code"
+.It Sy bd Ta block devices.
+.It Sy cd Ta character devices.
+.It Sy di Ta directories.
+.It Sy ex Ta executable files.
+.It Sy fi Ta regular files.
+.It Sy ln Ta symlinks.
+.It Sy or Ta symlinks with no target.
+.It Sy pi Ta named pipes.
+.It Sy so Ta sockets.
 .El
 .Pp
 .Ev EXA_COLORS
 can use many more:
-.Bl -bullet
-.It
-.Ql ur ,
-the user-read permission bit.
-.It
-.Ql uw ,
-the user-write permission bit.
-.It
-.Ql ux ,
-the user-execute permission bit for regular files.
-.It
-.Ql ue ,
-the user-execute for other file kinds.
-.It
-.Ql gr ,
-the group-read permission bit.
-.It 
-.Ql gw ,
-the group-write permission bit.
-.It
-.Ql gx ,
-the group-execute permission bit.
-.It
-.Ql tr ,
-the others-read permission bit.
-.It
-.Ql tw ,
-the others-write permission bit.
-.It
-.Ql tx ,
-the others-execute permission bit.
-.It
-.Ql su ,
-setuid, setgid, and sticky permission bits for files.
-.It
-.Ql sf ,
-setuid, setgid, and sticky for other file kinds.
-.It
-.Ql xa ,
-the extended attribute indicator.
-.It
-.Ql sn ,
-the numbers of a file's size.
-.It
-.Ql sb ,
-the units of a file's size.
-.It
-.Ql df ,
-a device's major ID.
-.It
-.Ql ds ,
-a device's minor ID.
-.It
-.Ql uu ,
-a user that's you.
-.It
-.Ql un ,
-a user that's someone else.
-.It
-.Ql gu ,
-a group that you belong to.
-.It
-.Ql gn ,
-a group you aren't a member of.
-.It
-.Ql lc ,
-a number of hard links.
-.It
-.Ql lm ,
-a number of hard links for a regular file with at least two.
-.It
-.Ql ga ,
-a new flag in Git.
-.It
-.Ql gm ,
-a modified flag in Git.
-.It
-.Ql gd ,
-a deleted flag in Git.
-.It
-.Ql gv ,
-a renamed flag in Git.
-.It
-.Ql gt ,
-a modified metadata flag in Git.
-.It
-.Ql xx ,
-.Qq punctuation
-including many background UI elements.
-.It
-.Ql da ,
-a file's date.
-.It
-.Ql in ,
-a file's inode number.
-.It
-.Ql bl ,
-a file's number of blocks.
-.It
-.Ql hd ,
-the header row of a table.
-.It
-.Ql lp ,
-the path of a symlink.
-.It
-.Ql cc ,
-an escaped character in a filename.
-.It
-.Ql b0 ,
-the overlay style for broken symlink paths.
+.Bl -column -offset indent "xx" "a very long description of the code"
+.It Sy b0 Ta the overlay style for broken symlink paths.
+.It Sy bl Ta a file's number of blocks.
+.It Sy cc Ta an escaped character in a filename.
+.It Sy da Ta a file's date.
+.It Sy df Ta a device's major ID.
+.It Sy ds Ta a device's minor ID.
+.It Sy ga Ta a new flag in Git.
+.It Sy gd Ta a deleted flag in Git.
+.It Sy gm Ta a modified flag in Git.
+.It Sy gn Ta a group you aren't a member of.
+.It Sy gr Ta the group-read permission bit.
+.It Sy gt Ta a modified metadata flag in Git.
+.It Sy gu Ta a group that you belong to.
+.It Sy gv Ta a renamed flag in Git.
+.It Sy gw Ta the group-write permission bit.
+.It Sy gx Ta the group-execute permission bit.
+.It Sy hd Ta the header row of a table.
+.It Sy in Ta a file's inode number.
+.It Sy lc Ta a number of hard links.
+.It Sy lm Ta a number of hard links for a regular file with at least two.
+.It Sy lp Ta the path of a symlink.
+.It Sy sb Ta the units of a file's size.
+.It Sy sf Ta setuid, setgid, and sticky for other file kinds.
+.It Sy sn Ta the numbers of a file's size.
+.It Sy su Ta setuid, setgid, and sticky permission bits for files.
+.It Sy tr Ta the others-read permission bit.
+.It Sy tw Ta the others-write permission bit.
+.It Sy tx Ta the others-execute permission bit.
+.It Sy ue Ta the user-execute for other file kinds.
+.It Sy un Ta a user that's someone else.
+.It Sy ur Ta the user-read permission bit.
+.It Sy uu Ta a user that's you.
+.It Sy uw Ta the user-write permission bit.
+.It Sy ux Ta the user-execute permission bit for regular files.
+.It Sy xa Ta the extended attribute indicator.
+.It Sy xx Ta Qo punctuation Qc , including many background UI elements.
 .El
 .Pp
 Values in
 .Ev EXA_COLORS
 override those given in
 .Ev LS_COLORS ,
-so you don't need to rewrite an existing
+so you don't need to redefine an existing
 .Ev LS_COLORS
 variable with proprietary extensions.
 .Pp
-Unlike some versions of
-.Xr ls 1 ,
-the given ANSI values must be valid colour codes:
-.Nm
-won't just print out whichever characters are given. Accepted codes are
-.Bl -bullet
-.It
-.Ql 1 ,
-for bold
-.It
-.Ql 4 ,
-for underline
-.It
-.Ql 31 ,
-for red text
-.It
-.Ql 32 ,
-for green text
-.It
-.Ql 33 ,
-for yellow text
-.It
-.Ql 34 ,
-for blue text
-.It
-.Ql 35 ,
-for purple text
-.It
-.Ql 36 ,
-for cyan text
-.It
-.Ql 37 ,
-for white text
-.It
-.Ql 38;5; Ns Ar nnn ,
-for colored text where
-.Ar nnn
-is a colour from 0 to 255.
+.Ar color
+is a sequence of valid SGR codes (specified in ECMA-48) separated by semicolons
+.Pq Sq \&; .
+.Nm exa
+recognizes the following codes:
+.Bl -column -offset indent "00" "short code description"
+.It Ar 1 Ta bold text or increased intensity colors.
+.It Ar 2 Ta decreased intensity colors.
+.It Ar 3 Ta italicized text.
+.It Ar 4 Ta underlined text.
+.It Ar 5 Ta slowly blinking text.
+.It Ar 7 Ta negative colors.
+.It Ar 8 Ta concealed text.
+.It Ar 9 Ta crossed-out text.
+.It Ar 30 Ta black color text.
+.It Ar 31 Ta red color text.
+.It Ar 32 Ta green color text.
+.It Ar 33 Ta yellow color text.
+.It Ar 34 Ta blue color text.
+.It Ar 35 Ta magenta color text.
+.It Ar 36 Ta cyan color text.
+.It Ar 37 Ta white color text.
+.It Ar 38 Ta 8/24 bit color text.
+.It Ar 40 Ta black color background.
+.It Ar 41 Ta red color background.
+.It Ar 42 Ta green color background.
+.It Ar 43 Ta yellow color background.
+.It Ar 44 Ta blue color background.
+.It Ar 45 Ta magenta color background.
+.It Ar 46 Ta cyan color background.
+.It Ar 47 Ta white color background.
+.It Ar 48 Ta 8/24 bit color background.
 .El
 .Pp
 Many terminals will treat bolded text as a different colour, or at least
 provide the option to.
+The 8 and 24 bit color modes for codes
+.Ar 38
+and
+.Ar 48
+are extensions to ECMA-48 that are defined in ISO/IEC 6429.
+The 8 bit mode is formatted using the sequence:
+.Sm off
+.Dl Ar 38 ; 5 ; n
+.Sm on
+where
+.Ar n
+is an number from 0-255.
+Numbers in this mode are seperated into four groups:
+.Bl -tag -width Ds
+.It 0-7
+normal intensity colors.
+These are the same as the SGR codes from 30-37 and 40-47.
+.It 8-15
+increased intensity colors.
+These are the same as combining the SGR codes from 30-37/40-47 with code 1.
+.It 16-231
+216 color lookup.
+Colors are defined using
+.EQ
+16 + 36 times r + 6 times g + b
+.EN
+with
+.EQ
+0 <= r, g, b <= 5.
+.EN
+.It 232-255
+24 grayscale color range, starts with black and steps up to white.
+.El
 .Pp
-.Nm
+.Nm exa
 provides its own builtin set of file extension mappings that cover a large
 range of common file extensions, including documents, archives, media, and
-temporary files. Any mappings in the environment variables will override
-this default set: running
+temporary files.
+Any mappings in the environment variables will override this default set:
+running
 .Nm
 with
 .Ev LS_COLORS Ns = Ns Qq *.zip Ns = Ns Ar 32
@@ -274,7 +189,7 @@ alone.
 You can also disable this builtin set entirely by including a reset entry
 at the beginning of
 .Ev EXA_COLORS :
-.Dl Ev EXA_COLORS Ns = Ns Qq reset Ns : Ns *.txt Ns = Ns Ar 31
+.Dl Ev EXA_COLORS Ns = Ns Qq reset : Ns *.txt Ns = Ns Ar 31
 will highlight only text files,
 .Dl Ev EXA_COLORS Ns = Ns Qq reset
 will highlight nothing.
@@ -313,13 +228,13 @@ will count as compiled when next to [aq]styles.less[aq] or
 .Sh EXAMPLES
 .Bl -bullet
 .It
-Disable the "current user" highlighting: 
+Disable the "current user" highlighting:
 .It
-Turn the date column green: 
+Turn the date column green:
 .It
-Highlight Vagrantfiles: 
+Highlight Vagrantfiles:
 .It
-Override the existing zip colour: 
+Override the existing zip colour:
 .It
 Markdown files a shade of green, log files a shade of grey:
 .El

--- a/contrib/man/exa.1
+++ b/contrib/man/exa.1
@@ -1,4 +1,4 @@
-.Dd December 23, 2018
+.Dd December 31, 2018
 .Dt EXA 1
 .Os
 .Sh NAME
@@ -12,11 +12,9 @@
 .Nm
 is a modern replacement for
 .Xr ls 1 .
-It colors information by default to distinguish between filetypes,
-such as whether you are the owner or in the owning group. It also has
-features not present in the original
-.Xr ls ,
-such as viewing the
+It colors information by default to distinguish between filetypes, such as
+whether you are the owner or in the owning group.
+It also has features not present in the original ls, such as viewing the
 .Xr git-status 1
 for a directory or recursing into directories with a tree view.
 .Sh DISPLAY OPTIONS
@@ -55,7 +53,7 @@ include entries that are hidden or begin with a dot
 .Pq Sq \&. .
 Use this twice to also include the
 .Sq \&.
-and 
+and
 .Sq ..
 directories.
 .It Fl d , Fl Fl listdirs
@@ -68,46 +66,51 @@ reverse the sort order.
 which field to sort entries by.
 .Ar SORT_FIELD
 can be:
-.Bl -bullet
+.Bl -tag -width Ds
+.It Ar name , Name
+sort by alphabetical order.
+.It Ar extension , Extension
+sort by file extension in alphabetical order.
+Entries without file extensions precede those that do.
+.It Ar size
+sort by file size ascending.
+.It Ar modified , date , time , newest
+sort by modification date ascending.
+.It Ar age , oldest
+sort by modification date decending.
+.It Ar accessed
+sort by access date ascending.
+.It Ar created
+sort by creation date ascending.
+.It Ar inode
+sort by inode number ascending.
+.It Ar type
+sort by filetype.
+The order is as follows:
+.Bl -enum
 .It
-.Ar name , Name
-\(em sort entries in alphabetical order.
+Directories.
 .It
-.Ar extension , Extension
-\(em sort entries by their file extension in alphabetical order. Entries
-without file extensions precede those that do.
+Files.
 .It
-.Ar size
-\(em sort entries by their file size.
+Links.
 .It
-.Ar modified
-\(em sort entries by modification date ascending.
+Pipes.
 .It
-.Ar accessed
-\(em sort entries by access date ascending.
+Sockets.
 .It
-.Ar created
+Char devices.
 .It
-.Ar inode
-\(em sort entries by inode modification.
+Block devices.
 .It
-.Ar type
-.It
-.Ar none
+Special files.
 .El
-The
-.Ar modified
-field has the aliases
-.Ar date , time
-and 
-.Ar newest ,
-and its reverse order has the aliases
-.Ar age
-and
-.Ar oldest .
+.It Ar none
+.El
+.Pp
 Fields starting with a capital letter will sort uppercase before lowercase:
 .Sq A
-then 
+then
 .Sq B
 then
 .Sq a
@@ -147,7 +150,7 @@ list file sizes in bytes, without any prefixes.
 list each file's group.
 .It Fl h , Fl Fl header
 add a header row to each column.
-.It Fl H , Fl Fl links.
+.It Fl H , Fl Fl links
 list each file's number of hard links.
 .It Fl i , Fl Fl inode
 list each file's inode number.
@@ -183,7 +186,7 @@ or
 use the accessed timestamp field.
 .It Fl U , Fl Fl created
 use the created timestamp field.
-.It Fl \&@, extended
+.It Fl \&@ , extended
 list each file's extended attributes and sizes
 .It Fl Fl git
 list each file's
@@ -195,13 +198,14 @@ if tracked.
 recognizes the following environment variables:
 .Bl -tag -width Ds
 .It Ev COLUMNS
-Overrides the width of the terminal, in characters. For example:
+Overrides the width of the terminal, in characters.
+For example:
 .Dl Ev COLUMNS Ns = Ns Ar 80
-will show a grid view with a maximum width of 80 characters. This option
-won't do anything when
+will show a grid view with a maximum width of 80 characters.
+This option won't do anything when
 .Nm exa Ns 's
 output doesnt wrap, such as when using the
-.Fl Fl Fl long
+.Fl Fl long
 or
 .Fl l
 option.
@@ -210,8 +214,8 @@ Enables
 .Em strict mode ,
 which will make
 .Nm
-error when two options are incompatible. Options can override each other
-going right-to-left so that
+error when two options are incompatible.
+Options can override each other going right-to-left so that
 .Nm
 can be aliased:
 .Pp
@@ -222,7 +226,8 @@ then running
 will run
 .Dl Nm Fl Fl sort Ns = Ns Ar ext Fl Fl sort Ns = Ns Ar size ,
 with the sort field specified by the user overriding the sort field specified
-by the alias. In
+by the alias.
+In
 .Em strict mode ,
 the two options will not cooperate, and exa will error.
 .Pp
@@ -233,13 +238,15 @@ Limits the grid-details view set by
 .Fl Fl grid
 and
 .Fl Fl long ,
-so that it is only activated when at least the given number of rows of
-output would be generated. With widescreen displays, it is possible for
-the grid to look very wide and sparse, on just one or two lines with none
-of the columns lining up. By specifying a minimum number of rows, you can
-only use the view if it's going to be worth using.
+so that it is only activated when at least the given number of rows of output
+would be generated.
+With widescreen displays, it is possible for the grid to look very wide and
+sparse, on just one or two lines with none of the columns lining up.
+By specifying a minimum number of rows, you can only use the view if it's
+going to be worth using.
 .It Ev LS_COLORS , EXA_COLORS
-Colorize entries according to specific patterns. See
+Colorize entries according to specific patterns.
+See
 .Xr exa-colors 5
 for more info.
 .El
@@ -254,10 +261,11 @@ Display a tree of entries, three levels deep:
 .Dl $ Nm Fl Fl long Fl Fl tree Fl Fl level Ns = Ns Ar 3
 .Sh SEE ALSO
 .Xr ls 1 ,
-.Xr tree 1 .
-.Sh AUTHOR
+.Xr tree 1
+.Sh AUTHORS
 .Nm
-is written and maintained by
+is maintained by
 .An Benjamin So ogham Sc Sago
-with contributions from many others. You can view the full list at:
-.Lk https://github.com/ogham/exa/graphs/contributors
+with contributions from many others.
+You can view the full list at
+.Aq Lk https://github.com/ogham/exa/graphs/contributors

--- a/contrib/man/exa.1
+++ b/contrib/man/exa.1
@@ -6,7 +6,7 @@
 .Nd list directory contents
 .Sh SYNOPSIS
 .Nm
-.Op Fl \&1abBdDFgGhHilmrRSTuUX
+.Op Fl 1@abBdDFgGhHilmrRSTuUX
 .Op Fl -color-scale
 .Op Fl -git
 .Op Fl -git-ignore

--- a/contrib/man/exa.1
+++ b/contrib/man/exa.1
@@ -1,4 +1,4 @@
-.Dd December 31, 2018
+.Dd February 10, 2019
 .Dt EXA 1
 .Os
 .Sh NAME
@@ -6,86 +6,131 @@
 .Nd list directory contents
 .Sh SYNOPSIS
 .Nm
-.Op Ar OPTIONS
+.Op Fl \&1abBdDFgGhHilmrRSTuUX
+.Op Fl -color-scale
+.Op Fl -git
+.Op Fl -git-ignore
+.Op Fl -group-directories-first
+.Op Fl I Ar globs
+.Op Fl L Ar depth
+.Op Fl s Ar sort_field
+.Op Fl t Ar field
+.Op Fl -color Ns = Ns Ar when
+.Op Fl -time-style Ns = Ns Ar style
 .Op Ar
 .Sh DESCRIPTION
 .Nm
 is a modern replacement for
 .Xr ls 1 .
-It colors information by default to distinguish between filetypes, such as
-whether you are the owner or in the owning group.
-It also has features not present in the original ls, such as viewing the
+It colors information by default to distinguish between filetypes,
+such as whether you are the owner or in the owning group.
+It also has features not present in the original ls,
+such as viewing the
 .Xr git-status 1
 for a directory or recursing into directories with a tree view.
-.Sh DISPLAY OPTIONS
+.Ss Display Options
 .Bl -tag -width Ds
-.It Fl 1 , Fl Fl oneline
-display one entry per line.
-.It Fl G , Fl Fl grid
-display entries as a grid
+.It Fl 1 , Fl -oneline
+Display one entry per line.
+.It Fl F , Fl -classify
+Display type indicator by file names.
+.It Fl G , Fl -grid
+Display entries as a grid
 .Pq default .
-.It Fl l , Fl Fl long
-display extended file metadata as a table.
-.It Fl x , Fl Fl across
-sort the grid across, rather than downwards.
-.It Fl R , Fl Fl recurse
-recurse into directories.
-.It Fl T , Fl Fl tree
-recurse into directories as a tree.
-.It Fl F , Fl Fl classify
-display type indicator by file names.
-.It Fl Fl color Ns = Ns Ar WHEN , Fl Fl colour Ns = Ns Ar WHEN
-colorize output;
-.Ar WHEN
+.It Fl l , Fl -long
+Display extended file metadata as a table.
+.It Fl R , Fl -recurse
+Recursively list subdirectories encountered.
+.It Fl T , Fl -tree
+Recursively list subdirectories as a tree.
+.It Fl x , Fl -across
+Sort the grid across, rather than downwards.
+.It Fl -color Ns = Ns Ar when , Fl -colour Ns = Ns Ar when
+Colorize output;
+.Ar when
 can be
 .Sq Ar always ,
-.Sq Ar automatic
+.Sq Ar auto
 .Pq default
 or
 .Sq Ar never .
-.It Fl Fl color-scale , Fl Fl colour-scale
-highlight levels of file sizes distinctly.
+.It Fl -color-scale , Fl -colour-scale
+Highlight levels of file sizes distinctly.
 .El
-.Sh FILTERING AND SORTING OPTIONS
+.Ss Filtering and Sorting Options
 .Bl -tag -width Ds
-.It Fl a , Fl Fl all
-include entries that are hidden or begin with a dot
+.It Fl a , Fl -all
+Include entries that are hidden or begin with a dot
 .Pq Sq \&. .
 Use this twice to also include the
 .Sq \&.
 and
 .Sq ..
 directories.
-.It Fl d , Fl Fl listdirs
-list directories like regular files.
-.It Fl L , Fl Fl level Ns = Ns Ar DEPTH
-limit the depth of recursion.
-.It Fl r , Fl Fl reverse
-reverse the sort order.
-.It Fl s , Fl Fl sort Ns = Ns Ar SORT_FIELD
-which field to sort entries by.
-.Ar SORT_FIELD
+.It Fl d , Fl -list-dirs
+List directories like regular files instead of listing their contents.
+.It Fl D , Fl -only-dirs
+List only directories.
+.It Fl I Ar globs , Fl -ignore-glob Ns = Ns Ar globs
+Pipe
+.Pq Sq |
+separated
+.Xr glob 7
+patterns of files to ignore.
+.It Fl L Ar depth , Fl -level Ns = Ns Ar depth
+Limit the depth of recursion.
+.It Fl r , Fl -reverse
+Reverse the sort order.
+.It Fl s Ar sort_field , Fl -sort Ns = Ns Ar sort_field
+Which field to sort entries by.
+.Ar sort_field
 can be:
 .Bl -tag -width Ds
-.It Ar name , Name
-sort by alphabetical order.
-.It Ar extension , Extension
-sort by file extension in alphabetical order.
+.It Ar name , Name , \&.name , \&.Name
+Sort by alphabetical order.
+.Pp
+.Ar name
+and
+.Ar Name
+are strictly alphabetical,
+i.e, entries that begin with a dot will always precede those that don't.
+The fields
+.Ar \&.name
+and
+.Ar \&.Name
+are equivalent to
+.Ar name
+and
+.Ar Name ,
+except that they ignore this starting dot when sorting alphabetically.
+.Pp
+.Ar name
+is the default sort field for
+.Nm .
+.It Ar extension , ext , Extension , Ext
+Sort by file extension in alphabetical order.
 Entries without file extensions precede those that do.
-.It Ar size
-sort by file size ascending.
-.It Ar modified , date , time , newest
-sort by modification date ascending.
-.It Ar age , oldest
-sort by modification date decending.
-.It Ar accessed
-sort by access date ascending.
-.It Ar created
-sort by creation date ascending.
+.Ar ext
+and
+.Ar Ext
+are equivalent to
+.Ar extension
+and
+.Ar Extension .
+.It Ar size , filesize
+Sort by file size ascending.
+.It Ar date , time , mod , modified , new , newest
+Sort by modification date ascending.
+.It Ar age , old , oldest
+Sort by modification date decending.
+.It Ar ac , accessed
+Sort by access date ascending.
+.It Ar cr , created
+Sort by creation date ascending.
 .It Ar inode
-sort by inode number ascending.
+Sort by inode number ascending.
 .It Ar type
-sort by filetype.
+Sort by filetype.
 The order is as follows:
 .Bl -enum
 .It
@@ -99,166 +144,186 @@ Pipes.
 .It
 Sockets.
 .It
-Char devices.
+Character devices.
 .It
 Block devices.
 .It
 Special files.
 .El
 .It Ar none
+Do not sort entries.
 .El
 .Pp
-Fields starting with a capital letter will sort uppercase before lowercase:
-.Sq A
+.Ar sort_field Ap s
+starting with a capital letter will sort uppercase before lowercase
+.Po Sq A
 then
 .Sq B
 then
 .Sq a
 then
-.Sq b .
-Fields starting with a lowercase letter will mix them:
+.Sq b
+.Pc
+whilst those starting with a lowercase letter will mix them
+.Po
 .Sq A
 then
 .Sq a
 then
 .Sq B
 then
-.Sq b .
-.It Fl I , Fl Fl ignore-glob Ns = Ns Ar GLOB Ns Op | Ns Ar GLOB ...
-pipe
-.Pq Sq |
-seperated
-.Xr glob 7
-patterns of files to ignore.
-.It Fl Fl git-ignore
-ignore files mentioned in
+.Sq b
+.Pc .
+.It Fl -git-ignore
+Ignore files mentioned in
 .Xr gitignore 5 .
-.It Fl Fl group-directories-first
-list directories before other files.
-.It Fl D , Fl Fl only-dirs
-list only directories.
+.It Fl -group-directories-first
+List directories before other files.
 .El
-.Sh LONG VIEW OPTIONS
+.Ss Long View Options
 These options are available when running with
-.Fl l , Fl Fl long :
+.Fl l , Fl -long :
 .Bl -tag -width Ds
-.It Fl b , Fl Fl binary
-list file sizes with binary prefixes.
-.It Fl B , Fl Fl bytes
-list file sizes in bytes, without any prefixes.
-.It Fl g , Fl Fl group
-list each file's group.
-.It Fl h , Fl Fl header
-add a header row to each column.
-.It Fl H , Fl Fl links
-list each file's number of hard links.
-.It Fl i , Fl Fl inode
-list each file's inode number.
-.It Fl m , Fl Fl modified
-use the modified timestamp field.
-.It Fl S , Fl Fl blocks
-list each file's number of file system blocks.
-.It Fl t , Fl Fl time Ns = Ns Ar WORD
-which timestamp field to list;
-.Ar WORD
+.It Fl \&@ , Fl -extended
+List each file's extended attributes and sizes.
+.It Fl b , Fl -binary
+List file sizes with binary prefixes.
+.It Fl B , Fl -bytes
+List file sizes in bytes, without any prefixes.
+.It Fl g , Fl -group
+List each file's group.
+.It Fl h , Fl -header
+Add a header row to each column.
+.It Fl H , Fl -links
+List each file's number of hard links.
+.It Fl i , Fl -inode
+List each file's inode number.
+.It Fl m , Fl -modified
+Use the modified timestamp field.
+.It Fl S , Fl -blocks
+List each file's number of file system blocks.
+.It Fl t Ar field , Fl -time Ns = Ns Ar field
+Which timestamp field to list;
+.Ar field
 can be
 .Sq Ar modified ,
 .Sq Ar accessed
 or
 .Sq Ar created .
-.It Fl Fl time-style Ns = Ns Ar STYLE
-how to format timestamps;
-.Ar STYLE
-can be
-.Ar default
-.Pq Sq %d %b %H:%M ,
-.Ar iso
-.Po
-.So %m-%d %H:%M Sc for entries modified within the current year,
-.So %Y-%m-%d Sc for older entries
-.Pc ,
-.Ar long-iso
-.Pq Sq %Y-%m-%d %H:%M
-or
-.Ar full-iso
-.Pq Sq %Y-%m-%d %H:%M:%S.%N %z .
-.It Fl u , Fl Fl accessed
-use the accessed timestamp field.
-.It Fl U , Fl Fl created
-use the created timestamp field.
-.It Fl \&@ , extended
-list each file's extended attributes and sizes
-.It Fl Fl git
-list each file's
+.It Fl u , Fl -accessed
+Use the accessed timestamp field.
+.It Fl U , Fl -created
+Use the created timestamp field.
+.It Fl -git
+List each file's
 .Xr git-status 1 ,
 if tracked.
+.It Fl -time-style Ns = Ns Ar style
+How to format timestamps;
+.Ar style
+can be:
+.Bl -tag -width Ds
+.It Ar default
+.Dq dd mmm hh:mm
+.It Ar iso
+.Dq mm-dd HH:MM
+for entries modified within the current year,
+.Dq ccyy-mm-dd
+for older entries
+.It Ar long-iso
+.Dq ccyy-mm-dd HH:MM
+.It Ar full-iso
+.Dq ccyy-mm-dd HH:MM:SS.nnnnnnnnn +/-hhmm .
+.El
 .El
 .Sh ENVIRONMENT
 .Nm
 recognizes the following environment variables:
 .Bl -tag -width Ds
 .It Ev COLUMNS
-Overrides the width of the terminal, in characters.
-For example:
-.Dl Ev COLUMNS Ns = Ns Ar 80
-will show a grid view with a maximum width of 80 characters.
+Sets the maximum character width for
+.Nm Ap s
+output,
+e.g, a value of 80 will show a grid view with a maximum width of
+80 characters.
 This option won't do anything when
 .Nm exa Ns 's
-output doesnt wrap, such as when using the
-.Fl Fl long
-or
+output doesn't wrap, such as when using the
 .Fl l
 option.
-.It Ev EXA_SRICT
+.It Ev EXA_STRICT
 Enables
 .Em strict mode ,
 which will make
 .Nm
 error when two options are incompatible.
-Options can override each other going right-to-left so that
+By default, options can override each other going right-to-left so that
 .Nm
-can be aliased:
+can be aliased.
+For example, setting:
 .Pp
-setting
-.Dl Nm alias Nm Ns = Ns Ql Nm Fl Fl sort Ns = Ns Ar ext Ns
-then running
-.Dl $ Nm Fl Fl sort Ns = Ns Ar size
+.Dl alias exa='exa -s ext'
+.Pp
+then running:
+.Pp
+.Dl $ exa -s size
+.Pp
 will run
-.Dl Nm Fl Fl sort Ns = Ns Ar ext Fl Fl sort Ns = Ns Ar size ,
-with the sort field specified by the user overriding the sort field specified
-by the alias.
+.Pp
+.Dl exa -s ext -s size
+.Pp
+with the sort field specified by the user overriding the sort field
+specified by the alias.
+.Pp
 In
 .Em strict mode ,
 the two options will not cooperate, and exa will error.
-.Pp
-This option is intended for use with automated scripts and situations where
-you want to use the right command.
+This option is intended for use with automated scripts and situations
+where you want to use the right command.
 .It Ev EXA_GRID_ROWS
 Limits the grid-details view set by
-.Fl Fl grid
+.Fl G
 and
-.Fl Fl long ,
-so that it is only activated when at least the given number of rows of output
-would be generated.
-With widescreen displays, it is possible for the grid to look very wide and
-sparse, on just one or two lines with none of the columns lining up.
-By specifying a minimum number of rows, you can only use the view if it's
-going to be worth using.
+.Fl l ,
+so that it is only activated when at least the given number of rows of
+output would be generated.
+With widescreen displays, it is possible for the grid to look very wide
+and sparse, on just one or two lines with none of the columns lining up.
+By specifying a minimum number of rows,
+you can only use the view if it's going to be worth using.
 .It Ev LS_COLORS , EXA_COLORS
 Colorize entries according to specific patterns.
 See
 .Xr exa-colors 5
 for more info.
 .El
+.Sh EXIT STATUS
+The
+.Nm
+utility exits with one of the following values:
+.Bl -tag -width Ds -compact
+.It Li 0
+No fatal errors occurred.
+.It Li 1
+At least one internal error occurred.
+.It Li 2
+At least one given file does not exist.
+.It Li 3
+.Nm
+was invoked with an unknown argument,
+or an argument was overridden with
+.Em strict mode
+enabled.
+.El
 .Sh EXAMPLES
-List the contents of the current working directory, with entries sorted by
-largest size decending:
+List the contents of the current working directory, with entries sorted
+by largest size decending:
 .Pp
-.Dl $ Nm Fl Fl reverse Fl Fl sort Ns = Ns Ar size
+.Dl $ exa -rs size
 .Pp
 Display a tree of entries, three levels deep:
 .Pp
-.Dl $ Nm Fl Fl long Fl Fl tree Fl Fl level Ns = Ns Ar 3
+.Dl $ exa -lT -L 3
 .Sh SEE ALSO
 .Xr ls 1 ,
 .Xr tree 1
@@ -268,4 +333,4 @@ is maintained by
 .An Benjamin So ogham Sc Sago
 with contributions from many others.
 You can view the full list at
-.Aq Lk https://github.com/ogham/exa/graphs/contributors
+.Lk https://github.com/ogham/exa/graphs/contributors

--- a/contrib/man/exa.1
+++ b/contrib/man/exa.1
@@ -1,451 +1,263 @@
-.hy
-.TH "exa" "1" "2017\-07\-07" "exa 0.7.0" ""
-.SH NAME
-.PP
-exa \- a modern replacement for ls
-.SH SYNOPSIS
-.PP
-exa [\f[I]options\f[]] [\f[I]files\f[]]...
-.SH DESCRIPTION
-.PP
-\f[C]exa\f[] is a modern replacement for \f[C]ls\f[].
-It uses colours for information by default, helping you distinguish
-between many types of files, such as whether you are the owner, or in
-the owning group.
-It also has extra features not present in the original \f[C]ls\f[], such
-as viewing the Git status for a directory, or recursing into directories
-with a tree view.
-.SH DISPLAY OPTIONS
-.TP
-.B \-1, \-\-oneline
-display one entry per line
-.RS
-.RE
-.TP
-.B \-G, \-\-grid
-display entries as a grid (default)
-.RS
-.RE
-.TP
-.B \-l, \-\-long
-display extended file metadata as a table
-.RS
-.RE
-.TP
-.B \-x, \-\-across
-sort the grid across, rather than downwards
-.RS
-.RE
-.TP
-.B \-R, \-\-recurse
-recurse into directories
-.RS
-.RE
-.TP
-.B \-T, \-\-tree
-recurse into directories as a tree
-.RS
-.RE
-.TP
-.B \-F, \-\-classify
-display type indicator by file names
-.RS
-.RE
-.TP
-.B \-\-color, \-\-colour=\f[I]WHEN\f[]
-when to use terminal colours (always, automatic, never)
-.RS
-.RE
-.TP
-.B \-\-color-scale, \-\-colour-scale
-highlight levels of file sizes distinctly
-.RS
-.RE
-.SH FILTERING AND SORTING OPTIONS
-.TP
-.B \-a, \-\-all
-show hidden and \[aq]dot\[aq] files.
-Use this twice to also show the \f[C].\f[] and \f[C]..\f[] directories.
-.RS
-.RE
-.TP
-.B \-d, \-\-list\-dirs
-list directories like regular files
-.RS
-.RE
-.TP
-.B \-L, \-\-level=\f[I]DEPTH\f[]
-limit the depth of recursion
-.RS
-.RE
-.TP
-.B \-r, \-\-reverse
-reverse the sort order
-.RS
-.RE
-.TP
-.B \-s, \-\-sort=\f[I]SORT_FIELD\f[]
-which field to sort by.
-Valid fields are name, Name, extension, Extension, size, modified, accessed, created, inode, type, and none.
-The modified field has the aliases date, time, and newest, and its reverse order has the aliases age and oldest.
-Fields starting with a capital letter will sort uppercase before lowercase: 'A' then 'B' then 'a' then 'b'.
-Fields starting with a lowercase letter will mix them: 'A' then 'a' then 'B' then 'b'.
-.RS
-.RE
-.TP
-.B \-I, \-\-ignore\-glob=\f[I]GLOBS\f[]
-Glob patterns, pipe-separated, of files to ignore
-.RS
-.RE
-.TP
-.B \-\-git\-ignore
-ignore files mentioned in '.gitignore'
-.RS
-.RE
-.TP
-.B \-\-group\-directories\-first
-list directories before other files
-.RS
-.RE
-.TP
-.B \-D, \-\-only\-dirs
-list only directories
-.RS
-.RE
-.SH LONG VIEW OPTIONS
-.PP
-These options are available when running with \f[C]\-\-long\f[]
-(\f[C]\-l\f[]):
-.TP
-.B \-b, \-\-binary
-list file sizes with binary prefixes
-.RS
-.RE
-.TP
-.B \-B, \-\-bytes
-list file sizes in bytes, without any prefixes
-.RS
-.RE
-.TP
-.B \-g, \-\-group
-list each file\[aq]s group
-.RS
-.RE
-.TP
-.B \-h, \-\-header
-add a header row to each column
-.RS
-.RE
-.TP
-.B \-H, \-\-links
-list each file\[aq]s number of hard links
-.RS
-.RE
-.TP
-.B \-i, \-\-inode
-list each file\[aq]s inode number
-.RS
-.RE
-.TP
-.B \-m, \-\-modified
-use the modified timestamp field
-.RS
-.RE
-.TP
-.B \-S, \-\-blocks
-list each file\[aq]s number of file system blocks
-.RS
-.RE
-.TP
-.B \-t, \-\-time=\f[I]WORD\f[]
-which timestamp field to list (modified, accessed, created)
-.RS
-.RE
-.TP
-.B \-\-time\-style=\f[I]STYLE\f[]
-how to format timestamps (default, iso, long-iso, full-iso)
-.RS
-.RE
-.TP
-.B \-u, \-\-accessed
-use the accessed timestamp field
-.RS
-.RE
-.TP
-.B \-U, \-\-created
-use the created timestamp field
-.RS
-.RE
-.TP
-.B \-\@, \-\-extended
-list each file\[aq]s extended attributes and sizes
-.RS
-.RE
-.TP
-.B \-\-git
-list each file\[aq]s Git status, if tracked
-.RS
-.RE
-.SH EXAMPLES
-.PP
-To display a list of files, with the largest at the top:
-.IP
-.nf
-\f[C]
-exa\ \-\-reverse\ \-\-sort=size
-\f[]
-.fi
-.PP
-To display a tree of files, three levels deep:
-.IP
-.nf
-\f[C]
-exa\ \-\-long\ \-\-tree\ \-\-level=3
-\f[]
-.fi
-.SH ENVIRONMENT VARIABLES
-.PP
-exa responds to the following environment variables:
-.SS \f[C]COLUMNS\f[]
-.PP
-Overrides the width of the terminal, in characters.
-For example, \f[C]COLUMNS=80\ exa\f[] will show a grid view with a
-maximum width of 80 characters.
-.PP
-This option won\[aq]t do anything when exa\[aq]s output doesn\[aq]t
-wrap, such as when using the \f[C]\-\-long\f[] view.
-.SS \f[C]EXA_STRICT\f[]
-.PP
-Enables \f[I]strict mode\f[], which will make exa error when two
-command\-line options are incompatible.
-Usually, options can override each other going right\-to\-left on the
-command line, so that exa can be given aliases: creating an alias
-\f[C]exa=exa\ \-\-sort=ext\f[] then running \f[C]exa\ \-\-sort=size\f[]
-with that alias will run \f[C]exa\ \-\-sort=ext\ \-\-sort=size\f[], and
-the sorting specified by the user will override the sorting specified by
-the alias.
-In strict mode, the two options will not co\-operate, and exa will
-error.
-.PP
-This option is intended for use with automated scripts and other
-situations where you want to be \f[I]certain\f[] you\[aq]re typing in
-the right command.
-.SS \f[C]EXA_GRID_ROWS\f[]
-.PP
-Limits the grid\-details view (\f[C]exa\ \-\-grid\ \-\-long\f[]) so
-it\[aq]s only activated when at least the given number of rows of output
-would be generated.
-With widescreen displays, it\[aq]s possible for the grid to look very
-wide and sparse, on just one or two lines with none of the columns
-lining up.
-By specifying a minimum number of rows, you can only use the view if
-it\[aq]s going to be worth using.
-.SS \f[C]LS_COLORS\f[] and \f[C]EXA_COLORS\f[]
-.PP
-The \f[C]EXA_COLORS\f[] variable is the traditional way of customising
-the colours used by \f[C]ls\f[].
-.PP
-You can use the \f[C]dircolors\f[] program to generate a script that
-sets the variable from an input file, or if you don\[aq]t mind editing
-long strings of text, you can just type it out directly.
-These variables have the following structure:
-.IP \[bu] 2
-A list of key\-value pairs separated by \f[C]=\f[], such as
-\f[C]*.txt=32\f[].
-.IP \[bu] 2
-Multiple ANSI formatting codes are separated by \f[C];\f[], such as
-\f[C]*.txt=32;1;4\f[].
-.IP \[bu] 2
-Finally, multiple pairs are separated by \f[C]:\f[], such as
-\f[C]*.txt=32:*.mp3=1;35\f[].
-.PP
-The key half of the pair can either be a two\-letter code or a file
-glob, and anything that\[aq]s not a valid code will be treated as a
-glob, including keys that happen to be two letters long.
-.PP
-\f[C]LS_COLORS\f[] can use these ten codes:
-.IP \[bu] 2
-\f[B]di\f[], directories
-.IP \[bu] 2
-\f[B]ex\f[], executable files
-.IP \[bu] 2
-\f[B]fi\f[], regular files
-.IP \[bu] 2
-\f[B]pi\f[], named pipes
-.IP \[bu] 2
-\f[B]so\f[], sockets
-.IP \[bu] 2
-\f[B]bd\f[], block devices
-.IP \[bu] 2
-\f[B]cd\f[], character devices
-.IP \[bu] 2
-\f[B]ln\f[], symlinks
-.IP \[bu] 2
-\f[B]or\f[], symlinks with no target
-.PP
-\f[C]EXA_COLORS\f[] can use many more:
-.IP \[bu] 2
-\f[B]ur\f[], the user\-read permission bit
-.IP \[bu] 2
-\f[B]uw\f[], the user\-write permission bit
-.IP \[bu] 2
-\f[B]ux\f[], the user\-execute permission bit for regular files
-.IP \[bu] 2
-\f[B]ue\f[], the user\-execute for other file kinds
-.IP \[bu] 2
-\f[B]gr\f[], the group\-read permission bit
-.IP \[bu] 2
-\f[B]gw\f[], the group\-write permission bit
-.IP \[bu] 2
-\f[B]gx\f[], the group\-execute permission bit
-.IP \[bu] 2
-\f[B]tr\f[], the others\-read permission bit
-.IP \[bu] 2
-\f[B]tw\f[], the others\-write permission bit
-.IP \[bu] 2
-\f[B]tx\f[], the others\-execute permission bit
-.IP \[bu] 2
-\f[B]su\f[], setuid, setgid, and sticky permission bits for files
-.IP \[bu] 2
-\f[B]sf\f[], setuid, setgid, and sticky for other file kinds
-.IP \[bu] 2
-\f[B]xa\f[], the extended attribute indicator
-.IP \[bu] 2
-\f[B]sn\f[], the numbers of a file\[aq]s size
-.IP \[bu] 2
-\f[B]sb\f[], the units of a file\[aq]s size
-.IP \[bu] 2
-\f[B]df\f[], a device\[aq]s major ID
-.IP \[bu] 2
-\f[B]ds\f[], a device\[aq]s minor ID
-.IP \[bu] 2
-\f[B]uu\f[], a user that\[aq]s you
-.IP \[bu] 2
-\f[B]un\f[], a user that\[aq]s someone else
-.IP \[bu] 2
-\f[B]gu\f[], a group that you belong to
-.IP \[bu] 2
-\f[B]gn\f[], a group you aren\[aq]t a member of
-.IP \[bu] 2
-\f[B]lc\f[], a number of hard links
-.IP \[bu] 2
-\f[B]lm\f[], a number of hard links for a regular file with at least two
-.IP \[bu] 2
-\f[B]ga\f[], a new flag in Git
-.IP \[bu] 2
-\f[B]gm\f[], a modified flag in Git
-.IP \[bu] 2
-\f[B]gd\f[], a deleted flag in Git
-.IP \[bu] 2
-\f[B]gv\f[], a renamed flag in Git
-.IP \[bu] 2
-\f[B]gt\f[], a modified metadata flag in Git
-.IP \[bu] 2
-\f[B]xx\f[], "punctuation", including many background UI elements
-.IP \[bu] 2
-\f[B]da\f[], a file\[aq]s date
-.IP \[bu] 2
-\f[B]in\f[], a file\[aq]s inode number
-.IP \[bu] 2
-\f[B]bl\f[], a file\[aq]s number of blocks
-.IP \[bu] 2
-\f[B]hd\f[], the header row of a table
-.IP \[bu] 2
-\f[B]lp\f[], the path of a symlink
-.IP \[bu] 2
-\f[B]cc\f[], an escaped character in a filename
-.IP \[bu] 2
-\f[B]bO\f[], the overlay style for broken symlink paths
-.PP
-Values in \f[C]EXA_COLORS\f[] override those given in
-\f[C]LS_COLORS\f[], so you don\[aq]t need to re\-write an existing
-\f[C]LS_COLORS\f[] variable with proprietary extensions.
-.PP
-Unlike some versions of \f[C]ls\f[], the given ANSI values must be valid
-colour codes: exa won\[aq]t just print out whichever characters are
-given.
-The codes accepted by exa are:
-.IP \[bu] 2
-\f[C]1\f[], for bold
-.IP \[bu] 2
-\f[C]4\f[], for underline
-.IP \[bu] 2
-\f[C]31\f[], for red text
-.IP \[bu] 2
-\f[C]32\f[], for green text
-.IP \[bu] 2
-\f[C]33\f[], for yellow text
-.IP \[bu] 2
-\f[C]34\f[], for blue text
-.IP \[bu] 2
-\f[C]35\f[], for purple text
-.IP \[bu] 2
-\f[C]36\f[], for cyan text
-.IP \[bu] 2
-\f[C]37\f[], for white text
-.IP \[bu] 2
-\f[C]38;5;\f[]\f[I]\f[C]nnn\f[]\f[], for a colour from 0 to 255 (replace
-the \f[I]nnn\f[] part)
-.PP
-Many terminals will treat bolded text as a different colour, or at least
-provide the option to.
-.PP
-exa provides its own built\-in set of file extension mappings that cover
-a large range of common file extensions, including documents, archives,
-media, and temporary files.
-Any mappings in the environment variables will override this default
-set: running exa with \f[C]LS_COLORS="*.zip=32"\f[] will turn zip files
-green but leave the colours of other compressed files alone.
-.PP
-You can also disable this built\-in set entirely by including a
-\f[C]reset\f[] entry at the beginning of \f[C]EXA_COLORS\f[].
-So setting \f[C]EXA_COLORS="reset:*.txt=31"\f[] will highlight only text
-files; setting \f[C]EXA_COLORS="reset"\f[] will highlight nothing.
-.SS Examples
-.IP \[bu] 2
-Disable the "current user" highlighting: \f[C]EXA_COLORS="uu=0:gu=0"\f[]
-.IP \[bu] 2
-Turn the date column green: \f[C]EXA_COLORS="da=32"\f[]
-.IP \[bu] 2
-Highlight Vagrantfiles: \f[C]EXA_COLORS="Vagrantfile=1;4;33"\f[]
-.IP \[bu] 2
-Override the existing zip colour: \f[C]EXA_COLORS="*.zip=38;5;125"\f[]
-.IP \[bu] 2
-Markdown files a shade of green, log files a shade of grey:
-\f[C]EXA_COLORS="*.md=38;5;121:*.log=38;5;248"\f[]
-.SS BUILT\-IN EXTENSIONS
-.IP \[bu] 2
-"Immediate" files are the files you should look at when downloading and
-building a project for the first time: READMEs, Makefiles, Cargo.toml,
-and others.
-They\[aq]re highlighted in yellow and underlined.
-.IP \[bu] 2
-Images (png, jpeg, gif) are purple.
-.IP \[bu] 2
-Videos (mp4, ogv, m2ts) are a slightly purpler purple.
-.IP \[bu] 2
-Music (mp3, m4a, ogg) is a deeper purple.
-.IP \[bu] 2
-Lossless music (flac, alac, wav) is deeper than \f[I]that\f[] purple.
-In general, most media files are some shade of purple.
-.IP \[bu] 2
-Cryptographic files (asc, enc, p12) are a faint blue.
-.IP \[bu] 2
-Documents (pdf, doc, dvi) are a less faint blue.
-.IP \[bu] 2
-Compressed files (zip, tgz, Z) are red.
-.IP \[bu] 2
-Temporary files (tmp, swp, ~) are grey.
-.IP \[bu] 2
-Compiled files (class, o, pyc) are faint orange.
-A file is also counted as compiled if it uses a common extension and is
-in the same directory as one of its source files: \[aq]styles.css\[aq]
-will count as compiled when next to \[aq]styles.less\[aq] or
-\[aq]styles.sass\[aq], and \[aq]scripts.js\[aq] when next to
-\[aq]scripts.ts\[aq] or \[aq]scripts.coffee\[aq].
-.SH AUTHOR
-.PP
-\f[C]exa\f[] is maintained by Benjamin \[aq]ogham\[aq] Sago and many
-other contributors.
-You can view the full list at
-<https://github.com/ogham/exa/graphs/contributors>.
+.Dd December 23, 2018
+.Dt EXA 1
+.Os
+.Sh NAME
+.Nm exa
+.Nd list directory contents
+.Sh SYNOPSIS
+.Nm
+.Op Ar OPTIONS
+.Op Ar
+.Sh DESCRIPTION
+.Nm
+is a modern replacement for
+.Xr ls 1 .
+It colors information by default to distinguish between filetypes,
+such as whether you are the owner or in the owning group. It also has
+features not present in the original
+.Xr ls ,
+such as viewing the
+.Xr git-status 1
+for a directory or recursing into directories with a tree view.
+.Sh DISPLAY OPTIONS
+.Bl -tag -width Ds
+.It Fl 1 , Fl Fl oneline
+display one entry per line.
+.It Fl G , Fl Fl grid
+display entries as a grid
+.Pq default .
+.It Fl l , Fl Fl long
+display extended file metadata as a table.
+.It Fl x , Fl Fl across
+sort the grid across, rather than downwards.
+.It Fl R , Fl Fl recurse
+recurse into directories.
+.It Fl T , Fl Fl tree
+recurse into directories as a tree.
+.It Fl F , Fl Fl classify
+display type indicator by file names.
+.It Fl Fl color Ns = Ns Ar WHEN , Fl Fl colour Ns = Ns Ar WHEN
+colorize output;
+.Ar WHEN
+can be
+.Sq Ar always ,
+.Sq Ar automatic
+.Pq default
+or
+.Sq Ar never .
+.It Fl Fl color-scale , Fl Fl colour-scale
+highlight levels of file sizes distinctly.
+.El
+.Sh FILTERING AND SORTING OPTIONS
+.Bl -tag -width Ds
+.It Fl a , Fl Fl all
+include entries that are hidden or begin with a dot
+.Pq Sq \&. .
+Use this twice to also include the
+.Sq \&.
+and 
+.Sq ..
+directories.
+.It Fl d , Fl Fl listdirs
+list directories like regular files.
+.It Fl L , Fl Fl level Ns = Ns Ar DEPTH
+limit the depth of recursion.
+.It Fl r , Fl Fl reverse
+reverse the sort order.
+.It Fl s , Fl Fl sort Ns = Ns Ar SORT_FIELD
+which field to sort entries by.
+.Ar SORT_FIELD
+can be:
+.Bl -bullet
+.It
+.Ar name , Name
+\(em sort entries in alphabetical order.
+.It
+.Ar extension , Extension
+\(em sort entries by their file extension in alphabetical order. Entries
+without file extensions precede those that do.
+.It
+.Ar size
+\(em sort entries by their file size.
+.It
+.Ar modified
+\(em sort entries by modification date ascending.
+.It
+.Ar accessed
+\(em sort entries by access date ascending.
+.It
+.Ar created
+.It
+.Ar inode
+\(em sort entries by inode modification.
+.It
+.Ar type
+.It
+.Ar none
+.El
+The
+.Ar modified
+field has the aliases
+.Ar date , time
+and 
+.Ar newest ,
+and its reverse order has the aliases
+.Ar age
+and
+.Ar oldest .
+Fields starting with a capital letter will sort uppercase before lowercase:
+.Sq A
+then 
+.Sq B
+then
+.Sq a
+then
+.Sq b .
+Fields starting with a lowercase letter will mix them:
+.Sq A
+then
+.Sq a
+then
+.Sq B
+then
+.Sq b .
+.It Fl I , Fl Fl ignore-glob Ns = Ns Ar GLOB Ns Op | Ns Ar GLOB ...
+pipe
+.Pq Sq |
+seperated
+.Xr glob 7
+patterns of files to ignore.
+.It Fl Fl git-ignore
+ignore files mentioned in
+.Xr gitignore 5 .
+.It Fl Fl group-directories-first
+list directories before other files.
+.It Fl D , Fl Fl only-dirs
+list only directories.
+.El
+.Sh LONG VIEW OPTIONS
+These options are available when running with
+.Fl l , Fl Fl long :
+.Bl -tag -width Ds
+.It Fl b , Fl Fl binary
+list file sizes with binary prefixes.
+.It Fl B , Fl Fl bytes
+list file sizes in bytes, without any prefixes.
+.It Fl g , Fl Fl group
+list each file's group.
+.It Fl h , Fl Fl header
+add a header row to each column.
+.It Fl H , Fl Fl links.
+list each file's number of hard links.
+.It Fl i , Fl Fl inode
+list each file's inode number.
+.It Fl m , Fl Fl modified
+use the modified timestamp field.
+.It Fl S , Fl Fl blocks
+list each file's number of file system blocks.
+.It Fl t , Fl Fl time Ns = Ns Ar WORD
+which timestamp field to list;
+.Ar WORD
+can be
+.Sq Ar modified ,
+.Sq Ar accessed
+or
+.Sq Ar created .
+.It Fl Fl time-style Ns = Ns Ar STYLE
+how to format timestamps;
+.Ar STYLE
+can be
+.Ar default
+.Pq Sq %d %b %H:%M ,
+.Ar iso
+.Po
+.So %m-%d %H:%M Sc for entries modified within the current year,
+.So %Y-%m-%d Sc for older entries
+.Pc ,
+.Ar long-iso
+.Pq Sq %Y-%m-%d %H:%M
+or
+.Ar full-iso
+.Pq Sq %Y-%m-%d %H:%M:%S.%N %z .
+.It Fl u , Fl Fl accessed
+use the accessed timestamp field.
+.It Fl U , Fl Fl created
+use the created timestamp field.
+.It Fl \&@, extended
+list each file's extended attributes and sizes
+.It Fl Fl git
+list each file's
+.Xr git-status 1 ,
+if tracked.
+.El
+.Sh ENVIRONMENT
+.Nm
+recognizes the following environment variables:
+.Bl -tag -width Ds
+.It Ev COLUMNS
+Overrides the width of the terminal, in characters. For example:
+.Dl Ev COLUMNS Ns = Ns Ar 80
+will show a grid view with a maximum width of 80 characters. This option
+won't do anything when
+.Nm exa Ns 's
+output doesnt wrap, such as when using the
+.Fl Fl Fl long
+or
+.Fl l
+option.
+.It Ev EXA_SRICT
+Enables
+.Em strict mode ,
+which will make
+.Nm
+error when two options are incompatible. Options can override each other
+going right-to-left so that
+.Nm
+can be aliased:
+.Pp
+setting
+.Dl Nm alias Nm Ns = Ns Ql Nm Fl Fl sort Ns = Ns Ar ext Ns
+then running
+.Dl $ Nm Fl Fl sort Ns = Ns Ar size
+will run
+.Dl Nm Fl Fl sort Ns = Ns Ar ext Fl Fl sort Ns = Ns Ar size ,
+with the sort field specified by the user overriding the sort field specified
+by the alias. In
+.Em strict mode ,
+the two options will not cooperate, and exa will error.
+.Pp
+This option is intended for use with automated scripts and situations where
+you want to use the right command.
+.It Ev EXA_GRID_ROWS
+Limits the grid-details view set by
+.Fl Fl grid
+and
+.Fl Fl long ,
+so that it is only activated when at least the given number of rows of
+output would be generated. With widescreen displays, it is possible for
+the grid to look very wide and sparse, on just one or two lines with none
+of the columns lining up. By specifying a minimum number of rows, you can
+only use the view if it's going to be worth using.
+.It Ev LS_COLORS , EXA_COLORS
+Colorize entries according to specific patterns. See
+.Xr exa-colors 5
+for more info.
+.El
+.Sh EXAMPLES
+List the contents of the current working directory, with entries sorted by
+largest size decending:
+.Pp
+.Dl $ Nm Fl Fl reverse Fl Fl sort Ns = Ns Ar size
+.Pp
+Display a tree of entries, three levels deep:
+.Pp
+.Dl $ Nm Fl Fl long Fl Fl tree Fl Fl level Ns = Ns Ar 3
+.Sh SEE ALSO
+.Xr ls 1 ,
+.Xr tree 1 .
+.Sh AUTHOR
+.Nm
+is written and maintained by
+.An Benjamin So ogham Sc Sago
+with contributions from many others. You can view the full list at:
+.Lk https://github.com/ogham/exa/graphs/contributors


### PR DESCRIPTION
Since 0.9 is soon to release and exa is now packaged on various *BSDs, I thought I'd take the time to rewrite the existing man pages in [mdoc(7)](https://man.openbsd.org/mdoc.7) format. Right now I've split the info about `(LS|EXA)_COLORS` into its own page, as it is extremely info dense and large enough to be it's own reference. I also want to properly document the syntax of the 4/8/24 bit color escape codes by referencing the standards themselves, but this may take some time. In general I tried to cut unneeded text and add more references/fix formatting issues. When this is finished I'll rebase my patches on a fresh fork and have it be one singular commit.

There are still some things yet to do:

## exa.1
- [ ] Properly document how each `SORT_FIELD` works.
- [ ] Add more examples (maybe).

## exa-colors.5
- [ ] Add full syntax for each color form.
- [ ] Comb through ECMA-48 and ISO 8613-6 for extra info.