### PR TITLE
Added checks for modified/accessed/created metadata

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -5,7 +5,7 @@ use std::io::Error as IOError;
 use std::io::Result as IOResult;
 use std::os::unix::fs::{MetadataExt, PermissionsExt, FileTypeExt};
 use std::path::{Path, PathBuf};
-use std::time::{UNIX_EPOCH, Duration};
+use std::time::{SystemTime, UNIX_EPOCH, Duration};
 
 use fs::dir::Dir;
 use fs::fields as f;
@@ -327,8 +327,13 @@ impl<'dir> File<'dir> {
     }
 
     /// This file’s last modified timestamp.
+    /// If the file's time is invalid, assume it was modified today
     pub fn modified_time(&self) -> Duration {
-        self.metadata.modified().unwrap().duration_since(UNIX_EPOCH).unwrap()
+        if self.metadata.modified().unwrap() < UNIX_EPOCH {
+            return SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
+        } else {
+            return self.metadata.created().unwrap().duration_since(UNIX_EPOCH).unwrap()
+        }
     }
 
     /// This file’s last changed timestamp.
@@ -337,13 +342,23 @@ impl<'dir> File<'dir> {
     }
 
     /// This file’s last accessed timestamp.
+    /// If the file's time is invalid, assume it was accessed today
     pub fn accessed_time(&self) -> Duration {
-        self.metadata.accessed().unwrap().duration_since(UNIX_EPOCH).unwrap()
+        if self.metadata.modified().unwrap() < UNIX_EPOCH{
+            return SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
+        } else {
+            return self.metadata.created().unwrap().duration_since(UNIX_EPOCH).unwrap()
+        }
     }
 
     /// This file’s created timestamp.
+    /// If the file's time is invalid, assume it was created today
     pub fn created_time(&self) -> Duration {
-        self.metadata.created().unwrap().duration_since(UNIX_EPOCH).unwrap()
+        if self.metadata.modified().unwrap() < UNIX_EPOCH {
+            return SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
+        } else {
+            return self.metadata.created().unwrap().duration_since(UNIX_EPOCH).unwrap()
+        }
     }
 
     /// This file’s ‘type’.

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -332,7 +332,7 @@ impl<'dir> File<'dir> {
         if self.metadata.modified().unwrap() < UNIX_EPOCH {
             return SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
         } else {
-            return self.metadata.created().unwrap().duration_since(UNIX_EPOCH).unwrap()
+            return self.metadata.modified().unwrap().duration_since(UNIX_EPOCH).unwrap()
         }
     }
 
@@ -344,17 +344,17 @@ impl<'dir> File<'dir> {
     /// This file’s last accessed timestamp.
     /// If the file's time is invalid, assume it was accessed today
     pub fn accessed_time(&self) -> Duration {
-        if self.metadata.modified().unwrap() < UNIX_EPOCH{
+        if self.metadata.accessed().unwrap() < UNIX_EPOCH{
             return SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
         } else {
-            return self.metadata.created().unwrap().duration_since(UNIX_EPOCH).unwrap()
+            return self.metadata.accessed().unwrap().duration_since(UNIX_EPOCH).unwrap()
         }
     }
 
     /// This file’s created timestamp.
     /// If the file's time is invalid, assume it was created today
     pub fn created_time(&self) -> Duration {
-        if self.metadata.modified().unwrap() < UNIX_EPOCH {
+        if self.metadata.created().unwrap() < UNIX_EPOCH {
             return SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
         } else {
             return self.metadata.created().unwrap().duration_since(UNIX_EPOCH).unwrap()


### PR DESCRIPTION
Added checks to `file.rs` to ensure that file's metadata exists after `UNIX_EPOCH`.
If the file was accessed/modified/created after UNIX_EPOCH, the current day is displayed.

See #556 