### PR TITLE
Add threading around std::fs::symlink_metadata

### DIFF
--- a/src/exa.rs
+++ b/src/exa.rs
@@ -28,7 +28,6 @@ use std::io::{stderr, Write, Result as IOResult};
 use std::path::{Component, PathBuf};
 
 use ansi_term::{ANSIStrings, Style};
-use scoped_threadpool::Pool;
 
 use fs::{Dir, File};
 use fs::feature::ignore::IgnoreCache;
@@ -125,25 +124,8 @@ impl<'args, 'w, W: Write + 'w> Exa<'args, 'w, W> {
         let mut dirs = Vec::new();
         let mut exit_status = 0;
 
-        // File::new calls std::fs::File::metadata, which on linux calls lstat. On some
-        // filesystems this can be very slow, but there's no async filesystem API
-        // so all we can do to hide the latency is use system threads.
-        let rx = {
-            let (tx, rx) = std::sync::mpsc::channel();
-            Pool::new(num_cpus::get().min(self.args.len()) as u32).scoped(|scoped| {
-                for arg in self.args.iter().cloned() {
-                    let tx = tx.clone();
-                    scoped.execute(move || {
-                        let f = File::new(PathBuf::from(arg), None, None);
-                        tx.send((arg, f)).unwrap();
-                    });
-                }
-            });
-            rx
-        };
-
-        for (file_path, file) in rx {
-            match file {
+        for file_path in &self.args {
+            match File::new(PathBuf::from(file_path), None, None) {
                 Err(e) => {
                     exit_status = 2;
                     writeln!(stderr(), "{:?}: {}", file_path, e)?;

--- a/src/exa.rs
+++ b/src/exa.rs
@@ -184,7 +184,7 @@ impl<'args, 'w, W: Write + 'w> Exa<'args, 'w, W> {
             }
 
             let mut children = Vec::new();
-            for file in dir.files(self.options.filter.dot_filter, self.ignore.as_ref(), pool) {
+            for file in dir.files(self.options.filter.dot_filter, self.ignore.as_ref(), Some(pool)) {
                 match file {
                     Ok(file)       => children.push(file),
                     Err((path, e)) => writeln!(stderr(), "[{}: {}]", path.display(), e)?,

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -283,7 +283,7 @@ impl<'a> Render<'a> {
             rows.push(row);
 
             if let Some(ref dir) = egg.dir {
-                for file_to_add in dir.files(self.filter.dot_filter, ignore, &mut Pool::new(num_cpus::get() as u32)) {
+                for file_to_add in dir.files(self.filter.dot_filter, ignore, None) {
                     match file_to_add {
                         Ok(f)          => files.push(f),
                         Err((path, e)) => errors.push((e, Some(path)))

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -283,7 +283,7 @@ impl<'a> Render<'a> {
             rows.push(row);
 
             if let Some(ref dir) = egg.dir {
-                for file_to_add in dir.files(self.filter.dot_filter, ignore) {
+                for file_to_add in dir.files(self.filter.dot_filter, ignore, &mut Pool::new(num_cpus::get() as u32)) {
                     match file_to_add {
                         Ok(f)          => files.push(f),
                         Err((path, e)) => errors.push((e, Some(path)))


### PR DESCRIPTION
The lstat system call that is used to implement `std::fs::symlink_metadata` is very slow on some filesystems; namely the lustre filesystem that I spend a lot of time on. For my large directories when the filesystem cache is cold (which is a quite common case for this kind of program) this brings the runtime of exa down from 14s to 0.5s.

I'd be quite interested to know if these changes have a measurable impact impact on anyone else's usage.