### PR TITLE
fix panic on broken symlink in git repository

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -484,6 +484,21 @@ Vagrant.configure(2) do |config|
       sudo chown #{user}:#{user} -R "#{test_dir}/git2"
     EOF
 
+    # A third Git repository
+    # Regression test for https://github.com/ogham/exa/issues/526
+    config.vm.provision :shell, privileged: false, inline: <<-EOF
+      set -xe
+      mkdir -p "#{test_dir}/git3"
+      cd       "#{test_dir}/git3"
+      git init
+
+      # Create a symbolic link pointing to a non-existing file
+      ln -s aaa/aaa/a b
+
+      find "#{test_dir}/git3" -exec touch {} -t #{some_date} \\;
+      sudo chown #{user}:#{user} -R "#{test_dir}/git3"
+    EOF
+
     # Hidden and dot file testcases.
     # We need to set the permissions of `.` and `..` because they actually
     # get displayed in the output here, so this has to come last.

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -265,11 +265,11 @@ impl Git {
 fn reorient(path: &Path) -> PathBuf {
     use std::env::current_dir;
     // I’m not 100% on this func tbh
-    match current_dir() {
+    let path = match current_dir() {
         Err(_)  => Path::new(".").join(&path),
         Ok(dir) => dir.join(&path),
-    }.canonicalize().unwrap()   // errors can be ignored here because they only occur if
-                                // the path does not exist / a component is not a folder
+    };
+    path.canonicalize().unwrap_or(path)
 }
 
 /// The character to display if the file has been modified, but not staged.

--- a/xtests/run.sh
+++ b/xtests/run.sh
@@ -210,6 +210,9 @@ $exa $testcases/git2/target                   -l --git 2>&1 | diff -q - $results
 $exa $testcases/git2/deeply/nested/repository -l --git 2>&1 | diff -q - $results/git_2_repository  || exit 1
 $exa $testcases/git2/{deeply,ignoreds,target} -l --git 2>&1 | diff -q - $results/git_2_all         || exit 1
 
+# Regressions test
+$exa $testcases/git3 -l --git &>/dev/null || echo "Failed to display broken symlink in git repository"; exit 1
+
 COLUMNS=150 $exa $testcases/git/**/* $testcases --git --long --grid -d | diff -q - $results/git_1_files  || exit 1
 
 $exa $testcases/git $testcases/git2 --git --long | diff -q - $results/git_12  || exit 1


### PR DESCRIPTION
The issue including reproducer is described here:
https://github.com/ogham/exa/issues/526
This commit includes proposed change as well as integration test.