### PR TITLE
Use same styling for spaces between icon and file name

### DIFF
--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -132,9 +132,9 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
             bits.push(style.paint(file_icon));
 
             match spaces_count {
-                1 => bits.push(Style::default().paint(" ")),
-                2 => bits.push(Style::default().paint("  ")),
-                n => bits.push(Style::default().paint(spaces(n))),
+                1 => bits.push(style.paint(" ")),
+                2 => bits.push(style.paint("  ")),
+                n => bits.push(style.paint(spaces(n))),
             }
         }
 


### PR DESCRIPTION
This is only visible when selecting both icon and file name, as most terminal emulators then invert background and foreground color.

It also workaround a Konsole bug: https://bugs.kde.org/show_bug.cgi?id=422776

Fix #648 