### PR TITLE
Fix icons for symlinked directories

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -44,7 +44,7 @@ pub fn painted_icon(file: &File, style: &FileStyle) -> String {
 
 fn icon(file: &File) -> char {
     let extensions = Box::new(FileExtensions);
-    if file.is_directory() { '\u{f115}' }
+    if file.points_to_directory() { '\u{f115}' }
     else if let Some(icon) = extensions.icon_file(file) { icon }
     else { 
         if let Some(ext) = file.ext.as_ref() {


### PR DESCRIPTION
Furthering #516 of grouping sym-linked directories.
This fixes symlinked folders from getting a generic file icon.