### PR TITLE
Add "octal-permissions" flag to list of options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ These options are available when running with `--long` (`-l`):
 - **--git**: list each file’s Git status, if tracked or ignored
 - **--time-style**: how to format timestamps
 - **--no-permissions**: suppress the permissions field
+- **--octal-permissions**: list each file's permission in octal format
 - **--no-filesize**: suppress the filesize field
 - **--no-user**: suppress the user field
 - **--no-time**: suppress the time field

--- a/completions/completions.fish
+++ b/completions/completions.fish
@@ -75,6 +75,7 @@ complete -c exa        -l 'time-style' -x -d "How to format timestamps" -a "
     full-iso\t'Display full ISO timestamps, up to the nanosecond'
 "
 complete -c exa        -l 'no-permissions' -d "Suppress the permissions field"
+complete -c exa        -l 'octal-permissions' -d "List each file's permission in octal format"
 complete -c exa        -l 'no-filesize'    -d "Suppress the filesize field"
 complete -c exa        -l 'no-user'        -d "Suppress the user field"
 complete -c exa        -l 'no-time'        -d "Suppress the time field"

--- a/completions/completions.zsh
+++ b/completions/completions.zsh
@@ -43,6 +43,7 @@ __exa() {
         {-t,--time}="[Which time field to show]:(time field):(accessed changed created modified)" \
         --time-style="[How to format timestamps]:(time style):(default iso long-iso full-iso)" \
         --no-permissions"[Suppress the permissions field]" \
+        --octal-permissions"[List each file's permission in octal format]" \
         --no-filesize"[Suppress the filesize field]" \
         --no-user"[Suppress the user field]" \
         --no-time"[Suppress the time field]" \


### PR DESCRIPTION
The absence of the flag was discovered thanks to #816

According to the
https://github.com/ogham/exa/blob/f42957fab8ef1f750315bd957a16baa848177f19/src/options/flags.rs#L65
and
https://github.com/ogham/exa/blob/86de17b788c676c08814441aac1becf2d2e40bdf/src/options/help.rs#L56
it really exists