### PR TITLE
Fix "trait objects without an explicit `dyn` are deprecated"

### DIFF
--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -16,7 +16,7 @@ pub struct FileStyle {
     pub classify: Classify,
 
     /// Mapping of file extensions to colours, to highlight regular files.
-    pub exts: Box<FileColours>,
+    pub exts: Box<dyn FileColours>,
 }
 
 impl FileStyle {
@@ -92,7 +92,7 @@ pub struct FileName<'a,  'dir: 'a,  C: Colours+'a> {
     classify: Classify,
 
     /// Mapping of file extensions to colours, to highlight regular files.
-    exts: &'a FileColours,
+    exts: &'a dyn FileColours,
 }
 
 

--- a/src/output/render/git.rs
+++ b/src/output/render/git.rs
@@ -5,7 +5,7 @@ use fs::fields as f;
 
 
 impl f::Git {
-    pub fn render(&self, colours: &Colours) -> TextCell {
+    pub fn render(&self, colours: &dyn Colours) -> TextCell {
         TextCell {
             width: DisplayWidth::from(2),
             contents: vec![
@@ -18,7 +18,7 @@ impl f::Git {
 
 
 impl f::GitStatus {
-    fn render(&self, colours: &Colours) -> ANSIString<'static> {
+    fn render(&self, colours: &dyn Colours) -> ANSIString<'static> {
         match *self {
             f::GitStatus::NotModified  => colours.not_modified().paint("-"),
             f::GitStatus::New          => colours.new().paint("N"),


### PR DESCRIPTION
Compiling exa gave a bunch of warnings like this one so I decided to fix them:
```
warning: trait objects without an explicit `dyn` are deprecated
  --> src/output/file_name.rs:19:19
   |
19 |     pub exts: Box<FileColours>,
   |                   ^^^^^^^^^^^ help: use `dyn`: `dyn FileColours`
   |
   = note: #[warn(bare_trait_objects)] on by default
```

Closes #575