### PR TITLE
Add option to show security attribute and improve extended support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ These options are available when running with `--long` (`-l`):
 - **-t**, **--time=(field)**: which timestamp field to use
 - **-u**, **--accessed**: use the accessed timestamp field
 - **-U**, **--created**: use the created timestamp field
+- **-Z**, **--context**: list each file’s security context
 - **-@**, **--extended**: list each file’s extended attributes and sizes
 - **--changed**: use the changed timestamp field
 - **--git**: list each file’s Git status, if tracked or ignored

--- a/completions/fish/exa.fish
+++ b/completions/fish/exa.fish
@@ -89,3 +89,4 @@ complete -c exa        -l 'no-time'        -d "Suppress the time field"
 # Optional extras
 complete -c exa -l 'git' -d "List each file's Git status, if tracked"
 complete -c exa -s '@' -l 'extended' -d "List each file's extended attributes and sizes"
+complete -c exa -s 'Z' -l 'context' -d "List each file's security context"

--- a/completions/zsh/_exa
+++ b/completions/zsh/_exa
@@ -53,6 +53,7 @@ __exa() {
         {-U,--created}"[Use the created timestamp field]" \
         --git"[List each file's Git status, if tracked]" \
         {-@,--extended}"[List each file's extended attributes and sizes]" \
+        {-Z,--context}"[List each file's security context]" \
         '*:filename:_files'
 }
 

--- a/man/exa.1.md
+++ b/man/exa.1.md
@@ -180,6 +180,9 @@ These options are available when running with `--long` (`-l`):
 `-@`, `--extended`
 : List each file’s extended attributes and sizes.
 
+`-Z`, `--context`
+: List each file's security context.
+
 `--git`  [if exa was built with git support]
 : List each file’s Git status, if tracked.
 

--- a/src/fs/fields.rs
+++ b/src/fs/fields.rs
@@ -259,3 +259,12 @@ impl Default for Git {
         }
     }
 }
+
+pub enum SecurityContextType<'a> {
+    SELinux(&'a str),
+    None
+}
+
+pub struct SecurityContext<'a> {
+    pub context: SecurityContextType<'a>,
+}

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -62,9 +62,10 @@ pub static NO_TIME: Arg = Arg { short: None, long: "no-time", takes_value: Takes
 pub static NO_ICONS: Arg = Arg { short: None, long: "no-icons", takes_value: TakesValue::Forbidden };
 
 // optional feature options
-pub static GIT:       Arg = Arg { short: None,       long: "git",               takes_value: TakesValue::Forbidden };
-pub static EXTENDED:  Arg = Arg { short: Some(b'@'), long: "extended",          takes_value: TakesValue::Forbidden };
-pub static OCTAL:     Arg = Arg { short: None,       long: "octal-permissions", takes_value: TakesValue::Forbidden };
+pub static GIT:              Arg = Arg { short: None,       long: "git",               takes_value: TakesValue::Forbidden };
+pub static EXTENDED:         Arg = Arg { short: Some(b'@'), long: "extended",          takes_value: TakesValue::Forbidden };
+pub static OCTAL:            Arg = Arg { short: None,       long: "octal-permissions", takes_value: TakesValue::Forbidden };
+pub static SECURITY_CONTEXT: Arg = Arg { short: Some(b'Z'), long: "context",           takes_value: TakesValue::Forbidden };
 
 
 pub static ALL_ARGS: Args = Args(&[
@@ -80,5 +81,5 @@ pub static ALL_ARGS: Args = Args(&[
     &BLOCKS, &TIME, &ACCESSED, &CREATED, &TIME_STYLE,
     &NO_PERMISSIONS, &NO_FILESIZE, &NO_USER, &NO_TIME, &NO_ICONS,
 
-    &GIT, &EXTENDED, &OCTAL
+    &GIT, &EXTENDED, &OCTAL, &SECURITY_CONTEXT
 ]);

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -64,6 +64,7 @@ LONG VIEW OPTIONS
 static GIT_FILTER_HELP: &str = "  --git-ignore               ignore files mentioned in '.gitignore'";
 static GIT_VIEW_HELP:   &str = "  --git                list each file's Git status, if tracked or ignored";
 static EXTENDED_HELP:   &str = "  -@, --extended       list each file's extended attributes and sizes";
+static SECATTR_HELP:    &str = "  -Z, --context        list each file's security context";
 
 
 /// All the information needed to display the help text, which depends
@@ -110,6 +111,7 @@ impl fmt::Display for HelpString {
 
         if xattr::ENABLED {
             write!(f, "\n{}", EXTENDED_HELP)?;
+            write!(f, "\n{}", SECATTR_HELP)?;
         }
 
         writeln!(f)

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -117,6 +117,7 @@ impl details::Options {
             table: None,
             header: false,
             xattr: xattr::ENABLED && matches.has(&flags::EXTENDED)?,
+            secattr: xattr::ENABLED && matches.has(&flags::SECURITY_CONTEXT)?,
         };
 
         Ok(details)
@@ -136,6 +137,7 @@ impl details::Options {
             table: Some(TableOptions::deduce(matches, vars)?),
             header: matches.has(&flags::HEADER)?,
             xattr: xattr::ENABLED && matches.has(&flags::EXTENDED)?,
+            secattr: xattr::ENABLED && matches.has(&flags::SECURITY_CONTEXT)?,
         })
     }
 }
@@ -201,17 +203,18 @@ impl Columns {
         let time_types = TimeTypes::deduce(matches)?;
         let git = matches.has(&flags::GIT)?;
 
-        let blocks = matches.has(&flags::BLOCKS)?;
-        let group  = matches.has(&flags::GROUP)?;
-        let inode  = matches.has(&flags::INODE)?;
-        let links  = matches.has(&flags::LINKS)?;
-        let octal  = matches.has(&flags::OCTAL)?;
+        let blocks           = matches.has(&flags::BLOCKS)?;
+        let group            = matches.has(&flags::GROUP)?;
+        let inode            = matches.has(&flags::INODE)?;
+        let links            = matches.has(&flags::LINKS)?;
+        let octal            = matches.has(&flags::OCTAL)?;
+        let security_context = xattr::ENABLED && matches.has(&flags::SECURITY_CONTEXT)?;
 
         let permissions = ! matches.has(&flags::NO_PERMISSIONS)?;
         let filesize =    ! matches.has(&flags::NO_FILESIZE)?;
         let user =        ! matches.has(&flags::NO_USER)?;
 
-        Ok(Self { time_types, inode, links, blocks, group, git, octal, permissions, filesize, user })
+        Ok(Self { time_types, inode, links, blocks, group, git, octal, security_context, permissions, filesize, user })
     }
 }
 

--- a/src/output/grid_details.rs
+++ b/src/output/grid_details.rs
@@ -7,7 +7,6 @@ use term_grid as grid;
 
 use crate::fs::{Dir, File};
 use crate::fs::feature::git::GitCache;
-use crate::fs::feature::xattr::FileAttributes;
 use crate::fs::filter::FileFilter;
 use crate::output::cell::TextCell;
 use crate::output::details::{Options as DetailsOptions, Row as DetailsRow, Render as DetailsRender};
@@ -150,7 +149,7 @@ impl<'a> Render<'a> {
         let (first_table, _) = self.make_table(options, &drender);
 
         let rows = self.files.iter()
-                       .map(|file| first_table.row_for_file(file, file_has_xattrs(file)))
+                       .map(|file| first_table.row_for_file(file, drender.show_xattr_hint(file)))
                        .collect::<Vec<_>>();
 
         let file_names = self.files.iter()
@@ -298,12 +297,4 @@ fn divide_rounding_up(a: usize, b: usize) -> usize {
     }
 
     result
-}
-
-
-fn file_has_xattrs(file: &File<'_>) -> bool {
-    match file.path.attributes() {
-        Ok(attrs)  => ! attrs.is_empty(),
-        Err(_)     => false,
-    }
 }

--- a/src/output/render/mod.rs
+++ b/src/output/render/mod.rs
@@ -35,3 +35,6 @@ pub use self::users::Colours as UserColours;
 
 mod octal;
 // octal uses just one colour
+
+mod securityctx;
+pub use self::securityctx::Colours as SecurityCtxColours;

--- a/src/output/render/permissions.rs
+++ b/src/output/render/permissions.rs
@@ -88,6 +88,7 @@ impl f::Permissions {
     }
 }
 
+#[cfg(windows)]
 impl f::Attributes {
     pub fn render<C: Colours+FiletypeColours>(&self, colours: &C) -> Vec<ANSIString<'static>> {
         let bit = |bit, chr: &'static str, style: Style| {

--- a/src/output/render/securityctx.rs
+++ b/src/output/render/securityctx.rs
@@ -1,0 +1,45 @@
+use ansi_term::Style;
+
+use crate::fs::fields as f;
+use crate::output::cell::{TextCell, DisplayWidth};
+
+
+impl f::SecurityContext<'_> {
+    pub fn render<C: Colours>(&self, colours: &C) -> TextCell {
+        match &self.context {
+            f::SecurityContextType::None => {
+                TextCell::paint_str(colours.none(), "?")
+            }
+            f::SecurityContextType::SELinux(context) => {
+                let mut chars = Vec::with_capacity(7);
+
+                for (i, part) in context.split(':').enumerate() {
+                    let partcolour = match i {
+                        0 => colours.selinux_user(),
+                        1 => colours.selinux_role(),
+                        2 => colours.selinux_type(),
+                        _ => colours.selinux_range()
+                    };
+                    if i > 0 {
+                        chars.push(colours.selinux_colon().paint(":"));
+                    }
+                    chars.push(partcolour.paint(String::from(part)));
+                }
+
+                TextCell {
+                    contents: chars.into(),
+                    width: DisplayWidth::from(context.len())
+                }
+            }
+        }
+    }
+}
+
+pub trait Colours {
+    fn none(&self)          -> Style;
+    fn selinux_colon(&self) -> Style;
+    fn selinux_user(&self)  -> Style;
+    fn selinux_role(&self)  -> Style;
+    fn selinux_type(&self)  -> Style;
+    fn selinux_range(&self) -> Style;
+}

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -44,6 +44,7 @@ pub struct Columns {
     pub group: bool,
     pub git: bool,
     pub octal: bool,
+    pub security_context: bool,
 
     // Defaults to true:
     pub permissions: bool,
@@ -93,6 +94,10 @@ impl Columns {
             columns.push(Column::Group);
         }
 
+        if self.security_context {
+            columns.push(Column::SecurityContext);
+        }
+
         if self.time_types.modified {
             columns.push(Column::Timestamp(TimeType::Modified));
         }
@@ -137,6 +142,8 @@ pub enum Column {
     GitStatus,
     #[cfg(unix)]
     Octal,
+    #[cfg(unix)]
+    SecurityContext,
 }
 
 /// Each column can pick its own **Alignment**. Usually, numbers are
@@ -194,6 +201,8 @@ impl Column {
             Self::GitStatus     => "Git",
             #[cfg(unix)]
             Self::Octal         => "Octal",
+            #[cfg(unix)]
+            Self::SecurityContext => "Security Context",
         }
     }
 }
@@ -492,6 +501,10 @@ impl<'a, 'f> Table<'a> {
             #[cfg(unix)]
             Column::Group => {
                 file.group().render(self.theme, &*self.env.lock_users(), self.user_format)
+            }
+            #[cfg(unix)]
+            Column::SecurityContext => {
+                file.security_context().render(self.theme)
             }
             Column::GitStatus => {
                 self.git_status(file).render(self.theme)

--- a/src/theme/default_theme.rs
+++ b/src/theme/default_theme.rs
@@ -66,6 +66,17 @@ impl UiStyles {
                 conflicted:  Red.normal(),
             },
 
+            security_context: SecurityContext {
+                none:       Style::default(),
+                selinux: SELinuxContext {
+                    colon: Style::default().dimmed(),
+                    user:  Blue.normal(),
+                    role:  Green.normal(),
+                    typ:   Yellow.normal(),
+                    range: Cyan.normal(),
+                },
+            },
+
             punctuation:  Fixed(244).normal(),
             date:         Blue.normal(),
             inode:        Purple.normal(),

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -308,6 +308,15 @@ impl FileNameColours for Theme {
     }
 }
 
+impl render::SecurityCtxColours for Theme {
+    fn none(&self)          -> Style { self.ui.security_context.none }
+    fn selinux_colon(&self) -> Style { self.ui.security_context.selinux.colon }
+    fn selinux_user(&self)  -> Style { self.ui.security_context.selinux.user }
+    fn selinux_role(&self)  -> Style { self.ui.security_context.selinux.role }
+    fn selinux_type(&self)  -> Style { self.ui.security_context.selinux.typ }
+    fn selinux_range(&self) -> Style { self.ui.security_context.selinux.range }
+}
+
 
 /// Some of the styles are **overlays**: although they have the same attribute
 /// set as regular styles (foreground and background colours, bold, underline,

--- a/src/theme/ui_styles.rs
+++ b/src/theme/ui_styles.rs
@@ -7,12 +7,13 @@ use crate::theme::lsc::Pair;
 pub struct UiStyles {
     pub colourful: bool,
 
-    pub filekinds:  FileKinds,
-    pub perms:      Permissions,
-    pub size:       Size,
-    pub users:      Users,
-    pub links:      Links,
-    pub git:        Git,
+    pub filekinds:        FileKinds,
+    pub perms:            Permissions,
+    pub size:             Size,
+    pub users:            Users,
+    pub links:            Links,
+    pub git:              Git,
+    pub security_context: SecurityContext,
 
     pub punctuation:  Style,
     pub date:         Style,
@@ -102,6 +103,21 @@ pub struct Git {
     pub typechange: Style,
     pub ignored: Style,
     pub conflicted: Style,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct SELinuxContext {
+    pub colon: Style,
+    pub user:  Style,
+    pub role:  Style,
+    pub typ:   Style,
+    pub range: Style,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct SecurityContext {
+    pub none:    Style,
+    pub selinux: SELinuxContext,
 }
 
 impl UiStyles {


### PR DESCRIPTION
Add a command line option `-Z/--context` to show the security context of objects, similar to ls(1).

Show the actual extended attribute values on `-@/--extended`, instead of just their length.

In case of a symlink, show the extended attributes of the symlink itself, not the target.
This matches the behavior of ls(1) and is more intuitive.

TODO:
   * test on `macos` (*should* compile)

In the future one might want to add support for SMACK security labels (`"security.SMACK64"`).

Closes: #254 #613

![exa](https://user-images.githubusercontent.com/6131885/115995675-8fddd480-a5dc-11eb-8a7c-95cf0a163ecc.jpg)

![exa2](https://user-images.githubusercontent.com/6131885/116300078-bf3c3f00-a79e-11eb-9563-3caec9a600a5.jpg)
