### PR TITLE
add ko to compiled objects

### DIFF
--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -88,7 +88,7 @@ impl FileExtensions {
     }
 
     fn is_compiled(&self, file: &File) -> bool {
-        if file.extension_is_one_of( &[ "class", "elc", "hi", "o", "pyc", "zwc" ]) {
+        if file.extension_is_one_of( &[ "class", "elc", "hi", "o", "pyc", "zwc", "ko" ]) {
             true
         }
         else if let Some(dir) = file.parent_dir {


### PR DESCRIPTION
Since a Linux/BSD kernel object is an object/compiled file, it should be counted as one along with o, pyc, and the others.