### PR TITLE
Warm when git feature is disabled instead of ignoring flags

### DIFF
--- a/man/exa.1.md
+++ b/man/exa.1.md
@@ -101,7 +101,7 @@ Sort fields starting with a capital letter will sort uppercase before lowercase:
 `-I`, `--ignore-glob=GLOBS`
 : Glob patterns, pipe-separated, of files to ignore.
 
-`--git-ignore`
+`--git-ignore` [if exa was built with git support]
 : Do not list files that are ignored by Git.
 
 `--group-directories-first`
@@ -174,7 +174,7 @@ These options are available when running with `--long` (`-l`):
 `-@`, `--extended`
 : List each file’s extended attributes and sizes.
 
-`--git`
+`--git`  [if exa was built with git support]
 : List each file’s Git status, if tracked.
 
 

--- a/src/fs/feature/mod.rs
+++ b/src/fs/feature/mod.rs
@@ -27,7 +27,7 @@ pub mod git {
         }
 
         pub fn get(&self, _index: &Path, _prefix_lookup: bool) -> f::Git {
-            panic!("Tried to query a Git cache, but Git support is disabled")
+            unreachable!();
         }
     }
 }

--- a/src/fs/feature/xattr.rs
+++ b/src/fs/feature/xattr.rs
@@ -7,9 +7,7 @@ use std::io;
 use std::path::Path;
 
 
-pub const ENABLED: bool =
-    cfg!(feature="git") &&
-    cfg!(any(target_os = "macos", target_os = "linux"));
+pub const ENABLED: bool = cfg!(any(target_os = "macos", target_os = "linux"));
 
 
 pub trait FileAttributes {

--- a/src/options/error.rs
+++ b/src/options/error.rs
@@ -16,7 +16,7 @@ pub enum OptionsError {
     /// The user supplied an illegal choice to an Argument.
     BadArgument(&'static Arg, OsString),
 
-    /// The user supplied a set of options
+    /// The user supplied a set of options that are unsupported
     Unsupported(String),
 
     /// An option was given twice or more in strict mode.

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -5,7 +5,7 @@ use crate::options::flags;
 use crate::options::parser::MatchedFlags;
 
 
-static USAGE: &str = r##"Usage:
+static USAGE_PART1: &str = "Usage:
   exa [options] [files...]
 
 META OPTIONS
@@ -32,8 +32,9 @@ FILTERING AND SORTING OPTIONS
   -s, --sort SORT_FIELD      which field to sort by
   --group-directories-first  list directories before other files
   -D, --only-dirs            list only directories
-  -I, --ignore-glob GLOBS    glob patterns (pipe-separated) of files to ignore
-  --git-ignore               ignore files mentioned in '.gitignore'
+  -I, --ignore-glob GLOBS    glob patterns (pipe-separated) of files to ignore";
+
+  static USAGE_PART2: &str = "  \
   Valid sort fields:         name, Name, extension, Extension, size, type,
                              modified, accessed, created, inode, and none.
                              date, time, old, and new all refer to modified.
@@ -56,10 +57,11 @@ LONG VIEW OPTIONS
   --octal-permissions  list each file's permission in octal format
   --no-filesize        suppress the filesize field
   --no-user            suppress the user field
-  --no-time            suppress the time field"##;
+  --no-time            suppress the time field";
 
-static GIT_HELP:      &str = r##"  --git                list each file's Git status, if tracked or ignored"##;
-static EXTENDED_HELP: &str = r##"  -@, --extended       list each file's extended attributes and sizes"##;
+static GIT_FILTER_HELP: &str = "  --git-ignore               ignore files mentioned in '.gitignore'";
+static GIT_VIEW_HELP:   &str = "  --git                list each file's Git status, if tracked or ignored";
+static EXTENDED_HELP:   &str = "  -@, --extended       list each file's extended attributes and sizes";
 
 
 /// All the information needed to display the help text, which depends
@@ -92,14 +94,20 @@ impl fmt::Display for HelpString {
     /// Format this help options into an actual string of help
     /// text to be displayed to the user.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        writeln!(f, "{}", USAGE)?;
+        write!(f, "{}", USAGE_PART1)?;
 
-        if cfg!(feature="git") {
-            writeln!(f, "{}", GIT_HELP)?;
+        if cfg!(feature = "git") {
+            write!(f, "\n{}", GIT_FILTER_HELP)?;
+        }
+
+        write!(f, "\n{}", USAGE_PART2)?;
+
+        if cfg!(feature = "git") {
+            write!(f, "\n{}", GIT_VIEW_HELP)?;
         }
 
         if xattr::ENABLED {
-            writeln!(f, "{}", EXTENDED_HELP)?;
+            write!(f, "\n{}", EXTENDED_HELP)?;
         }
 
         Ok(())

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -176,6 +176,13 @@ impl Options {
     /// Determines the complete set of options based on the given command-line
     /// arguments, after they’ve been parsed.
     fn deduce<V: Vars>(matches: &MatchedFlags<'_>, vars: &V) -> Result<Self, OptionsError> {
+        if cfg!(not(feature = "git")) &&
+                matches.has_where_any(|f| f.matches(&flags::GIT) || f.matches(&flags::GIT_IGNORE)).is_some() {
+            return Err(OptionsError::Unsupported(format!(
+                "Options --git and --git-ignore can't be used because `git` feature was disabled in this build of exa"
+            )));
+        }
+
         let view = View::deduce(matches, vars)?;
         let dir_action = DirAction::deduce(matches, matches!(view.mode, Mode::Details(_)))?;
         let filter = FileFilter::deduce(matches)?;

--- a/src/options/version.rs
+++ b/src/options/version.rs
@@ -31,7 +31,11 @@ impl VersionString {
 
 impl fmt::Display for VersionString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        writeln!(f, "{}", include!(concat!(env!("OUT_DIR"), "/version_string.txt")))
+        writeln!(
+            f,
+            "{} (git support: {})",
+            include!(concat!(env!("OUT_DIR"), "/version_string.txt")),
+            if cfg!(feature = "git") { "enabled" } else { "disabled" })
     }
 }
 

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -91,7 +91,7 @@ impl Mode {
                 }
             }
 
-            if cfg!(feature = "git") && matches.has(&flags::GIT)? {
+            if matches.has(&flags::GIT)? {
                 return Err(OptionsError::Useless(&flags::GIT, false, &flags::LONG));
             }
             else if matches.has(&flags::LEVEL)? && ! matches.has(&flags::RECURSE)? && ! matches.has(&flags::TREE)? {
@@ -192,7 +192,7 @@ impl TableOptions {
 impl Columns {
     fn deduce(matches: &MatchedFlags<'_>) -> Result<Self, OptionsError> {
         let time_types = TimeTypes::deduce(matches)?;
-        let git = cfg!(feature = "git") && matches.has(&flags::GIT)?;
+        let git = matches.has(&flags::GIT)?;
 
         let blocks = matches.has(&flags::BLOCKS)?;
         let group  = matches.has(&flags::GROUP)?;

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -99,7 +99,7 @@ impl Columns {
             columns.push(Column::Timestamp(TimeType::Accessed));
         }
 
-        if cfg!(feature = "git") && self.git && actually_enable_git {
+        if self.git && actually_enable_git {
             columns.push(Column::GitStatus);
         }
 


### PR DESCRIPTION
The flags `--git` and `--git-ignore` are caught early during options parsing, so no more checking for git feature is done elsewhere.

Since `--git-ignore` depends on git too [since recently](https://github.com/ogham/exa/pull/653), remove it from help when git feature is disabled.

Extended attributes now don’t artificially depends on git feature being enabled.

Tell if exa was compiled with git support or not when using --help

Tell in the man that some flags needs exa built with git support 

Fix #761