### PR TITLE
Distinguish Bundles from Directories

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -105,6 +105,12 @@ impl<'dir> File<'dir> {
         self.metadata.is_dir()
     }
 
+    /// Whether this file is a 'bundle'. That is, a directory with a file 
+    /// extension.
+    pub fn is_bundle(&self) -> bool {
+        self.is_directory() && File::ext(&self.path).is_some()
+    }
+ 
     /// Whether this file is a directory, or a symlink pointing to a directory.
     pub fn points_to_directory(&self) -> bool {
         if self.is_directory() {

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -253,6 +253,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
 
     fn kind_style(&self) -> Option<Style> {
         Some(match self.file {
+            f if f.is_bundle()           => self.colours.bundle(),
             f if f.is_directory()        => self.colours.directory(),
             f if f.is_executable_file()  => self.colours.executable_file(),
             f if f.is_link()             => self.colours.symlink(),

--- a/src/output/render/filetype.rs
+++ b/src/output/render/filetype.rs
@@ -21,6 +21,7 @@ impl f::Type {
 
 pub trait Colours {
     fn normal(&self) -> Style;
+    fn bundle(&self) -> Style;
     fn directory(&self) -> Style;
     fn pipe(&self) -> Style;
     fn symlink(&self) -> Style;

--- a/src/style/colours.rs
+++ b/src/style/colours.rs
@@ -34,6 +34,7 @@ pub struct Colours {
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct FileKinds {
     pub normal: Style,
+    pub bundle: Style,
     pub directory: Style,
     pub symlink: Style,
     pub pipe: Style,
@@ -116,6 +117,7 @@ impl Colours {
 
             filekinds: FileKinds {
                 normal:       Style::default(),
+                bundle:       Cyan.bold(),
                 directory:    Blue.bold(),
                 symlink:      Cyan.normal(),
                 pipe:         Yellow.normal(),
@@ -312,6 +314,7 @@ impl render::BlocksColours for Colours {
 
 impl render::FiletypeColours for Colours {
     fn normal(&self)       -> Style { self.filekinds.normal }
+    fn bundle(&self)       -> Style { self.filekinds.bundle }
     fn directory(&self)    -> Style { self.filekinds.directory }
     fn pipe(&self)         -> Style { self.filekinds.pipe }
     fn symlink(&self)      -> Style { self.filekinds.symlink }


### PR DESCRIPTION
On some platforms, like macOS, directories with file extensions are displayed differently to users because they represent opaque file-like containers.  Distinguish these from plain directories in the output of this tool as well.