### PR TITLE
Update determine_time_zone function to check TZ

### DIFF
--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -1,4 +1,5 @@
 use std::cmp::max;
+use std::env;
 use std::fmt;
 use std::ops::Deref;
 use std::sync::{Mutex, MutexGuard};
@@ -286,7 +287,12 @@ impl Environment {
 }
 
 fn determine_time_zone() -> TZResult<TimeZone> {
-    TimeZone::from_file("/etc/localtime")
+    let tz = env::var("TZ");
+    if tz.is_err() {
+        return TimeZone::from_file("/etc/localtime");
+    } else {
+        return TimeZone::from_file(format!("/usr/share/zoneinfo/{}", tz.unwrap()));
+    }
 }
 
 

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -287,11 +287,10 @@ impl Environment {
 }
 
 fn determine_time_zone() -> TZResult<TimeZone> {
-    let tz = env::var("TZ");
-    if tz.is_err() {
-        return TimeZone::from_file("/etc/localtime");
+    if let Ok(file) = env::var("TZ") {
+        TimeZone::from_file(format!("/usr/share/zoneinfo/{}", file))
     } else {
-        return TimeZone::from_file(format!("/usr/share/zoneinfo/{}", tz.unwrap()));
+        TimeZone::from_file("/etc/localtime")
     }
 }
 


### PR DESCRIPTION
Instead of defaulting immediately to /etc/filename for the timezone, we can first check whether the TZ environment variable is set. If so, we can pull the corresponding timezone file from /usr/share/zoneinfo. Closes #453.