### PR TITLE
Fix a rounding error in human readable filesizes

### DIFF
--- a/src/output/render/size.rs
+++ b/src/output/render/size.rs
@@ -41,9 +41,9 @@ impl f::Size {
         };
 
         let symbol = prefix.symbol();
-        let number = if n < 10_f64 { numerics.format_float(n, 1) }
-                              else { numerics.format_int(n as isize) };
-
+        let decimal_to_diplay = if n < 10_f64 { 1 } else { 0 };
+        let number = numerics.format_float(n, decimal_to_diplay);
+        
         // The numbers and symbols are guaranteed to be written in ASCII, so
         // we can skip the display width calculation.
         let width = DisplayWidth::from(number.len() + symbol.len());


### PR DESCRIPTION
Fix #812

For example, for a file of 454 908 bytes, exa displayed 454k but now displays 455k.

This was due to the fact that when the size of the file in the appropriate base (k, M, etc.) was superior to 10, exa stopped displaying the first decimal and formatted the number as an int by casting the float, which in practice was the same thing as if it took the floor of the size. Now, exa uses the same code path that does that the round case, except that it tells the library it uses to use 0 decimals in this particular case.