### PR TITLE
Improve zsh completion

### DIFF
--- a/contrib/completions.zsh
+++ b/contrib/completions.zsh
@@ -1,9 +1,17 @@
 #compdef exa
 
+# Save this file as _exa in /usr/local/share/zsh/site-functions or in any
+# other folder in $fpath.  E. g. save it in a folder called ~/.zfunc and add a
+# line containing `fpath=(~/.zfunc $fpath)` somewhere before `compinit` in your
+# ~/.zshrc.
+
 __exa() {
-    _arguments \
-        "(- 1 *)"{-v,--version}"[Show version of exa]" \
-        "(- 1 *)"{-\?,--help}"[Show list of command-line options]" \
+    # Give completions using the `_arguments` utility function with
+    # `-s` for option stacking like `exa -ab` for `exa -a -b` and
+    # `-S` for delimiting options with `--` like in `exa -- -a`.
+    _arguments -s -S \
+        "(- *)"{-v,--version}"[Show version of exa]" \
+        "(- *)"{-'\?',--help}"[Show list of command-line options]" \
         {-1,--oneline}"[Display one entry per line]" \
         {-l,--long}"[Display extended file metadata as a table]" \
         {-G,--grid}"[Display entries as a grid]" \
@@ -11,15 +19,15 @@ __exa() {
         {-R,--recurse}"[Recurse into directories]" \
         {-T,--tree}"[Recurse into directories as a tree]" \
         {-F,--classify}"[Display type indicator by file names]" \
-        {--color,--colour}"[When to use terminal colours]" \
-        {--color,--colour}-scale"[Highlight levels of file sizes distinctly]" \
+        --colo{,u}r"[When to use terminal colours]" \
+        --colo{,u}r-scale"[Highlight levels of file sizes distinctly]" \
         --group-directories-first"[Sort directories before other files]" \
         --git-ignore"[Ignore files mentioned in '.gitignore']" \
         {-a,--all}"[Show hidden and 'dot' files]" \
         {-d,--list-dirs}"[List directories like regular files]" \
         {-L,--level}"+[Limit the depth of recursion]" \
         {-r,--reverse}"[Reverse the sort order]" \
-        {-s,--sort}"[Which field to sort by]:(sort field):(accessed age created date extension Extension filename Filename inode modified oldest name Name newest none size time type)" \
+        {-s,--sort}="[Which field to sort by]:(sort field):(accessed age created date extension Extension filename Filename inode modified oldest name Name newest none size time type)" \
         {-I,--ignore-glob}"[Ignore files that match these glob patterns]" \
         {-b,--binary}"[List file sizes with binary prefixes]" \
         {-B,--bytes}"[List file sizes in bytes, without any prefixes]" \
@@ -29,8 +37,8 @@ __exa() {
         {-i,--inode}"[List each file's inode number]" \
         {-m,--modified}"[Use the modified timestamp field]" \
         {-S,--blocks}"[List each file's number of filesystem blocks]" \
-        {-t,--time}"[Which time field to show]:(time field):(accessed created modified)" \
-        --time-style"[How to format timestamps]:(time style):(default iso long-iso full-iso)" \
+        {-t,--time}="[Which time field to show]:(time field):(accessed created modified)" \
+        --time-style="[How to format timestamps]:(time style):(default iso long-iso full-iso)" \
         {-u,--accessed}"[Use the accessed timestamp field]" \
         {-U,--created}"[Use the created timestamp field]" \
         --git"[List each file's Git status, if tracked]" \


### PR DESCRIPTION
Make the `zsh` completion support option stacking as in `exa -al` and delimiting with `--` as  in `exa -- -a`. Also made the completion allow separating arguments for options with ` ` or `=` as in `exa --sort=name`.

For convenience added a comment to the beginning of the file, saying where to put it.