### PR TITLE
Fixed compile warning

### DIFF
--- a/src/fs/feature/xattr.rs
+++ b/src/fs/feature/xattr.rs
@@ -103,7 +103,7 @@ pub fn list_attrs(lister: &lister::Lister, path: &Path) -> io::Result<Vec<Attrib
 #[cfg(target_os = "macos")]
 mod lister {
     use std::ffi::CString;
-    use libc::{c_int, size_t, ssize_t, c_char, c_void, uint32_t};
+    use libc::{c_int, size_t, ssize_t, c_char, c_void};
     use super::FollowSymlinks;
     use std::ptr;
 
@@ -115,7 +115,7 @@ mod lister {
 
         fn getxattr(
             path: *const c_char, name: *const c_char,
-            value: *mut c_void, size: size_t, position: uint32_t,
+            value: *mut c_void, size: size_t, position: u32,
             options: c_int
         ) -> ssize_t;
     }


### PR DESCRIPTION
```
warning: use of deprecated item 'fs::feature::xattr::libc::uint32_t': Use u32 instead.
   --> src/fs/feature/xattr.rs:106:56
    |
106 |     use libc::{c_int, size_t, ssize_t, c_char, c_void, uint32_t};
    |                                                        ^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: use of deprecated item 'fs::feature::xattr::libc::uint32_t': Use u32 instead.
   --> src/fs/feature/xattr.rs:118:57
    |
118 |             value: *mut c_void, size: size_t, position: uint32_t,
    |                                                         ^^^^^^^^

warning: 2 warnings emitted
```