### PR TITLE
Use thousand separators again and fix alignement when it’s not ASCII

### DIFF
--- a/src/output/render/size.rs
+++ b/src/output/render/size.rs
@@ -36,20 +36,20 @@ impl f::Size {
         };
 
         let (prefix, n) = match result {
-            NumberPrefix::Standalone(b)   => return TextCell::paint(colours.size(None), b.to_string()),
+            NumberPrefix::Standalone(b)   => return TextCell::paint(colours.size(None), numerics.format_int(b)),
             NumberPrefix::Prefixed(p, n)  => (p, n),
         };
 
         let symbol = prefix.symbol();
-        let decimal_to_diplay = if n < 10_f64 { 1 } else { 0 };
-        let number = numerics.format_float(n, decimal_to_diplay);
+        let number = if n < 10_f64 {
+            numerics.format_float(n, 1)
+        } else {
+            numerics.format_int(n.round() as isize)
+        };
         
-        // The numbers and symbols are guaranteed to be written in ASCII, so
-        // we can skip the display width calculation.
-        let width = DisplayWidth::from(number.len() + symbol.len());
-
         TextCell {
-            width,
+            // symbol is guaranteed to be ASCII since unit prefixes are hardcoded.
+            width: DisplayWidth::from(&*number) + symbol.len(),
             contents: vec![
                 colours.size(Some(prefix)).paint(number),
                 colours.unit(Some(prefix)).paint(symbol),


### PR DESCRIPTION
Fix #657

- If the number has no prefix (Ki, Mi, etc.), use `format_int()` instead of `to_string()` to use thousand separator
- Use `DisplayWidth::from()` on strings instead of assuming ASCII.

I introduced a regression in #822: I used `format_float()` instead of `format_int()` in certain cases, but the first doesn’t include thousand separators in its representation, so it fixed the alignment issue but now the numbers aren’t displayed properly.

So, the initial bug was that when using `-b`, sometimes the size of a file is for example between 1000KiB and 1024KiB, so it’s under 1MiB and it’s the only case where thousands separator were used (since no thousand separator is used with `-B`). Size of numbers was computed by using stdlib `.len()`, but the thousand separator is non ASCII for some languages (e.g., French or Swedish, which both uses U+202F). This problem was present except when the size was between 1000 and 1024 bytes because then it would use another code path with a plain `.to_string()`, which was obviously wrong as well.

Just for fun I found where the comment about how «it’s guaranteed to be ASCII» has been introduced: 4c2bf2f2e6231c14a8aa44cb49c828034c342a69. It seems we can’t assume anything we don’t write ourselves is ASCII after all.

Before (0.9.0, `LC_NUMERIC=sv_SE.UTF-8`):
```
$ exa -lb
.rw-r--r--     1 002 ariasuni  6 Apr 15:41 1000_bytes.txt
.rw-r--r-- 1 014Ki ariasuni  6 Apr 15:39 1000_Ki.txt
```

Before (0.10.0):
```
$ exa -lb
.rw-r--r--   1002 ariasuni  6 Apr 15:41 1000_bytes.txt
.rw-r--r-- 1014Ki ariasuni  6 Apr 15:39 1000_Ki.txt
```

After (`LC_NUMERIC=en_US.UTF-8`):
```
$ exa -lb
.rw-r--r--   1 002 ariasuni  6 Apr 15:41 1000_bytes.txt
.rw-r--r-- 1 014Ki ariasuni  6 Apr 15:39 1000_Ki.txt

```

After (`LC_NUMERIC=sv_SE.UTF-8`):
```
$ exa -lb
.rw-r--r--   1 002 ariasuni  6 Apr 15:41 1000_bytes.txt
.rw-r--r-- 1 014Ki ariasuni  6 Apr 15:39 1000_Ki.txt
```

---

Following this:
- Is it voluntary that sizes displayed when the `-B` flag don’t use a thousand separator?
- I’m wondering if `TextCell` shouldn’t have a method that takes a `contents` vec and compute the `DisplayWidth` by itself, instead of relying on every part of the code that needs something more complex than `TextCell::paint()` to do the right thing.