### PR TITLE
Display icons when file names are too long for grid

### DIFF
--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -63,6 +63,9 @@ impl<'a> Render<'a> {
             // This isn’t *quite* the same as the lines view, which also
             // displays full link paths.
             for file in &self.files {
+                if self.opts.icons {
+                    write!(w, "{}", painted_icon(&file, &self.style))?;
+                }
                 let name_cell = self.style.for_file(file, self.colours).paint();
                 writeln!(w, "{}", name_cell.strings())?;
             }


### PR DESCRIPTION
Fixes #548