### PR TITLE
Add BUILD.bazel as another Bazel file type

### DIFF
--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -23,7 +23,7 @@ impl FileExtensions {
         file.name.to_lowercase().starts_with("readme") || file.name_is_one_of( &[
             "Makefile", "Cargo.toml", "SConstruct", "CMakeLists.txt",
             "build.gradle", "Rakefile", "Gruntfile.js",
-            "Gruntfile.coffee", "BUILD", "WORKSPACE", "build.xml"
+            "Gruntfile.coffee", "BUILD", "BUILD.bazel", "WORKSPACE", "build.xml"
         ])
     }
 


### PR DESCRIPTION
This seems to be preferred now, though both are valid.