### PR TITLE
Add additional TeX compiled files

### DIFF
--- a/src/info/sources.rs
+++ b/src/info/sources.rs
@@ -21,6 +21,7 @@ impl<'a> File<'a> {
 
                 "aux" |                                          // TeX: auxiliary file
                 "bbl" |                                          // BibTeX bibliography file
+                "bcf" |                                          // biblatex control file
                 "blg" |                                          // BibTeX log file
                 "fdb_latexmk" |                                  // TeX latexmk file
                 "fls" |                                          // TeX -recorder file

--- a/src/info/sources.rs
+++ b/src/info/sources.rs
@@ -22,6 +22,8 @@ impl<'a> File<'a> {
                 "aux" |                                          // TeX: auxiliary file
                 "bbl" |                                          // BibTeX bibliography file
                 "blg" |                                          // BibTeX log file
+                "fdb_latexmk" |                                  // TeX latexmk file
+                "fls" |                                          // TeX -recorder file
                 "lof" |                                          // TeX list of figures
                 "log" |                                          // TeX log file
                 "lot" |                                          // TeX list of tables


### PR DESCRIPTION
Specifically .fls and .fdb_latexmk, which the popular [`latexmk`](https://www.ctan.org/pkg/latexmk) tool produces.

There are [more](https://tex.stackexchange.com/questions/7770/file-extensions-related-to-latex-etc), but these are particularly common. There are two more that are very common, but I couldn't at first glance see how to add them:

 - `.run.xml` generated by the `biber` bibilography tool
 - `-blx.bib` control file generated by `biblatex`

Might be good to include those too if they're easy to add.