### PR TITLE
Fix wrong fish completion

### DIFF
--- a/contrib/completions.fish
+++ b/contrib/completions.fish
@@ -76,5 +76,5 @@ complete -c exa        -l 'time-style' -x -d "How to format timestamps" -a "
 "
 
 # Optional extras
-complete -c exa -s 'g' -l 'git'      -d "List each file's Git status, if tracked"
+complete -c exa -l 'git' -d "List each file's Git status, if tracked"
 complete -c exa -s '@' -l 'extended' -d "List each file's extended attributes and sizes"


### PR DESCRIPTION
Same short option in`-g --group` and `-g --git`
Remove wrong short option