### PR TITLE
Fix SystemTimeError when file's time is earlier than UNIX_EPOCH

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -329,7 +329,7 @@ impl<'dir> File<'dir> {
     /// If the file's time is invalid, assume it was modified today
     pub fn modified_time(&self) -> Duration {
         match self.metadata.modified() {
-            Ok(system_time) => system_time.duration_since(UNIX_EPOCH).unwrap(),
+            Ok(system_time) => system_time.duration_since(UNIX_EPOCH).unwrap_or_default(),
             Err(_) => Duration::new(0, 0),
         }
     }
@@ -343,7 +343,7 @@ impl<'dir> File<'dir> {
     /// If the file's time is invalid, assume it was accessed today
     pub fn accessed_time(&self) -> Duration {
         match self.metadata.accessed() {
-            Ok(system_time) => system_time.duration_since(UNIX_EPOCH).unwrap(),
+            Ok(system_time) => system_time.duration_since(UNIX_EPOCH).unwrap_or_default(),
             Err(_) => Duration::new(0, 0),
         }
     }
@@ -352,7 +352,7 @@ impl<'dir> File<'dir> {
     /// If the file's time is invalid, assume it was created today
     pub fn created_time(&self) -> Duration {
         match self.metadata.created() {
-            Ok(system_time) => system_time.duration_since(UNIX_EPOCH).unwrap(),
+            Ok(system_time) => system_time.duration_since(UNIX_EPOCH).unwrap_or_default(),
             Err(_) => Duration::new(0, 0),
         }
     }


### PR DESCRIPTION
A file with `1970-01-01 00:00:00.000000000 +0800` as created time
will cause SystemTimeError.