### PR TITLE
Remove unused code in File#get_source_files

### DIFF
--- a/src/info/sources.rs
+++ b/src/info/sources.rs
@@ -8,21 +8,16 @@ impl<'a> File<'a> {
     /// For this file, return a vector of alternate file paths that, if any of
     /// them exist, mean that *this* file should be coloured as “compiled”.
     ///
-    /// The point of this is to highlight compiled files such as `foo.o` when
-    /// their source file `foo.c` exists in the same directory. It's too
-    /// dangerous to highlight *all* compiled, so the paths in this vector
-    /// are checked for existence first: for example, `foo.js` is perfectly
-    /// valid without `foo.coffee`.
+    /// The point of this is to highlight compiled files such as `foo.js` when
+    /// their source file `foo.coffee` exists in the same directory.
+    /// For example, `foo.js` is perfectly valid without `foo.coffee`, so we
+    /// don't want to always blindly highlight `*.js` as compiled.
+    /// (See also `FileExtensions#is_compiled`)
     pub fn get_source_files(&self) -> Vec<PathBuf> {
         if let Some(ref ext) = self.ext {
             match &ext[..] {
-                "class" => vec![self.path.with_extension("java")],  // Java
                 "css"   => vec![self.path.with_extension("sass"),   self.path.with_extension("less")],  // SASS, Less
-                "elc"   => vec![self.path.with_extension("el")],    // Emacs Lisp
-                "hi"    => vec![self.path.with_extension("hs")],    // Haskell
                 "js"    => vec![self.path.with_extension("coffee"), self.path.with_extension("ts")],  // CoffeeScript, TypeScript
-                "o"     => vec![self.path.with_extension("c"),      self.path.with_extension("cpp")], // C, C++
-                "pyc"   => vec![self.path.with_extension("py")],    // Python
 
                 "aux" |                                          // TeX: auxiliary file
                 "bbl" |                                          // BibTeX bibliography file


### PR DESCRIPTION
as the "class", "elc", "hi", "o", "pyc" extensions are first tested in FileExtensions#is_compiled, so removed code is redundant and neved called.