### PR TITLE
Fixes #719. Change August to Aug.

### DIFF
--- a/src/output/time.rs
+++ b/src/output/time.rs
@@ -137,7 +137,7 @@ impl DefaultFormat {
             datetime::Month::May => "May",
             datetime::Month::June => "Jun",
             datetime::Month::July => "Jul",
-            datetime::Month::August => "August",
+            datetime::Month::August => "Aug",
             datetime::Month::September => "Sep",
             datetime::Month::October => "Oct",
             datetime::Month::November => "Nov",


### PR DESCRIPTION
Fixes #719 

Month abbreviation for August was incorrect.