### PR TITLE
Correct panic resulting from pre-epoch file times

### DIFF
--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -250,11 +250,11 @@ impl SortField {
 
             SortField::Size          => a.metadata.len().cmp(&b.metadata.len()),
             SortField::FileInode     => a.metadata.ino().cmp(&b.metadata.ino()),
-            SortField::ModifiedDate  => a.modified_time().cmp(&b.modified_time()),
-            SortField::AccessedDate  => a.accessed_time().cmp(&b.accessed_time()),
-            SortField::ChangedDate   => a.changed_time().cmp(&b.changed_time()),
-            SortField::CreatedDate   => a.created_time().cmp(&b.created_time()),
-            SortField::ModifiedAge   => b.modified_time().cmp(&a.modified_time()),  // flip b and a
+            SortField::ModifiedDate  => b.modified_since().cmp(&a.modified_since()), // flip b and a
+            SortField::AccessedDate  => b.accessed_since().cmp(&a.accessed_since()),
+            SortField::ChangedDate   => b.changed_since().cmp(&a.changed_since()),
+            SortField::CreatedDate   => b.created_since().cmp(&a.created_since()),
+            SortField::ModifiedAge   => a.modified_since().cmp(&b.modified_since()),
 
             SortField::FileType => match a.type_char().cmp(&b.type_char()) { // todo: this recomputes
                 Ordering::Equal  => natord::compare(&*a.name, &*b.name),

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -363,10 +363,10 @@ impl<'a, 'f> Table<'a> {
             Column::Group          => file.group().render(self.colours, &*self.env.lock_users()),
             Column::GitStatus      => self.git_status(file).render(self.colours),
 
-            Column::Timestamp(Modified)  => file.modified_time().render(self.colours.date, &self.env.tz, &self.time_format),
-            Column::Timestamp(Changed)   => file.changed_time() .render(self.colours.date, &self.env.tz, &self.time_format),
-            Column::Timestamp(Created)   => file.created_time() .render(self.colours.date, &self.env.tz, &self.time_format),
-            Column::Timestamp(Accessed)  => file.accessed_time().render(self.colours.date, &self.env.tz, &self.time_format),
+            Column::Timestamp(Modified)  => file.modified_since().render(self.colours.date, &self.env.tz, &self.time_format),
+            Column::Timestamp(Changed)   => file.changed_since() .render(self.colours.date, &self.env.tz, &self.time_format),
+            Column::Timestamp(Created)   => file.created_since() .render(self.colours.date, &self.env.tz, &self.time_format),
+            Column::Timestamp(Accessed)  => file.accessed_since().render(self.colours.date, &self.env.tz, &self.time_format),
         }
     }
 

--- a/src/output/time.rs
+++ b/src/output/time.rs
@@ -150,15 +150,14 @@ impl DefaultFormat {
         if time.as_nanos() == 0 {
             return "-".to_string();
         }
-        let date = LocalDateTime::at(time.as_secs() as i64);
-
-        if self.is_recent(date) {
+        let dt = LocalDateTime::now() - datetime::Duration::of(time.as_secs() as i64);
+        if self.is_recent(dt) {
             format!("{:2} {} {:02}:{:02}",
-            date.day(), DefaultFormat::month_to_abbrev(date.month()),
-            date.hour(), date.minute())
+            dt.day(), DefaultFormat::month_to_abbrev(dt.month()),
+            dt.hour(), dt.minute())
         }
         else {
-            self.date_and_year.format(&date, &self.locale)
+            self.date_and_year.format(&dt, &self.locale)
         }
     }
 
@@ -168,15 +167,18 @@ impl DefaultFormat {
             return "-".to_string();
         }
 
-        let date = zone.to_zoned(LocalDateTime::at(time.as_secs() as i64));
-
-        if self.is_recent(date) {
+        let local_dt: LocalDateTime = zone.to_zoned(LocalDateTime::now());
+        let elapsed_time: datetime::Duration = datetime::Duration::of(
+            time.as_secs() as i64
+        );
+        let dt: LocalDateTime = local_dt - elapsed_time;
+        if self.is_recent(dt) {
             format!("{:2} {} {:02}:{:02}",
-            date.day(), DefaultFormat::month_to_abbrev(date.month()),
-            date.hour(), date.minute())
+            dt.day(), DefaultFormat::month_to_abbrev(dt.month()),
+            dt.hour(), dt.minute())
         }
         else {
-            self.date_and_year.format(&date, &self.locale)
+            self.date_and_year.format(&dt, &self.locale)
         }
     }
 }


### PR DESCRIPTION
Fix for issue https://github.com/ogham/exa/issues/699 where specifying the -l flag would produce a panic if a file had a modified date from before the unix epoch.

This fixes the issue by creating the dates to display by subtracting the elapsed time since the reported event from the current time instead of producing the datetime from the duration since the unix epoch.

