### PR TITLE
Add code for file types (image, document, etc.) in EXA_COLORS

### DIFF
--- a/man/exa_colors.5.md
+++ b/man/exa_colors.5.md
@@ -76,8 +76,41 @@ LIST OF CODES
 `or`
 : symlinks with no target
 
+`mh`
+: hard link count when more than one hardlink
+
 
 `EXA_COLORS` can use many more:
+
+`tm`
+: a regular file that’s temporary (ex: a text editor’s backup file)
+
+`bu`
+: a regular file that’s used to build a project (ex: a build script or config)
+
+`ig`
+: a regular file that’s an image
+
+`vi`
+: a regular file that’s a video
+
+`mu`
+: a regular file that’s lossy music
+
+`lo`
+: a regular file that’s lossless music
+
+`cr`
+: a regular file that’s related to cryptography (ex: a key or a certificate)
+
+`dc`
+: a regular file that’s a document (ex: an office suite document or a PDF)
+
+`cs`
+: a regular file that’s compressed
+
+`cl`
+: a regular file that’s a compilation artifact (ex: a Java class file)
 
 `ur`
 : the user-read permission bit

--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -8,7 +8,7 @@ use ansi_term::Style;
 
 use crate::fs::File;
 use crate::output::icons::FileIcon;
-use crate::theme::FileColours;
+use crate::output::render::FiletypeColours;
 
 
 #[derive(Debug, Default, PartialEq)]
@@ -16,10 +16,10 @@ pub struct FileExtensions;
 
 impl FileExtensions {
 
-    /// An “immediate” file is something that can be run or activated somehow
+    /// A build file is something that can be run or activated somehow
     /// in order to kick off the build of a project. It’s usually only present
     /// in directories full of source code.
-    fn is_immediate(&self, file: &File<'_>) -> bool {
+    fn is_build(&self, file: &File<'_>) -> bool {
         file.name.to_lowercase().starts_with("readme") ||
         file.name.ends_with(".ninja") ||
         file.name_is_one_of( &[
@@ -100,24 +100,20 @@ impl FileExtensions {
             false
         }
     }
-}
 
-impl FileColours for FileExtensions {
-    fn colour_file(&self, file: &File<'_>) -> Option<Style> {
-        use ansi_term::Colour::*;
-
+    pub fn colour_file(&self, file: &File<'_>, colours: &impl FiletypeColours) -> Option<Style> {
         Some(match file {
-            f if self.is_temp(f)        => Fixed(244).normal(),
-            f if self.is_immediate(f)   => Yellow.bold().underline(),
-            f if self.is_image(f)       => Fixed(133).normal(),
-            f if self.is_video(f)       => Fixed(135).normal(),
-            f if self.is_music(f)       => Fixed(92).normal(),
-            f if self.is_lossless(f)    => Fixed(93).normal(),
-            f if self.is_crypto(f)      => Fixed(109).normal(),
-            f if self.is_document(f)    => Fixed(105).normal(),
-            f if self.is_compressed(f)  => Red.normal(),
-            f if self.is_compiled(f)    => Fixed(137).normal(),
-            _                           => return None,
+            f if self.is_temp(f)       => colours.temp(),
+            f if self.is_build(f)      => colours.build(),
+            f if self.is_image(f)      => colours.image(),
+            f if self.is_video(f)      => colours.video(),
+            f if self.is_music(f)      => colours.music(),
+            f if self.is_lossless(f)   => colours.lossless(),
+            f if self.is_crypto(f)     => colours.crypto(),
+            f if self.is_document(f)   => colours.document(),
+            f if self.is_compressed(f) => colours.compressed(),
+            f if self.is_compiled(f)   => colours.compiled(),
+            _                          => return None,
         })
     }
 }

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -7,7 +7,7 @@ use crate::fs::{File, FileTarget};
 use crate::output::cell::TextCellContents;
 use crate::output::escape;
 use crate::output::icons::{icon_for_file, iconify_style};
-use crate::output::render::FiletypeColours;
+use crate::output::render::FilekindColours;
 
 
 /// Basically a file name factory.
@@ -309,7 +309,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
 
 
 /// The set of colours that are needed to paint a file name.
-pub trait Colours: FiletypeColours {
+pub trait Colours: FilekindColours {
 
     /// The style to paint the path of a symlink’s target, up to but not
     /// including the file’s name.

--- a/src/output/render/filekind.rs
+++ b/src/output/render/filekind.rs
@@ -1,0 +1,31 @@
+use ansi_term::{ANSIString, Style};
+
+use crate::fs::fields as f;
+
+
+impl f::Type {
+    pub fn render<C: Colours>(self, colours: &C) -> ANSIString<'static> {
+        match self {
+            Self::File         => colours.normal().paint("."),
+            Self::Directory    => colours.directory().paint("d"),
+            Self::Pipe         => colours.pipe().paint("|"),
+            Self::Link         => colours.symlink().paint("l"),
+            Self::BlockDevice  => colours.block_device().paint("b"),
+            Self::CharDevice   => colours.char_device().paint("c"),
+            Self::Socket       => colours.socket().paint("s"),
+            Self::Special      => colours.special().paint("?"),
+        }
+    }
+}
+
+
+pub trait Colours {
+    fn normal(&self) -> Style;
+    fn directory(&self) -> Style;
+    fn pipe(&self) -> Style;
+    fn symlink(&self) -> Style;
+    fn block_device(&self) -> Style;
+    fn char_device(&self) -> Style;
+    fn socket(&self) -> Style;
+    fn special(&self) -> Style;
+}

--- a/src/output/render/filetype.rs
+++ b/src/output/render/filetype.rs
@@ -1,31 +1,14 @@
-use ansi_term::{ANSIString, Style};
-
-use crate::fs::fields as f;
-
-
-impl f::Type {
-    pub fn render<C: Colours>(self, colours: &C) -> ANSIString<'static> {
-        match self {
-            Self::File         => colours.normal().paint("."),
-            Self::Directory    => colours.directory().paint("d"),
-            Self::Pipe         => colours.pipe().paint("|"),
-            Self::Link         => colours.symlink().paint("l"),
-            Self::BlockDevice  => colours.block_device().paint("b"),
-            Self::CharDevice   => colours.char_device().paint("c"),
-            Self::Socket       => colours.socket().paint("s"),
-            Self::Special      => colours.special().paint("?"),
-        }
-    }
-}
-
+use ansi_term::Style;
 
 pub trait Colours {
-    fn normal(&self) -> Style;
-    fn directory(&self) -> Style;
-    fn pipe(&self) -> Style;
-    fn symlink(&self) -> Style;
-    fn block_device(&self) -> Style;
-    fn char_device(&self) -> Style;
-    fn socket(&self) -> Style;
-    fn special(&self) -> Style;
+    fn temp(&self) -> Style;
+    fn build(&self) -> Style;
+    fn image(&self) -> Style;
+    fn video(&self) -> Style;
+    fn music(&self) -> Style;
+    fn lossless(&self) -> Style;
+    fn crypto(&self) -> Style;
+    fn document(&self) -> Style;
+    fn compressed(&self) -> Style;
+    fn compiled(&self) -> Style;
 }

--- a/src/output/render/mod.rs
+++ b/src/output/render/mod.rs
@@ -1,11 +1,14 @@
 mod blocks;
 pub use self::blocks::Colours as BlocksColours;
 
-mod filetype;
-pub use self::filetype::Colours as FiletypeColours;
+mod filekind;
+pub use self::filekind::Colours as FilekindColours;
 
 mod git;
 pub use self::git::Colours as GitColours;
+
+mod filetype;
+pub use self::filetype::Colours as FiletypeColours;
 
 mod groups;
 pub use self::groups::Colours as GroupColours;

--- a/src/output/render/permissions.rs
+++ b/src/output/render/permissions.rs
@@ -2,11 +2,11 @@ use ansi_term::{ANSIString, Style};
 
 use crate::fs::fields as f;
 use crate::output::cell::{TextCell, DisplayWidth};
-use crate::output::render::FiletypeColours;
+use crate::output::render::FilekindColours;
 
 
 impl f::PermissionsPlus {
-    pub fn render<C: Colours+FiletypeColours>(&self, colours: &C) -> TextCell {
+    pub fn render<C: Colours+FilekindColours>(&self, colours: &C) -> TextCell {
         let mut chars = vec![ self.file_type.render(colours) ];
         chars.extend(self.permissions.render(colours, self.file_type.is_regular_file()));
 

--- a/src/theme/default_theme.rs
+++ b/src/theme/default_theme.rs
@@ -66,6 +66,19 @@ impl UiStyles {
                 conflicted:  Red.normal(),
             },
 
+            filetypes: FileTypes {
+                temp:        Fixed(244).normal(),
+                build:       Yellow.bold().underline(),
+                image:       Fixed(133).normal(),
+                video:       Fixed(135).normal(),
+                music:       Fixed(92).normal(),
+                lossless:    Fixed(93).normal(),
+                crypto:      Fixed(109).normal(),
+                document:    Fixed(105).normal(),
+                compressed:  Red.normal(),
+                compiled:    Fixed(137).normal(),
+            },
+
             punctuation:  Fixed(244).normal(),
             date:         Blue.normal(),
             inode:        Purple.normal(),

--- a/src/theme/lsc.rs
+++ b/src/theme/lsc.rs
@@ -28,13 +28,13 @@ impl<'var> LSColors<'var> {
     pub fn each_pair<C>(&mut self, mut callback: C)
     where C: FnMut(Pair<'var>)
     {
-        for next in self.0.split(':') {
+        for next in self.0.split(|c| c == ':' || c == '\n') {
             let bits = next.split('=')
                            .take(3)
                            .collect::<Vec<_>>();
 
-            if bits.len() == 2 && ! bits[0].is_empty() && ! bits[1].is_empty() {
-                callback(Pair { key: bits[0], value: bits[1] });
+            if bits.len() != 1 && ! bits[0].is_empty() && ! bits[1].is_empty() {
+                callback(Pair { key: bits[0].trim(), value: bits[1].trim() });
             }
         }
     }

--- a/src/theme/ui_styles.rs
+++ b/src/theme/ui_styles.rs
@@ -13,6 +13,7 @@ pub struct UiStyles {
     pub users:      Users,
     pub links:      Links,
     pub git:        Git,
+    pub filetypes:  FileTypes,
 
     pub punctuation:  Style,
     pub date:         Style,
@@ -104,6 +105,20 @@ pub struct Git {
     pub conflicted: Style,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct FileTypes {
+    pub temp: Style,
+    pub build: Style,
+    pub image: Style,
+    pub video: Style,
+    pub music: Style,
+    pub lossless: Style,
+    pub crypto: Style,
+    pub document: Style,
+    pub compressed: Style,
+    pub compiled: Style,
+}
+
 impl UiStyles {
     pub fn plain() -> Self {
         Self::default()
@@ -112,12 +127,13 @@ impl UiStyles {
 
 
 impl UiStyles {
-
     /// Sets a value on this set of colours using one of the keys understood
-    /// by the `LS_COLORS` environment variable. Invalid keys set nothing, but
-    /// return false.
-    pub fn set_ls(&mut self, pair: &Pair<'_>) -> bool {
+    /// by the `LS_COLORS` or `EXA_COLORS` environment variable. Invalid keys
+    /// set nothing, but return false.
+    pub fn set_colours(&mut self, pair: &Pair<'_>, only_ls: bool) -> bool {
         match pair.key {
+            // LS_COLORS codes:
+
             "di" => self.filekinds.directory    = pair.to_style(),  // DIR
             "ex" => self.filekinds.executable   = pair.to_style(),  // EXEC
             "fi" => self.filekinds.normal       = pair.to_style(),  // FILE
@@ -127,20 +143,39 @@ impl UiStyles {
             "cd" => self.filekinds.char_device  = pair.to_style(),  // CHR
             "ln" => self.filekinds.symlink      = pair.to_style(),  // LINK
             "or" => self.broken_symlink         = pair.to_style(),  // ORPHAN
-             _   => return false,
-             // Codes we don’t do anything with:
-             // MULTIHARDLINK, DOOR, SETUID, SETGID, CAPABILITY,
-             // STICKY_OTHER_WRITABLE, OTHER_WRITABLE, STICKY, MISSING
-        }
-        true
-    }
+            "mh" => self.links.multi_link_file  = pair.to_style(),  // MULTIHARDLINK
 
-    /// Sets a value on this set of colours using one of the keys understood
-    /// by the `EXA_COLORS` environment variable. Invalid keys set nothing,
-    /// but return false. This doesn’t take the `LS_COLORS` keys into account,
-    /// so `set_ls` should have been run first.
-    pub fn set_exa(&mut self, pair: &Pair<'_>) -> bool {
-        match pair.key {
+            // Codes we don’t do anything with:
+            "rs"   // RESET
+            | "no" // NORMAL
+            | "mi" // MISSING
+            | "do" // DOOR
+            | "sg" // SETGID
+            | "st" // STICKY
+            | "ow" // OTHER_WRITABLE
+            | "ca" // CAPABILITY
+                => {},
+
+            // Code we ignore in LS_COLORS (repurposed in EXA_COLORS):
+            "tw"   // STICKY_OTHER_WRITABLE
+            | "su" // // SETUID
+                if only_ls => {},
+
+            _ if only_ls => return false,
+
+            // EXA_COLORS exclusive codes:
+
+            "tm" => self.filetypes.temp           = pair.to_style(),
+            "bu" => self.filetypes.build          = pair.to_style(),
+            "ig" => self.filetypes.image          = pair.to_style(),
+            "vi" => self.filetypes.video          = pair.to_style(),
+            "mu" => self.filetypes.music          = pair.to_style(),
+            "lo" => self.filetypes.lossless       = pair.to_style(),
+            "cr" => self.filetypes.crypto         = pair.to_style(),
+            "dc" => self.filetypes.document       = pair.to_style(),
+            "cs" => self.filetypes.compressed     = pair.to_style(),
+            "cl" => self.filetypes.compiled       = pair.to_style(),
+
             "ur" => self.perms.user_read          = pair.to_style(),
             "uw" => self.perms.user_write         = pair.to_style(),
             "ux" => self.perms.user_execute_file  = pair.to_style(),
@@ -154,7 +189,7 @@ impl UiStyles {
             "su" => self.perms.special_user_file  = pair.to_style(),
             "sf" => self.perms.special_other      = pair.to_style(),
             "xa" => self.perms.attribute          = pair.to_style(),
-
+ 
             "sn" => self.set_number_style(pair.to_style()),
             "sb" => self.set_unit_style(pair.to_style()),
             "nb" => self.size.number_byte         = pair.to_style(),
@@ -169,21 +204,21 @@ impl UiStyles {
             "uh" => self.size.unit_huge           = pair.to_style(),
             "df" => self.size.major               = pair.to_style(),
             "ds" => self.size.minor               = pair.to_style(),
-
+ 
             "uu" => self.users.user_you           = pair.to_style(),
             "un" => self.users.user_someone_else  = pair.to_style(),
             "gu" => self.users.group_yours        = pair.to_style(),
             "gn" => self.users.group_not_yours    = pair.to_style(),
-
+ 
             "lc" => self.links.normal             = pair.to_style(),
             "lm" => self.links.multi_link_file    = pair.to_style(),
-
+ 
             "ga" => self.git.new                  = pair.to_style(),
             "gm" => self.git.modified             = pair.to_style(),
             "gd" => self.git.deleted              = pair.to_style(),
             "gv" => self.git.renamed              = pair.to_style(),
             "gt" => self.git.typechange           = pair.to_style(),
-
+ 
             "xx" => self.punctuation              = pair.to_style(),
             "da" => self.date                     = pair.to_style(),
             "in" => self.inode                    = pair.to_style(),
@@ -194,7 +229,7 @@ impl UiStyles {
             "bO" => self.broken_path_overlay      = pair.to_style(),
 
              _   => return false,
-        }
+        };
 
         true
     }


### PR DESCRIPTION
- Added `mh` in LS_COLORS, seems like it was forgotten
- Add ten new codes in EXA_COLORS for file types

Fix #363

In the future, we should probably use some kind of config file for theme, because `EXA_COLORS` tends to be long and cryptic.