### PR TITLE
Add options for -n or --numeric-gid-uid.

### DIFF
--- a/completions/completions.fish
+++ b/completions/completions.fish
@@ -65,7 +65,7 @@ complete -c exa -s 't' -l 'time'  -x -d "Which timestamp field to list" -a "
     created\t'Display created time'
 "
 complete -c exa -s 'm' -l 'modified'      -d "Use the modified timestamp field"
-complete -c exa -s 'n' -l 'numeric-uid-gid' -d "List numeric user and group IDs."
+complete -c exa -s 'n' -l 'numeric'       -d "List numeric user and group IDs."
 complete -c exa        -l 'changed'       -d "Use the changed timestamp field"
 complete -c exa -s 'u' -l 'accessed'      -d "Use the accessed timestamp field"
 complete -c exa -s 'U' -l 'created'       -d "Use the created timestamp field"

--- a/completions/completions.fish
+++ b/completions/completions.fish
@@ -65,7 +65,7 @@ complete -c exa -s 't' -l 'time'  -x -d "Which timestamp field to list" -a "
     created\t'Display created time'
 "
 complete -c exa -s 'm' -l 'modified'      -d "Use the modified timestamp field"
-complete -c -exa -s 'n' -l 'numeric-uid-gid' -d "List numeric user and group IDs."
+complete -c exa -s 'n' -l 'numeric-uid-gid' -d "List numeric user and group IDs."
 complete -c exa        -l 'changed'       -d "Use the changed timestamp field"
 complete -c exa -s 'u' -l 'accessed'      -d "Use the accessed timestamp field"
 complete -c exa -s 'U' -l 'created'       -d "Use the created timestamp field"

--- a/completions/completions.fish
+++ b/completions/completions.fish
@@ -65,6 +65,7 @@ complete -c exa -s 't' -l 'time'  -x -d "Which timestamp field to list" -a "
     created\t'Display created time'
 "
 complete -c exa -s 'm' -l 'modified'      -d "Use the modified timestamp field"
+complete -c -exa -s 'n' -l 'numeric-uid-gid' -d "List numeric user and group IDs."
 complete -c exa        -l 'changed'       -d "Use the changed timestamp field"
 complete -c exa -s 'u' -l 'accessed'      -d "Use the accessed timestamp field"
 complete -c exa -s 'U' -l 'created'       -d "Use the created timestamp field"

--- a/completions/completions.zsh
+++ b/completions/completions.zsh
@@ -39,6 +39,7 @@ __exa() {
         {-H,--links}"[List each file's number of hard links]" \
         {-i,--inode}"[List each file's inode number]" \
         {-m,--modified}"[Use the modified timestamp field]" \
+        {-n, --numeric-uid-gid}"[List numeric user and group IDs.]" \
         {-S,--blocks}"[List each file's number of filesystem blocks]" \
         {-t,--time}="[Which time field to show]:(time field):(accessed changed created modified)" \
         --time-style="[How to format timestamps]:(time style):(default iso long-iso full-iso)" \

--- a/completions/completions.zsh
+++ b/completions/completions.zsh
@@ -39,7 +39,7 @@ __exa() {
         {-H,--links}"[List each file's number of hard links]" \
         {-i,--inode}"[List each file's inode number]" \
         {-m,--modified}"[Use the modified timestamp field]" \
-        {-n, --numeric-uid-gid}"[List numeric user and group IDs.]" \
+        {-n, --numeric}"[List numeric user and group IDs.]" \
         {-S,--blocks}"[List each file's number of filesystem blocks]" \
         {-t,--time}="[Which time field to show]:(time field):(accessed changed created modified)" \
         --time-style="[How to format timestamps]:(time style):(default iso long-iso full-iso)" \

--- a/man/exa.1.md
+++ b/man/exa.1.md
@@ -140,6 +140,9 @@ These options are available when running with `--long` (`-l`):
 `-m`, `--modified`
 : Use the modified timestamp field.
 
+`-n`, `--numeric-uid-gid`
+: List numeric user and group IDs.
+
 `-S`, `--blocks`
 : List each file’s number of file system blocks.
 

--- a/man/exa.1.md
+++ b/man/exa.1.md
@@ -140,7 +140,7 @@ These options are available when running with `--long` (`-l`):
 `-m`, `--modified`
 : Use the modified timestamp field.
 
-`-n`, `--numeric-uid-gid`
+`-n`, `--numeric`
 : List numeric user and group IDs.
 
 `-S`, `--blocks`

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -39,7 +39,7 @@ const SORTS: Values = &[ "name", "Name", "size", "extension",
 pub static BINARY:     Arg = Arg { short: Some(b'b'), long: "binary",     takes_value: TakesValue::Forbidden };
 pub static BYTES:      Arg = Arg { short: Some(b'B'), long: "bytes",      takes_value: TakesValue::Forbidden };
 pub static GROUP:      Arg = Arg { short: Some(b'g'), long: "group",      takes_value: TakesValue::Forbidden };
-pub static NUM_UGID:   Arg = Arg { short: Some(b'n'), long: "numeric-uid-gid", takes_value: TakesValue::Forbidden };
+pub static NUMERIC:    Arg = Arg { short: Some(b'n'), long: "numeric",    takes_value: TakesValue::Forbidden };
 pub static HEADER:     Arg = Arg { short: Some(b'h'), long: "header",     takes_value: TakesValue::Forbidden };
 pub static ICONS:      Arg = Arg { short: None,       long: "icons",      takes_value: TakesValue::Forbidden };
 pub static INODE:      Arg = Arg { short: Some(b'i'), long: "inode",      takes_value: TakesValue::Forbidden };
@@ -75,7 +75,7 @@ pub static ALL_ARGS: Args = Args(&[
     &ALL, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST,
     &IGNORE_GLOB, &GIT_IGNORE, &ONLY_DIRS,
 
-    &BINARY, &BYTES, &GROUP, &NUM_UGID, &HEADER, &ICONS, &INODE, &LINKS, &MODIFIED, &CHANGED,
+    &BINARY, &BYTES, &GROUP, &NUMERIC, &HEADER, &ICONS, &INODE, &LINKS, &MODIFIED, &CHANGED,
     &BLOCKS, &TIME, &ACCESSED, &CREATED, &TIME_STYLE,
     &NO_PERMISSIONS, &NO_FILESIZE, &NO_USER, &NO_TIME,
 

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -39,6 +39,7 @@ const SORTS: Values = &[ "name", "Name", "size", "extension",
 pub static BINARY:     Arg = Arg { short: Some(b'b'), long: "binary",     takes_value: TakesValue::Forbidden };
 pub static BYTES:      Arg = Arg { short: Some(b'B'), long: "bytes",      takes_value: TakesValue::Forbidden };
 pub static GROUP:      Arg = Arg { short: Some(b'g'), long: "group",      takes_value: TakesValue::Forbidden };
+pub static NUM_UGID:   Arg = Arg { short: Some(b'n'), long: "numeric-uid-gid", takes_value: TakesValue::Forbidden };
 pub static HEADER:     Arg = Arg { short: Some(b'h'), long: "header",     takes_value: TakesValue::Forbidden };
 pub static ICONS:      Arg = Arg { short: None,       long: "icons",      takes_value: TakesValue::Forbidden };
 pub static INODE:      Arg = Arg { short: Some(b'i'), long: "inode",      takes_value: TakesValue::Forbidden };
@@ -74,7 +75,7 @@ pub static ALL_ARGS: Args = Args(&[
     &ALL, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST,
     &IGNORE_GLOB, &GIT_IGNORE, &ONLY_DIRS,
 
-    &BINARY, &BYTES, &GROUP, &HEADER, &ICONS, &INODE, &LINKS, &MODIFIED, &CHANGED,
+    &BINARY, &BYTES, &GROUP, &NUM_UGID, &HEADER, &ICONS, &INODE, &LINKS, &MODIFIED, &CHANGED,
     &BLOCKS, &TIME, &ACCESSED, &CREATED, &TIME_STYLE,
     &NO_PERMISSIONS, &NO_FILESIZE, &NO_USER, &NO_TIME,
 

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -39,28 +39,28 @@ FILTERING AND SORTING OPTIONS
                              date, time, old, and new all refer to modified.
 
 LONG VIEW OPTIONS
-  -b, --binary         list file sizes with binary prefixes
-  -B, --bytes          list file sizes in bytes, without any prefixes
-  -g, --group          list each file's group
-  -h, --header         add a header row to each column
-  -H, --links          list each file's number of hard links
-  -i, --inode          list each file's inode number
-  -m, --modified       use the modified timestamp field
-  -n, --numeric-uid-gid list numeric user and group IDs
-  -S, --blocks         show number of file system blocks
-  -t, --time FIELD     which timestamp field to list (modified, accessed, created)
-  -u, --accessed       use the accessed timestamp field
-  -U, --created        use the created timestamp field
-  --changed            use the changed timestamp field
-  --time-style         how to format timestamps (default, iso, long-iso, full-iso)
-  --no-permissions     suppress the permissions field
-  --octal-permissions  list each file's permission in octal format
-  --no-filesize        suppress the filesize field
-  --no-user            suppress the user field
-  --no-time            suppress the time field"##;
+  -b, --binary           list file sizes with binary prefixes
+  -B, --bytes            list file sizes in bytes, without any prefixes
+  -g, --group            list each file's group
+  -h, --header           add a header row to each column
+  -H, --links            list each file's number of hard links
+  -i, --inode            list each file's inode number
+  -m, --modified         use the modified timestamp field
+  -n, --numeric-uid-gid  list numeric user and group IDs
+  -S, --blocks           show number of file system blocks
+  -t, --time FIELD       which timestamp field to list (modified, accessed, created)
+  -u, --accessed         use the accessed timestamp field
+  -U, --created          use the created timestamp field
+  --changed              use the changed timestamp field
+  --time-style           how to format timestamps (default, iso, long-iso, full-iso)
+  --no-permissions       suppress the permissions field
+  --octal-permissions    list each file's permission in octal format
+  --no-filesize          suppress the filesize field
+  --no-user              suppress the user field
+  --no-time              suppress the time field"##;
 
-static GIT_HELP:      &str = r##"  --git                list each file's Git status, if tracked or ignored"##;
-static EXTENDED_HELP: &str = r##"  -@, --extended       list each file's extended attributes and sizes"##;
+static GIT_HELP:      &str = r##"  --git                  list each file's Git status, if tracked or ignored"##;
+static EXTENDED_HELP: &str = r##"  -@, --extended         list each file's extended attributes and sizes"##;
 
 
 /// All the information needed to display the help text, which depends

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -46,6 +46,7 @@ LONG VIEW OPTIONS
   -H, --links          list each file's number of hard links
   -i, --inode          list each file's inode number
   -m, --modified       use the modified timestamp field
+  -n, --numeric-uid-gid list numeric user and group IDs
   -S, --blocks         show number of file system blocks
   -t, --time FIELD     which timestamp field to list (modified, accessed, created)
   -u, --accessed       use the accessed timestamp field

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -39,28 +39,28 @@ FILTERING AND SORTING OPTIONS
                              date, time, old, and new all refer to modified.
 
 LONG VIEW OPTIONS
-  -b, --binary           list file sizes with binary prefixes
-  -B, --bytes            list file sizes in bytes, without any prefixes
-  -g, --group            list each file's group
-  -h, --header           add a header row to each column
-  -H, --links            list each file's number of hard links
-  -i, --inode            list each file's inode number
-  -m, --modified         use the modified timestamp field
-  -n, --numeric-uid-gid  list numeric user and group IDs
-  -S, --blocks           show number of file system blocks
-  -t, --time FIELD       which timestamp field to list (modified, accessed, created)
-  -u, --accessed         use the accessed timestamp field
-  -U, --created          use the created timestamp field
-  --changed              use the changed timestamp field
-  --time-style           how to format timestamps (default, iso, long-iso, full-iso)
-  --no-permissions       suppress the permissions field
-  --octal-permissions    list each file's permission in octal format
-  --no-filesize          suppress the filesize field
-  --no-user              suppress the user field
-  --no-time              suppress the time field"##;
+  -b, --binary         list file sizes with binary prefixes
+  -B, --bytes          list file sizes in bytes, without any prefixes
+  -g, --group          list each file's group
+  -h, --header         add a header row to each column
+  -H, --links          list each file's number of hard links
+  -i, --inode          list each file's inode number
+  -m, --modified       use the modified timestamp field
+  -n, --numeric        list numeric user and group IDs
+  -S, --blocks         show number of file system blocks
+  -t, --time FIELD     which timestamp field to list (modified, accessed, created)
+  -u, --accessed       use the accessed timestamp field
+  -U, --created        use the created timestamp field
+  --changed            use the changed timestamp field
+  --time-style         how to format timestamps (default, iso, long-iso, full-iso)
+  --no-permissions     suppress the permissions field
+  --octal-permissions  list each file's permission in octal format
+  --no-filesize        suppress the filesize field
+  --no-user            suppress the user field
+  --no-time            suppress the time field"##;
 
-static GIT_HELP:      &str = r##"  --git                  list each file's Git status, if tracked or ignored"##;
-static EXTENDED_HELP: &str = r##"  -@, --extended         list each file's extended attributes and sizes"##;
+static GIT_HELP:      &str = r##"  --git                list each file's Git status, if tracked or ignored"##;
+static EXTENDED_HELP: &str = r##"  -@, --extended       list each file's extended attributes and sizes"##;
 
 
 /// All the information needed to display the help text, which depends

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -266,12 +266,12 @@ impl TimeFormat {
     }
 }
 
+
 impl UserFormat {
     fn deduce(matches: &MatchedFlags<'_>) -> Result<Self, OptionsError> {
         let flag = matches.has(&flags::NUM_UGID)?;
         Ok(if flag { Self::Numeric } else { Self::Name })
     }
-
 }
 
 

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -354,7 +354,8 @@ mod test {
                                    &flags::CREATED, &flags::ACCESSED,
                                    &flags::HEADER, &flags::GROUP,  &flags::INODE, &flags::GIT,
                                    &flags::LINKS,  &flags::BLOCKS, &flags::LONG,  &flags::LEVEL,
-                                   &flags::GRID,   &flags::ACROSS, &flags::ONE_LINE, &flags::TREE ];
+                                   &flags::GRID,   &flags::ACROSS, &flags::ONE_LINE, &flags::TREE,
+                                   &flags::NUM_UGID ];
 
     macro_rules! test {
 
@@ -532,59 +533,61 @@ mod test {
 
 
         // Default
-        test!(empty:         Mode <- [], None;            Both => like Ok(Mode::Grid(_)));
+        test!(empty:          Mode <- [], None;            Both => like Ok(Mode::Grid(_)));
 
         // Grid views
-        test!(original_g:    Mode <- ["-G"], None;        Both => like Ok(Mode::Grid(GridOptions { across: false, .. })));
-        test!(grid:          Mode <- ["--grid"], None;    Both => like Ok(Mode::Grid(GridOptions { across: false, .. })));
-        test!(across:        Mode <- ["--across"], None;  Both => like Ok(Mode::Grid(GridOptions { across: true,  .. })));
-        test!(gracross:      Mode <- ["-xG"], None;       Both => like Ok(Mode::Grid(GridOptions { across: true,  .. })));
+        test!(original_g:     Mode <- ["-G"], None;        Both => like Ok(Mode::Grid(GridOptions { across: false, .. })));
+        test!(grid:           Mode <- ["--grid"], None;    Both => like Ok(Mode::Grid(GridOptions { across: false, .. })));
+        test!(across:         Mode <- ["--across"], None;  Both => like Ok(Mode::Grid(GridOptions { across: true,  .. })));
+        test!(gracross:       Mode <- ["-xG"], None;       Both => like Ok(Mode::Grid(GridOptions { across: true,  .. })));
 
         // Lines views
-        test!(lines:         Mode <- ["--oneline"], None;     Both => like Ok(Mode::Lines));
-        test!(prima:         Mode <- ["-1"], None;            Both => like Ok(Mode::Lines));
+        test!(lines:          Mode <- ["--oneline"], None;     Both => like Ok(Mode::Lines));
+        test!(prima:          Mode <- ["-1"], None;            Both => like Ok(Mode::Lines));
 
         // Details views
-        test!(long:          Mode <- ["--long"], None;    Both => like Ok(Mode::Details(_)));
-        test!(ell:           Mode <- ["-l"], None;        Both => like Ok(Mode::Details(_)));
+        test!(long:           Mode <- ["--long"], None;    Both => like Ok(Mode::Details(_)));
+        test!(ell:            Mode <- ["-l"], None;        Both => like Ok(Mode::Details(_)));
 
         // Grid-details views
-        test!(lid:           Mode <- ["--long", "--grid"], None;  Both => like Ok(Mode::GridDetails(_)));
-        test!(leg:           Mode <- ["-lG"], None;               Both => like Ok(Mode::GridDetails(_)));
+        test!(lid:            Mode <- ["--long", "--grid"], None;  Both => like Ok(Mode::GridDetails(_)));
+        test!(leg:            Mode <- ["-lG"], None;               Both => like Ok(Mode::GridDetails(_)));
 
         // Options that do nothing with --long
-        test!(long_across:   Mode <- ["--long", "--across"],   None;  Last => like Ok(Mode::Details(_)));
+        test!(long_across:    Mode <- ["--long", "--across"],   None;  Last => like Ok(Mode::Details(_)));
 
         // Options that do nothing without --long
-        test!(just_header:   Mode <- ["--header"], None;  Last => like Ok(Mode::Grid(_)));
-        test!(just_group:    Mode <- ["--group"],  None;  Last => like Ok(Mode::Grid(_)));
-        test!(just_inode:    Mode <- ["--inode"],  None;  Last => like Ok(Mode::Grid(_)));
-        test!(just_links:    Mode <- ["--links"],  None;  Last => like Ok(Mode::Grid(_)));
-        test!(just_blocks:   Mode <- ["--blocks"], None;  Last => like Ok(Mode::Grid(_)));
-        test!(just_binary:   Mode <- ["--binary"], None;  Last => like Ok(Mode::Grid(_)));
-        test!(just_bytes:    Mode <- ["--bytes"],  None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_header:    Mode <- ["--header"],           None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_group:     Mode <- ["--group"],            None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_inode:     Mode <- ["--inode"],            None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_links:     Mode <- ["--links"],            None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_blocks:    Mode <- ["--blocks"],           None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_binary:    Mode <- ["--binary"],           None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_bytes:     Mode <- ["--bytes"],            None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_num_ugid:  Mode <- ["--numeric-uid-gid"],  None;  Last => like Ok(Mode::Grid(_)));
 
         #[cfg(feature = "git")]
         test!(just_git:      Mode <- ["--git"],    None;  Last => like Ok(Mode::Grid(_)));
 
-        test!(just_header_2: Mode <- ["--header"], None;  Complain => err OptionsError::Useless(&flags::HEADER, false, &flags::LONG));
-        test!(just_group_2:  Mode <- ["--group"],  None;  Complain => err OptionsError::Useless(&flags::GROUP,  false, &flags::LONG));
-        test!(just_inode_2:  Mode <- ["--inode"],  None;  Complain => err OptionsError::Useless(&flags::INODE,  false, &flags::LONG));
-        test!(just_links_2:  Mode <- ["--links"],  None;  Complain => err OptionsError::Useless(&flags::LINKS,  false, &flags::LONG));
-        test!(just_blocks_2: Mode <- ["--blocks"], None;  Complain => err OptionsError::Useless(&flags::BLOCKS, false, &flags::LONG));
-        test!(just_binary_2: Mode <- ["--binary"], None;  Complain => err OptionsError::Useless(&flags::BINARY, false, &flags::LONG));
-        test!(just_bytes_2:  Mode <- ["--bytes"],  None;  Complain => err OptionsError::Useless(&flags::BYTES,  false, &flags::LONG));
+        test!(just_header_2:  Mode <- ["--header"],           None;  Complain => err OptionsError::Useless(&flags::HEADER,   false, &flags::LONG));
+        test!(just_group_2:   Mode <- ["--group"],            None;  Complain => err OptionsError::Useless(&flags::GROUP,    false, &flags::LONG));
+        test!(just_inode_2:   Mode <- ["--inode"],            None;  Complain => err OptionsError::Useless(&flags::INODE,    false, &flags::LONG));
+        test!(just_links_2:   Mode <- ["--links"],            None;  Complain => err OptionsError::Useless(&flags::LINKS,    false, &flags::LONG));
+        test!(just_blocks_2:  Mode <- ["--blocks"],           None;  Complain => err OptionsError::Useless(&flags::BLOCKS,   false, &flags::LONG));
+        test!(just_binary_2:  Mode <- ["--binary"],           None;  Complain => err OptionsError::Useless(&flags::BINARY,   false, &flags::LONG));
+        test!(just_bytes_2:   Mode <- ["--bytes"],            None;  Complain => err OptionsError::Useless(&flags::BYTES,    false, &flags::LONG));
+        test!(just_num_ugid2: Mode <- ["--numeric-uid-gid"],  None;  Complain => err OptionsError::Useless(&flags::NUM_UGID, false, &flags::LONG));
 
         #[cfg(feature = "git")]
-        test!(just_git_2:    Mode <- ["--git"],    None;  Complain => err OptionsError::Useless(&flags::GIT,    false, &flags::LONG));
+        test!(just_git_2:     Mode <- ["--git"],    None;  Complain => err OptionsError::Useless(&flags::GIT,    false, &flags::LONG));
 
         // Contradictions and combinations
-        test!(lgo:           Mode <- ["--long", "--grid", "--oneline"], None;  Both => like Ok(Mode::Lines));
-        test!(lgt:           Mode <- ["--long", "--grid", "--tree"],    None;  Both => like Ok(Mode::Details(_)));
-        test!(tgl:           Mode <- ["--tree", "--grid", "--long"],    None;  Both => like Ok(Mode::GridDetails(_)));
-        test!(tlg:           Mode <- ["--tree", "--long", "--grid"],    None;  Both => like Ok(Mode::GridDetails(_)));
-        test!(ot:            Mode <- ["--oneline", "--tree"],           None;  Both => like Ok(Mode::Details(_)));
-        test!(og:            Mode <- ["--oneline", "--grid"],           None;  Both => like Ok(Mode::Grid(_)));
-        test!(tg:            Mode <- ["--tree", "--grid"],              None;  Both => like Ok(Mode::Grid(_)));
+        test!(lgo:            Mode <- ["--long", "--grid", "--oneline"], None;  Both => like Ok(Mode::Lines));
+        test!(lgt:            Mode <- ["--long", "--grid", "--tree"],    None;  Both => like Ok(Mode::Details(_)));
+        test!(tgl:            Mode <- ["--tree", "--grid", "--long"],    None;  Both => like Ok(Mode::GridDetails(_)));
+        test!(tlg:            Mode <- ["--tree", "--long", "--grid"],    None;  Both => like Ok(Mode::GridDetails(_)));
+        test!(ot:             Mode <- ["--oneline", "--tree"],           None;  Both => like Ok(Mode::Details(_)));
+        test!(og:             Mode <- ["--oneline", "--grid"],           None;  Both => like Ok(Mode::Grid(_)));
+        test!(tg:             Mode <- ["--tree", "--grid"],              None;  Both => like Ok(Mode::Grid(_)));
     }
 }

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -85,7 +85,7 @@ impl Mode {
         // user about flags that won’t have any effect.
         if matches.is_strict() {
             for option in &[ &flags::BINARY, &flags::BYTES, &flags::INODE, &flags::LINKS,
-                             &flags::HEADER, &flags::BLOCKS, &flags::TIME, &flags::GROUP, &flags::NUM_UGID ] {
+                             &flags::HEADER, &flags::BLOCKS, &flags::TIME, &flags::GROUP, &flags::NUMERIC ] {
                 if matches.has(option)? {
                     return Err(OptionsError::Useless(*option, false, &flags::LONG));
                 }
@@ -269,7 +269,7 @@ impl TimeFormat {
 
 impl UserFormat {
     fn deduce(matches: &MatchedFlags<'_>) -> Result<Self, OptionsError> {
-        let flag = matches.has(&flags::NUM_UGID)?;
+        let flag = matches.has(&flags::NUMERIC)?;
         Ok(if flag { Self::Numeric } else { Self::Name })
     }
 }
@@ -355,7 +355,7 @@ mod test {
                                    &flags::HEADER, &flags::GROUP,  &flags::INODE, &flags::GIT,
                                    &flags::LINKS,  &flags::BLOCKS, &flags::LONG,  &flags::LEVEL,
                                    &flags::GRID,   &flags::ACROSS, &flags::ONE_LINE, &flags::TREE,
-                                   &flags::NUM_UGID ];
+                                   &flags::NUMERIC ];
 
     macro_rules! test {
 
@@ -533,61 +533,61 @@ mod test {
 
 
         // Default
-        test!(empty:          Mode <- [], None;            Both => like Ok(Mode::Grid(_)));
+        test!(empty:         Mode <- [], None;            Both => like Ok(Mode::Grid(_)));
 
         // Grid views
-        test!(original_g:     Mode <- ["-G"], None;        Both => like Ok(Mode::Grid(GridOptions { across: false, .. })));
-        test!(grid:           Mode <- ["--grid"], None;    Both => like Ok(Mode::Grid(GridOptions { across: false, .. })));
-        test!(across:         Mode <- ["--across"], None;  Both => like Ok(Mode::Grid(GridOptions { across: true,  .. })));
-        test!(gracross:       Mode <- ["-xG"], None;       Both => like Ok(Mode::Grid(GridOptions { across: true,  .. })));
+        test!(original_g:    Mode <- ["-G"], None;        Both => like Ok(Mode::Grid(GridOptions { across: false, .. })));
+        test!(grid:          Mode <- ["--grid"], None;    Both => like Ok(Mode::Grid(GridOptions { across: false, .. })));
+        test!(across:        Mode <- ["--across"], None;  Both => like Ok(Mode::Grid(GridOptions { across: true,  .. })));
+        test!(gracross:      Mode <- ["-xG"], None;       Both => like Ok(Mode::Grid(GridOptions { across: true,  .. })));
 
         // Lines views
-        test!(lines:          Mode <- ["--oneline"], None;     Both => like Ok(Mode::Lines));
-        test!(prima:          Mode <- ["-1"], None;            Both => like Ok(Mode::Lines));
+        test!(lines:         Mode <- ["--oneline"], None;     Both => like Ok(Mode::Lines));
+        test!(prima:         Mode <- ["-1"], None;            Both => like Ok(Mode::Lines));
 
         // Details views
-        test!(long:           Mode <- ["--long"], None;    Both => like Ok(Mode::Details(_)));
-        test!(ell:            Mode <- ["-l"], None;        Both => like Ok(Mode::Details(_)));
+        test!(long:          Mode <- ["--long"], None;    Both => like Ok(Mode::Details(_)));
+        test!(ell:           Mode <- ["-l"], None;        Both => like Ok(Mode::Details(_)));
 
         // Grid-details views
-        test!(lid:            Mode <- ["--long", "--grid"], None;  Both => like Ok(Mode::GridDetails(_)));
-        test!(leg:            Mode <- ["-lG"], None;               Both => like Ok(Mode::GridDetails(_)));
+        test!(lid:           Mode <- ["--long", "--grid"], None;  Both => like Ok(Mode::GridDetails(_)));
+        test!(leg:           Mode <- ["-lG"], None;               Both => like Ok(Mode::GridDetails(_)));
 
         // Options that do nothing with --long
-        test!(long_across:    Mode <- ["--long", "--across"],   None;  Last => like Ok(Mode::Details(_)));
+        test!(long_across:   Mode <- ["--long", "--across"],   None;  Last => like Ok(Mode::Details(_)));
 
         // Options that do nothing without --long
-        test!(just_header:    Mode <- ["--header"],           None;  Last => like Ok(Mode::Grid(_)));
-        test!(just_group:     Mode <- ["--group"],            None;  Last => like Ok(Mode::Grid(_)));
-        test!(just_inode:     Mode <- ["--inode"],            None;  Last => like Ok(Mode::Grid(_)));
-        test!(just_links:     Mode <- ["--links"],            None;  Last => like Ok(Mode::Grid(_)));
-        test!(just_blocks:    Mode <- ["--blocks"],           None;  Last => like Ok(Mode::Grid(_)));
-        test!(just_binary:    Mode <- ["--binary"],           None;  Last => like Ok(Mode::Grid(_)));
-        test!(just_bytes:     Mode <- ["--bytes"],            None;  Last => like Ok(Mode::Grid(_)));
-        test!(just_num_ugid:  Mode <- ["--numeric-uid-gid"],  None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_header:   Mode <- ["--header"],   None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_group:    Mode <- ["--group"],    None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_inode:    Mode <- ["--inode"],    None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_links:    Mode <- ["--links"],    None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_blocks:   Mode <- ["--blocks"],   None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_binary:   Mode <- ["--binary"],   None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_bytes:    Mode <- ["--bytes"],    None;  Last => like Ok(Mode::Grid(_)));
+        test!(just_numeric:  Mode <- ["--numeric"],  None;  Last => like Ok(Mode::Grid(_)));
 
         #[cfg(feature = "git")]
         test!(just_git:      Mode <- ["--git"],    None;  Last => like Ok(Mode::Grid(_)));
 
-        test!(just_header_2:  Mode <- ["--header"],           None;  Complain => err OptionsError::Useless(&flags::HEADER,   false, &flags::LONG));
-        test!(just_group_2:   Mode <- ["--group"],            None;  Complain => err OptionsError::Useless(&flags::GROUP,    false, &flags::LONG));
-        test!(just_inode_2:   Mode <- ["--inode"],            None;  Complain => err OptionsError::Useless(&flags::INODE,    false, &flags::LONG));
-        test!(just_links_2:   Mode <- ["--links"],            None;  Complain => err OptionsError::Useless(&flags::LINKS,    false, &flags::LONG));
-        test!(just_blocks_2:  Mode <- ["--blocks"],           None;  Complain => err OptionsError::Useless(&flags::BLOCKS,   false, &flags::LONG));
-        test!(just_binary_2:  Mode <- ["--binary"],           None;  Complain => err OptionsError::Useless(&flags::BINARY,   false, &flags::LONG));
-        test!(just_bytes_2:   Mode <- ["--bytes"],            None;  Complain => err OptionsError::Useless(&flags::BYTES,    false, &flags::LONG));
-        test!(just_num_ugid2: Mode <- ["--numeric-uid-gid"],  None;  Complain => err OptionsError::Useless(&flags::NUM_UGID, false, &flags::LONG));
+        test!(just_header_2: Mode <- ["--header"],   None;  Complain => err OptionsError::Useless(&flags::HEADER,  false, &flags::LONG));
+        test!(just_group_2:  Mode <- ["--group"],    None;  Complain => err OptionsError::Useless(&flags::GROUP,   false, &flags::LONG));
+        test!(just_inode_2:  Mode <- ["--inode"],    None;  Complain => err OptionsError::Useless(&flags::INODE,   false, &flags::LONG));
+        test!(just_links_2:  Mode <- ["--links"],    None;  Complain => err OptionsError::Useless(&flags::LINKS,   false, &flags::LONG));
+        test!(just_blocks_2: Mode <- ["--blocks"],   None;  Complain => err OptionsError::Useless(&flags::BLOCKS,  false, &flags::LONG));
+        test!(just_binary_2: Mode <- ["--binary"],   None;  Complain => err OptionsError::Useless(&flags::BINARY,  false, &flags::LONG));
+        test!(just_bytes_2:  Mode <- ["--bytes"],    None;  Complain => err OptionsError::Useless(&flags::BYTES,   false, &flags::LONG));
+        test!(just_numeric2: Mode <- ["--numeric"],  None;  Complain => err OptionsError::Useless(&flags::NUMERIC, false, &flags::LONG));
 
         #[cfg(feature = "git")]
-        test!(just_git_2:     Mode <- ["--git"],    None;  Complain => err OptionsError::Useless(&flags::GIT,    false, &flags::LONG));
+        test!(just_git_2:    Mode <- ["--git"],    None;  Complain => err OptionsError::Useless(&flags::GIT,    false, &flags::LONG));
 
         // Contradictions and combinations
-        test!(lgo:            Mode <- ["--long", "--grid", "--oneline"], None;  Both => like Ok(Mode::Lines));
-        test!(lgt:            Mode <- ["--long", "--grid", "--tree"],    None;  Both => like Ok(Mode::Details(_)));
-        test!(tgl:            Mode <- ["--tree", "--grid", "--long"],    None;  Both => like Ok(Mode::GridDetails(_)));
-        test!(tlg:            Mode <- ["--tree", "--long", "--grid"],    None;  Both => like Ok(Mode::GridDetails(_)));
-        test!(ot:             Mode <- ["--oneline", "--tree"],           None;  Both => like Ok(Mode::Details(_)));
-        test!(og:             Mode <- ["--oneline", "--grid"],           None;  Both => like Ok(Mode::Grid(_)));
-        test!(tg:             Mode <- ["--tree", "--grid"],              None;  Both => like Ok(Mode::Grid(_)));
+        test!(lgo:           Mode <- ["--long", "--grid", "--oneline"], None;  Both => like Ok(Mode::Lines));
+        test!(lgt:           Mode <- ["--long", "--grid", "--tree"],    None;  Both => like Ok(Mode::Details(_)));
+        test!(tgl:           Mode <- ["--tree", "--grid", "--long"],    None;  Both => like Ok(Mode::GridDetails(_)));
+        test!(tlg:           Mode <- ["--tree", "--long", "--grid"],    None;  Both => like Ok(Mode::GridDetails(_)));
+        test!(ot:            Mode <- ["--oneline", "--tree"],           None;  Both => like Ok(Mode::Details(_)));
+        test!(og:            Mode <- ["--oneline", "--grid"],           None;  Both => like Ok(Mode::Grid(_)));
+        test!(tg:            Mode <- ["--tree", "--grid"],              None;  Both => like Ok(Mode::Grid(_)));
     }
 }

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -4,7 +4,7 @@ use crate::options::parser::MatchedFlags;
 use crate::output::{View, Mode, TerminalWidth, grid, details};
 use crate::output::grid_details::{self, RowThreshold};
 use crate::output::file_name::Options as FileStyle;
-use crate::output::table::{TimeTypes, SizeFormat, Columns, Options as TableOptions};
+use crate::output::table::{TimeTypes, SizeFormat, UserFormat, Columns, Options as TableOptions};
 use crate::output::time::TimeFormat;
 
 
@@ -183,8 +183,9 @@ impl TableOptions {
     fn deduce<V: Vars>(matches: &MatchedFlags<'_>, vars: &V) -> Result<Self, OptionsError> {
         let time_format = TimeFormat::deduce(matches, vars)?;
         let size_format = SizeFormat::deduce(matches)?;
+        let user_format = UserFormat::deduce(matches)?;
         let columns = Columns::deduce(matches)?;
-        Ok(Self { time_format, size_format, columns })
+        Ok(Self { time_format, size_format, columns , user_format})
     }
 }
 
@@ -263,6 +264,14 @@ impl TimeFormat {
             Err(OptionsError::BadArgument(&flags::TIME_STYLE, word))
         }
     }
+}
+
+impl UserFormat {
+    fn deduce(matches: &MatchedFlags<'_>) -> Result<Self, OptionsError> {
+        let flag = matches.has(&flags::NUM_UGID)?;
+        Ok(if flag { Self::Numeric } else { Self::Name })
+    }
+
 }
 
 

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -85,7 +85,7 @@ impl Mode {
         // user about flags that won’t have any effect.
         if matches.is_strict() {
             for option in &[ &flags::BINARY, &flags::BYTES, &flags::INODE, &flags::LINKS,
-                             &flags::HEADER, &flags::BLOCKS, &flags::TIME, &flags::GROUP ] {
+                             &flags::HEADER, &flags::BLOCKS, &flags::TIME, &flags::GROUP, &flags::NUM_UGID ] {
                 if matches.has(option)? {
                     return Err(OptionsError::Useless(*option, false, &flags::LONG));
                 }

--- a/src/output/render/users.rs
+++ b/src/output/render/users.rs
@@ -3,13 +3,15 @@ use users::Users;
 
 use crate::fs::fields as f;
 use crate::output::cell::TextCell;
+use crate::output::table::UserFormat;
 
 
 impl f::User {
-    pub fn render<C: Colours, U: Users>(self, colours: &C, users: &U) -> TextCell {
-        let user_name = match users.get_user_by_uid(self.0) {
-            Some(user)  => user.name().to_string_lossy().into(),
-            None        => self.0.to_string(),
+    pub fn render<C: Colours, U: Users>(self, colours: &C, users: &U, format: UserFormat) -> TextCell {
+        let user_name = match (format, users.get_user_by_uid(self.0)) {
+            (_, None)                      => self.0.to_string(),
+            (UserFormat::Numeric, _)       => self.0.to_string(),
+            (UserFormat::Name, Some(user)) => user.name().to_string_lossy().into(),
         };
 
         let style = if users.get_current_uid() == self.0 { colours.you() }
@@ -31,6 +33,7 @@ pub mod test {
     use super::Colours;
     use crate::fs::fields as f;
     use crate::output::cell::TextCell;
+    use crate::output::table::UserFormat;
 
     use users::User;
     use users::mock::MockUsers;
@@ -53,7 +56,10 @@ pub mod test {
 
         let user = f::User(1000);
         let expected = TextCell::paint_str(Red.bold(), "enoch");
-        assert_eq!(expected, user.render(&TestColours, &users))
+        assert_eq!(expected, user.render(&TestColours, &users, UserFormat::Name));
+
+        let expected = TextCell::paint_str(Red.bold(), "1000");
+        assert_eq!(expected, user.render(&TestColours, &users, UserFormat::Numeric));
     }
 
     #[test]
@@ -62,7 +68,8 @@ pub mod test {
 
         let user = f::User(1000);
         let expected = TextCell::paint_str(Red.bold(), "1000");
-        assert_eq!(expected, user.render(&TestColours, &users));
+        assert_eq!(expected, user.render(&TestColours, &users, UserFormat::Name));
+        assert_eq!(expected, user.render(&TestColours, &users, UserFormat::Numeric));
     }
 
     #[test]
@@ -72,20 +79,20 @@ pub mod test {
 
         let user = f::User(1000);
         let expected = TextCell::paint_str(Blue.underline(), "enoch");
-        assert_eq!(expected, user.render(&TestColours, &users));
+        assert_eq!(expected, user.render(&TestColours, &users, UserFormat::Name));
     }
 
     #[test]
     fn different_unnamed() {
         let user = f::User(1000);
         let expected = TextCell::paint_str(Blue.underline(), "1000");
-        assert_eq!(expected, user.render(&TestColours, &MockUsers::with_current_uid(0)));
+        assert_eq!(expected, user.render(&TestColours, &MockUsers::with_current_uid(0), UserFormat::Numeric));
     }
 
     #[test]
     fn overflow() {
         let user = f::User(2_147_483_648);
         let expected = TextCell::paint_str(Blue.underline(), "2147483648");
-        assert_eq!(expected, user.render(&TestColours, &MockUsers::with_current_uid(0)));
+        assert_eq!(expected, user.render(&TestColours, &MockUsers::with_current_uid(0), UserFormat::Numeric));
     }
 }

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -23,6 +23,7 @@ use crate::theme::Theme;
 pub struct Options {
     pub size_format: SizeFormat,
     pub time_format: TimeFormat,
+    pub user_format: UserFormat,
     pub columns: Columns,
 }
 
@@ -180,6 +181,15 @@ pub enum SizeFormat {
     JustBytes,
 }
 
+/// Formatting options for user and group.
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub enum UserFormat {
+    /// The UID / GID
+    Numeric,
+    /// Show the name
+    Name,
+}
+
 impl Default for SizeFormat {
     fn default() -> Self {
         Self::DecimalBytes
@@ -311,6 +321,7 @@ pub struct Table<'a> {
     widths: TableWidths,
     time_format: TimeFormat,
     size_format: SizeFormat,
+    user_format: UserFormat,
     git: Option<&'a GitCache>,
 }
 
@@ -333,6 +344,7 @@ impl<'a, 'f> Table<'a> {
             env,
             time_format: options.time_format,
             size_format: options.size_format,
+            user_format: options.user_format,
         }
     }
 
@@ -392,10 +404,10 @@ impl<'a, 'f> Table<'a> {
                 file.blocks().render(self.theme)
             }
             Column::User => {
-                file.user().render(self.theme, &*self.env.lock_users())
+                file.user().render(self.theme, &*self.env.lock_users(), self.user_format)
             }
             Column::Group => {
-                file.group().render(self.theme, &*self.env.lock_users())
+                file.group().render(self.theme, &*self.env.lock_users(), self.user_format)
             }
             Column::GitStatus => {
                 self.git_status(file).render(self.theme)


### PR DESCRIPTION
Closes #807.

This option is only available in -l.
There's test for rendering, but no test for option parsing.
(I don't understand that section of code.)

Also in `ls` this option implies `-l`, is it worth it to follow behavior of `ls`?