### PR TITLE
Add immediate file types for PHP ecosystem

### DIFF
--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -26,7 +26,7 @@ impl FileExtensions {
             "Makefile", "Cargo.toml", "SConstruct", "CMakeLists.txt",
             "build.gradle", "pom.xml", "Rakefile", "package.json", "Gruntfile.js",
             "Gruntfile.coffee", "BUILD", "BUILD.bazel", "WORKSPACE", "build.xml",
-            "webpack.config.js", "meson.build",
+            "webpack.config.js", "meson.build", "composer.json", "RoboFile.php",
         ])
     }
 


### PR DESCRIPTION
Added the following imemdiate file types for PHP:
- `composer.json` for [Composer](https://getcomposer.org/), the defactor standard package manager for PHP;
- `RoboFile.php`, for [Robo](https://robo.li/), the PHP task runner.

Note: [Phing]() uses `build.xml`, which was already included in the list.