### PR TITLE
Fix vagrant integration tests

### DIFF
--- a/xtests/help
+++ b/xtests/help
@@ -14,6 +14,7 @@ DISPLAY OPTIONS
   -F, --classify     display type indicator by file names
   --colo[u]r=WHEN    when to use terminal colours (always, auto, never)
   --colo[u]r-scale   highlight levels of file sizes distinctly
+  --icons            display icons
 
 FILTERING AND SORTING OPTIONS
   -a, --all                  show hidden and 'dot' files

--- a/xtests/run.sh
+++ b/xtests/run.sh
@@ -153,8 +153,8 @@ $exa $testcases/dates -l       --time-style=iso      2>&1 | diff -q - $results/d
 # Locales
 # These two are used in particular because they have 5-long and 4-long
 # month names respectively
-env LANG=fr_FR.UTF-8  $exa $testcases/dates -l | diff -q - $results/dates_fr  || exit 1
-env LANG=ja_JP.UTF-8  $exa $testcases/dates -l | diff -q - $results/dates_jp  || exit 1
+env LC_ALL=fr_FR.UTF-8 LANG=fr_FR.UTF-8 $exa $testcases/dates -l | diff -q - $results/dates_fr  || exit 1
+env LC_ALL=ja_JP.UTF-8 LANG=ja_JP.UTF-8 $exa $testcases/dates -l | diff -q - $results/dates_jp  || exit 1
 
 
 # Paths and directories


### PR DESCRIPTION
Hi o/

* For dates need the LC_ALL env
* Missing new option --icons on help output

This fix:

```
Files - and /vagrant/xtests/dates_fr differ
Files - and /vagrant/xtests/help differ
```

Cheers!