### PR TITLE
Fix readme list rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ These options are available when running with --long (`-l`):
 - **-@**, **--extended**: list each file's extended attributes and sizes
 - **--git**: list each file's Git status, if tracked or ignored
 - **--time-style**: how to format timestamps
-
 - Valid **--color** options are **always**, **automatic**, and **never**.
 - Valid sort fields are **accessed**, **changed**, **created**, **extension**, **Extension**, **inode**, **modified**, **name**, **Name**, **size**, **type**, and **none**. Fields starting with a capital letter sort uppercase before lowercase. The modified field has the aliases **date**, **time**, and **newest**, while its reverse has the aliases **age** and **oldest**.
 - Valid time fields are **modified**, **changed**, **accessed**, and **created**.


### PR DESCRIPTION
List wasn't rendered properly since markdown is picky about empty lines in lists