### PR TITLE
Better icons spacing

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -38,7 +38,7 @@ pub fn painted_icon(file: &File, style: &FileStyle) -> String {
                     c.paint(file_icon).to_string() 
                 }
             });
-    format!("{} ", painted)
+    format!("{}  ", painted)
 }
 
 fn icon(file: &File) -> char {


### PR DESCRIPTION
Hi, 
I just added a whitespace, in order to make the output a bit nicer (at least to me).
Thought it might be worth a PR in case someone else is interested.
Here are the preview comparisons:

macOS Terminal:
![terminal](https://user-images.githubusercontent.com/9359296/71624896-31ba0080-2be5-11ea-8236-dd73f58f2cbb.gif)

iTerm2:
![iterm](https://user-images.githubusercontent.com/9359296/71624897-32eb2d80-2be5-11ea-8068-054749c72f76.gif)

kitty:
![kitty](https://user-images.githubusercontent.com/9359296/71624898-3383c400-2be5-11ea-917d-538858284186.gif)
Apparently kitty tries to center non-ASCII glyphs in two cells if followed by two whitespaces, this leads to a bit weird aligning. (I believe I came across an issue regarding this)