### PR TITLE
Support reading arguments from config file and environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,16 +10,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "byteorder"
@@ -43,6 +72,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
 name = "datetime"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,11 +110,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "exa"
 version = "0.9.0"
 dependencies = [
  "ansi_term",
  "datetime",
+ "dirs",
  "git2",
  "glob",
  "lazy_static",
@@ -73,11 +146,23 @@ dependencies = [
  "num_cpus",
  "number_prefix",
  "scoped_threadpool",
+ "shell-words",
  "term_grid",
  "term_size",
  "unicode-width",
  "users",
  "zoneinfo_compiled",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -189,7 +274,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -296,10 +381,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_users"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
+dependencies = [
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "scoped_threadpool"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
+
+[[package]]
+name = "shell-words"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
 
 [[package]]
 name = "term_grid"
@@ -382,6 +496,12 @@ name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ term_size = "0.3"
 unicode-width = "0.1"
 users = "0.11"
 zoneinfo_compiled = "0.5"
+dirs = "3.0.1"
+shell-words = "1.0.0"
 
 [dependencies.git2]
 version = "0.13"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,121 @@
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::path::PathBuf;
+
+/// Wrapper for 'dirs' that treats macOS more like Linux, by following the XDG specification.
+/// This means that the `XDG_CONFIG_HOME` environment variable is checked first.
+/// The fallback directory is `~/.config/exa`.
+fn config_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    let config_dir_op = env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute())
+        .or_else(|| dirs::home_dir().map(|d| d.join(".config")));
+
+    #[cfg(not(target_os = "macos"))]
+    let config_dir_op = dirs::config_dir();
+
+    config_dir_op.map(|d| d.join("exa"))
+}
+
+fn config_file() -> PathBuf {
+    env::var("EXA_CONFIG_PATH")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|config_path| config_path.is_file())
+        .unwrap_or_else(|| {
+            config_dir()
+                .expect("Could not get home directory")
+                .join("config")
+        })
+}
+
+pub fn get_args_from_config_file() -> Result<Vec<OsString>, shell_words::ParseError> {
+    Ok(fs::read_to_string(config_file())
+        .ok()
+        .map(|content| get_args_from_str(&content))
+        .transpose()?
+        .unwrap_or_else(Vec::new))
+}
+
+pub fn get_args_from_env_var() -> Option<Result<Vec<OsString>, shell_words::ParseError>> {
+    env::var("EXA_OPTS").ok().map(|s| get_args_from_str(&s))
+}
+
+fn get_args_from_str(content: &str) -> Result<Vec<OsString>, shell_words::ParseError> {
+    let args_per_line = content
+        .split('\n')
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty())
+        .filter(|line| !line.starts_with('#'))
+        .map(|line| shell_words::split(line))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(args_per_line
+        .iter()
+        .flatten()
+        .map(|line| line.into())
+        .collect())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn empty() {
+        let args = get_args_from_str("").unwrap();
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn single() {
+        assert_eq!(vec!["--binary"], get_args_from_str("--binary").unwrap());
+    }
+
+    #[test]
+    fn multiple() {
+        assert_eq!(
+            vec!["--binary", "--time-style=iso"],
+            get_args_from_str("--binary --time-style=iso").unwrap()
+        );
+    }
+
+    #[test]
+    fn quotes() {
+        assert_eq!(
+            vec!["--time-style", "iso"],
+            get_args_from_str("--time-style \"iso\"").unwrap()
+        );
+    }
+
+    #[test]
+    fn multi_line() {
+        let config = "
+        -l
+        --sort newest
+        --time-style=iso
+        ";
+        assert_eq!(
+            vec!["-l", "--sort", "newest", "--time-style=iso"],
+            get_args_from_str(config).unwrap()
+        );
+    }
+
+    #[test]
+    fn comments() {
+        let config = "
+        # Display file metadata as a table
+        -l
+        # Sort by newest
+        --sort newest
+        # Use ISO timestamp format
+        --time-style=iso
+        ";
+        assert_eq!(
+            vec!["-l", "--sort", "newest", "--time-style=iso"],
+            get_args_from_str(config).unwrap()
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ mod logger;
 mod options;
 mod output;
 mod theme;
+mod config;
 
 
 fn main() {
@@ -50,7 +51,11 @@ fn main() {
 
     logger::configure(env::var_os(vars::EXA_DEBUG));
 
-    let args: Vec<_> = env::args_os().skip(1).collect();
+    let cli_args: Vec<_> = env::args_os().skip(1).collect();
+    let mut args = config::get_args_from_env_var()
+        .unwrap_or_else(config::get_args_from_config_file)
+        .expect("Could not parse configuration file");
+    args.extend(cli_args);
     match Options::parse(args.iter().map(|e| e.as_ref()), &LiveVars) {
         OptionsResult::Ok(options, mut input_paths) => {
 


### PR DESCRIPTION
Idea and code adapted from [`bat`](https://github.com/sharkdp/bat).

Basically the same logic as bat:

- Look for `EXA_OPTS` environment variable
- If `EXA_OPTS` is not found, look for `EXA_CONFIG_PATH` and check if it exists
- Load arguments from `EXA_OPTS` or config file, and append the ones defined at runtime

Note that `--generate-config-file` is not implemented but I'd like to if there is any demand.

Doc is not updated for the moment because things may change 😄 

Resolves #511

I know little about Rust so correct me if I made any mistake 😃 (and I learned a lot from making this PR).