### PR TITLE
Fix gitignore option when invert mark exists after asterisk

### DIFF
--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -346,7 +346,19 @@ impl IgnorePatterns {
 
     /// Test whether the given file should be hidden from the results.
     pub fn is_ignored_path(&self, file: &Path) -> bool {
-        self.patterns.iter().any(|p| p.matches_path(file))
+        let iter = self.patterns.iter();
+        let mut is_ignored_path = false;
+        for pattern in iter {
+            if pattern.as_str().starts_with('!') {
+                let exclude_file = format!("{}{}", '!', file.display());
+                if pattern.as_str() == exclude_file {
+                    is_ignored_path = false;
+                };
+            } else {
+                is_ignored_path = is_ignored_path || pattern.matches_path(file);
+            }
+        }
+        is_ignored_path
     }
 
     // TODO(ogham): The fact that `is_ignored_path` is pub while `is_ignored`


### PR DESCRIPTION
## Bug

- `--git-ignore` option ignore the `!aaa` after `*` in .gitignore.

# Screenshots

<img width="356" alt="ss" src="https://user-images.githubusercontent.com/41639488/87246757-4af01380-c48a-11ea-837d-81217cdd9e92.png">

# Why this happens

https://github.com/ogham/exa/blob/master/src/fs/filter.rs#L349

If the Pattern of asterisk exists in .gitignore, `fn matches_path` of glob library returns true, so `any` of `fn is_ignored_path` always returns true.

# remark
I can't think up of a case to need to care about relative path. If it's necessary, I will fix.