### PR TITLE
Don't make assumptions about Metadata based on temp_dir

### DIFF
--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -2,7 +2,7 @@ mod dir;
 pub use self::dir::{Dir, DotFilter};
 
 mod file;
-pub use self::file::{File, FileTarget, PlatformMetadata};
+pub use self::file::{File, FileTarget};
 
 pub mod feature;
 pub mod fields;

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -1,6 +1,6 @@
 //! Parsing the options for `FileFilter`.
 
-use fs::{DotFilter, PlatformMetadata};
+use fs::DotFilter;
 use fs::filter::{FileFilter, SortField, SortCase, IgnorePatterns, GitIgnore};
 
 use options::{flags, Misfire};
@@ -67,23 +67,7 @@ impl SortField {
             _ => return Err(Misfire::BadArgument(&flags::SORT, word.into()))
         };
 
-        match SortField::to_platform_metadata(field) {
-            Some(m) => match m.check_supported() {
-                Ok(_) => Ok(field),
-                Err(misfire) => Err(misfire),
-            },
-            None => Ok(field),
-        }
-    }
-
-    fn to_platform_metadata(field: Self) -> Option<PlatformMetadata> {
-        match field {
-            SortField::ModifiedDate => Some(PlatformMetadata::ModifiedTime),
-            SortField::ChangedDate  => Some(PlatformMetadata::ChangedTime),
-            SortField::AccessedDate => Some(PlatformMetadata::AccessedTime),
-            SortField::CreatedDate  => Some(PlatformMetadata::CreatedTime),
-            _ => None
-        }
+        Ok(field)
     }
 }
 

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -6,7 +6,6 @@ use output::time::TimeFormat;
 use options::{flags, Misfire, Vars};
 use options::parser::MatchedFlags;
 
-use fs::PlatformMetadata;
 use fs::feature::xattr;
 
 
@@ -344,17 +343,6 @@ impl TimeTypes {
             TimeTypes::default()
         };
 
-        let mut fields = vec![];
-        if time_types.modified { fields.push(PlatformMetadata::ModifiedTime); }
-        if time_types.changed  { fields.push(PlatformMetadata::ChangedTime); }
-        if time_types.accessed { fields.push(PlatformMetadata::AccessedTime); }
-        if time_types.created  { fields.push(PlatformMetadata::CreatedTime); }
-
-        for field in fields {
-            if let Err(misfire) = field.check_supported() {
-                return Err(misfire);
-            }
-        }
         Ok(time_types)
     }
 }
@@ -542,15 +530,9 @@ mod test {
         test!(time_a:    TimeTypes <- ["-t", "acc"];           Both => Ok(TimeTypes { modified: false, changed: false, accessed: true,  created: false }));
 
         // Created
-        #[cfg(not(target_os = "linux"))]
         test!(cr:        TimeTypes <- ["--created"];           Both => Ok(TimeTypes { modified: false, changed: false, accessed: false, created: true  }));
-        #[cfg(target_os = "linux")]
-        test!(cr:        TimeTypes <- ["--created"];           Both => err Misfire::Unsupported("creation time is not available on this platform currently".to_string()));
-        #[cfg(not(target_os = "linux"))]
         test!(c:         TimeTypes <- ["-U"];                  Both => Ok(TimeTypes { modified: false, changed: false, accessed: false, created: true  }));
-        #[cfg(not(target_os = "linux"))]
         test!(time_cr:   TimeTypes <- ["--time=created"];      Both => Ok(TimeTypes { modified: false, changed: false, accessed: false, created: true  }));
-        #[cfg(not(target_os = "linux"))]
         test!(t_cr:      TimeTypes <- ["-tcr"];                Both => Ok(TimeTypes { modified: false, changed: false, accessed: false, created: true  }));
 
         // Multiples

--- a/src/output/render/times.rs
+++ b/src/output/render/times.rs
@@ -11,18 +11,22 @@ pub trait Render {
                         format: &TimeFormat) -> TextCell;
 }
 
-impl Render for std::time::Duration {
+impl Render for Option<std::time::Duration> {
     fn render(self, style: Style,
                         tz: &Option<TimeZone>,
                         format: &TimeFormat) -> TextCell {
-
-        if let Some(ref tz) = *tz {
-            let datestamp = format.format_zoned(self, tz);
-            TextCell::paint(style, datestamp)
+        if let Some(duration) = self {
+            if let Some(ref tz) = *tz {
+                let datestamp = format.format_zoned(duration, tz);
+                TextCell::paint(style, datestamp)
+            }
+            else {
+                let datestamp = format.format_local(duration);
+                TextCell::paint(style, datestamp)
+            }
         }
         else {
-            let datestamp = format.format_local(self);
-            TextCell::paint(style, datestamp)
+            TextCell::paint(style, String::from("-"))
         }
     }
 }


### PR DESCRIPTION
Previously, exa would attempt to get the metadata for
`std::env::temp_dir`, and if fetching a certain timestamp
(e.g., creation time) failed, it would assume that the OS couldn't
produce that stamp for _any_ file. Requests to display or sort by that
timestamp would misfire the entire program.

This caused exa to make some sweeping claims that aren't true; e.g., that
Linux can't produce file creation times. The real story is that tmpfs
(the filesystem usually used for `/tmp`) can't, but other Linux
filesystems can and do. (The Rust standard library docs even mention
that `Metadata.created()` is backed by `statx()` since Linux 4.11.)

Since exa could be asked to list files from several filesystems,
let's handle metadata on a per-file basis. This patch makes File's
`*_time()` methods return an Option<Duration>
(`changed_time()` always returns None on a non-Unix system),
and prints a hyphen for files without that particular timestamp.
For example:

        $ exa -lhUd --sort=created /tmp/example Cargo.toml Cargo.lock src target

        Permissions Size User    Date Created Name
        .rw-r--r--     0 mrkline -            /tmp/example
        .rw-r--r--   25k mrkline 12 Jan 22:35 Cargo.lock
        .rw-r--r--  1.2k mrkline 12 Jan 22:35 Cargo.toml
        drwxr-xr-x     - mrkline 12 Jan 22:35 src
        drwxr-xr-x     - mrkline 12 Jan 22:46 target