### PR TITLE
Prevent crash for impossible time

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -329,7 +329,9 @@ impl<'dir> File<'dir> {
     /// If the file's time is invalid, assume it was modified today
     pub fn modified_time(&self) -> Duration {
         match self.metadata.modified() {
-            Ok(system_time) => system_time.duration_since(UNIX_EPOCH).unwrap(),
+            Ok(system_time) => system_time.duration_since(UNIX_EPOCH).unwrap_or_else(|_| {
+                Duration::new(0, 0)
+            }),
             Err(_) => Duration::new(0, 0),
         }
     }


### PR DESCRIPTION
If a file has an invalid modified-time (the time is impossible, e.g.  in the future), assume that it was modified today to prevent crashing (Like with other invalid times).
This enables you to list files even though some may have corrupt metadata. It should fix #738.