### PR TITLE
Update determine_time_zone according to GNU manual

### DIFF
--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -292,9 +292,21 @@ impl Environment {
 
 fn determine_time_zone() -> TZResult<TimeZone> {
     if let Ok(file) = env::var("TZ") {
-        TimeZone::from_file(format!("/usr/share/zoneinfo/{}", file))
-    }
-    else {
+        TimeZone::from_file({
+            if file.starts_with("/") {
+                file
+            } else {
+                format!("/usr/share/zoneinfo/{}", {
+                    if file.starts_with(":") {
+                        // Unwrap is panic-free here because we've checked if file starts with colon
+                        file.strip_prefix(":").unwrap()
+                    } else {
+                        file.as_str()
+                    }
+                })
+            }
+        })
+    } else {
         TimeZone::from_file("/etc/localtime")
     }
 }

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -298,10 +298,9 @@ fn determine_time_zone() -> TZResult<TimeZone> {
             } else {
                 format!("/usr/share/zoneinfo/{}", {
                     if file.starts_with(":") {
-                        // Unwrap is panic-free here because we've checked if file starts with colon
-                        file.strip_prefix(":").unwrap()
+                        file.replace(":", "")
                     } else {
-                        file.as_str()
+                        file
                     }
                 })
             }

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -298,7 +298,7 @@ fn determine_time_zone() -> TZResult<TimeZone> {
             } else {
                 format!("/usr/share/zoneinfo/{}", {
                     if file.starts_with(":") {
-                        file.replace(":", "")
+                        file.replacen(":", "", 1)
                     } else {
                         file
                     }


### PR DESCRIPTION
Fixes #817 

GNU manual: https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html

> The third format looks like this:

> :characters
If characters begins with a slash, it is an absolute file name; otherwise the library looks for the file /usr/share/zoneinfo/characters.