### PR TITLE
Don’t produce extra column sometimes with long grid + header

### DIFF
--- a/src/output/grid_details.rs
+++ b/src/output/grid_details.rs
@@ -157,7 +157,11 @@ impl<'a> Render<'a> {
                              .map(|file| self.file_style.for_file(file, self.theme).paint().promote())
                              .collect::<Vec<_>>();
 
-        let mut last_working_table = self.make_grid(1, options, &file_names, rows.clone(), &drender);
+        let mut last_working_grid = self.make_grid(1, options, &file_names, rows.clone(), &drender);
+        
+        if file_names.len() == 1 {
+            return Some((last_working_grid, 1));
+        }
 
         // If we can’t fit everything in a grid 100 columns wide, then
         // something has gone seriously awry
@@ -166,23 +170,26 @@ impl<'a> Render<'a> {
 
             let the_grid_fits = {
                 let d = grid.fit_into_columns(column_count);
-                d.is_complete() && d.width() <= self.console_width
+                d.width() <= self.console_width
             };
 
             if the_grid_fits {
-                last_working_table = grid;
-            }
-            else {
+                if column_count == file_names.len() {
+                    return Some((grid, column_count));
+                } else { 
+                    last_working_grid = grid;
+                }
+            } else {
                 // If we’ve figured out how many columns can fit in the user’s
                 // terminal, and it turns out there aren’t enough rows to
                 // make it worthwhile, then just resort to the lines view.
                 if let RowThreshold::MinimumRows(thresh) = self.row_threshold {
-                    if last_working_table.fit_into_columns(column_count - 1).row_count() < thresh {
+                    if last_working_grid.fit_into_columns(column_count - 1).row_count() < thresh {
                         return None;
                     }
                 }
 
-                return Some((last_working_table, column_count - 1));
+                return Some((last_working_grid, column_count - 1));
             }
         }
 

--- a/xtests/grid-details-view.toml
+++ b/xtests/grid-details-view.toml
@@ -76,3 +76,24 @@ stdout = { file = "outputs/files_paths_long_grid_3col.ansitxt" }
 stderr = { empty = true }
 status = 0
 tags = [ 'env', 'long', 'grid' ]
+
+
+# check if exa is using the minimum number of columns with headers
+
+[[cmd]]
+name = "‘COLUMN=200 exa -lGh’ with one file don’t produce extra columns even if there place for more"
+shell = "exa -lGh /testcases/files/10_bytes"
+environment = { COLUMNS = "200" }
+stdout = { file = "outputs/files_paths_long_grid_header_1file.ansitxt" }
+stderr = { empty = true }
+status = 0
+tags = [ 'env', 'long', 'grid' ]
+
+[[cmd]]
+name = "‘COLUMN=200 exa -lGh’ with several files don’t produce extra columns even if there place for more"
+shell = "exa -lGh /testcases/files/10_{bytes,KiB}"
+environment = { COLUMNS = "200" }
+stdout = { file = "outputs/files_paths_long_grid_header_2files.ansitxt" }
+stderr = { empty = true }
+status = 0
+tags = [ 'env', 'long', 'grid' ]

--- a/xtests/outputs/files_paths_long_grid_header_1file.ansitxt
+++ b/xtests/outputs/files_paths_long_grid_header_1file.ansitxt
@@ -1,0 +1,2 @@
+[4mPermissions[0m [4mSize[0m [4mUser[0m      [4mDate Modified[0m [4mName[0m
+.[1;33mr[31mw[0m[38;5;244m-[33mr[38;5;244m--[33mr[38;5;244m--[0m    [1;32m10[0m cassowary [34m 1 Jan 12:34[0m  [36m/testcases/files/[0m10_bytes

--- a/xtests/outputs/files_paths_long_grid_header_2files.ansitxt
+++ b/xtests/outputs/files_paths_long_grid_header_2files.ansitxt
@@ -1,0 +1,2 @@
+[4mPermissions[0m [4mSize[0m [4mUser[0m      [4mDate Modified[0m [4mName[0m                         [4mPermissions[0m [4mSize[0m [4mUser[0m      [4mDate Modified[0m [4mName[0m
+.[1;33mr[31mw[0m[38;5;244m-[33mr[38;5;244m--[33mr[38;5;244m--[0m    [1;32m10[0m cassowary [34m 1 Jan 12:34[0m  [36m/testcases/files/[0m10_bytes    .[1;33mr[31mw[0m[38;5;244m-[33mr[38;5;244m--[33mr[38;5;244m--[0m   [1;32m10[0m[32mk[0m cassowary [34m 1 Jan 12:34[0m  [36m/testcases/files/[0m10_KiB


### PR DESCRIPTION
The number of necessary columns was computed by producing a grid in different sizes and see if all columns were used. However, if there was two files and we tried to fit them in a 3-column grid, it would produces three headers and all three columns would be used; when trying a 4-column grid, the two supplementary headers would fill the third column and the fourth would be empty; so 3 columns would be used.

Now, when the grid fits into the terminal and the number of columns is exactly the number of files to display, it returns immediately instead of trying bigger grids.

Fixes GH-436.