### PR TITLE
Fix all remaining clippy warnings

### DIFF
--- a/src/fs/feature/xattr.rs
+++ b/src/fs/feature/xattr.rs
@@ -246,7 +246,7 @@ mod lister {
 
             unsafe {
                 listxattr(
-                    c_path.as_ptr() as *const _,
+                    c_path.as_ptr().cast(),
                     ptr::null_mut(),
                     0,
                 )
@@ -261,8 +261,8 @@ mod lister {
 
             unsafe {
                 listxattr(
-                    c_path.as_ptr() as *const _,
-                    buf.as_mut_ptr() as *mut c_char,
+                    c_path.as_ptr().cast(),
+                    buf.as_mut_ptr().cast::<i8>(),
                     bufsize as size_t,
                 )
             }
@@ -276,8 +276,8 @@ mod lister {
 
             unsafe {
                 getxattr(
-                    c_path.as_ptr() as *const _,
-                    buf.as_ptr() as *const c_char,
+                    c_path.as_ptr().cast(),
+                    buf.as_ptr().cast::<i8>(),
                     ptr::null_mut(),
                     0,
                 )

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -78,11 +78,11 @@ impl<'dir> File<'dir> {
         let metadata   = std::fs::symlink_metadata(&path)?;
         let is_all_all = false;
 
-        Ok(File { path, parent_dir, metadata, ext, name, is_all_all })
+        Ok(File { name, ext, path, metadata, parent_dir, is_all_all })
     }
 
     pub fn new_aa_current(parent_dir: &'dir Dir) -> io::Result<File<'dir>> {
-        let path       = parent_dir.path.to_path_buf();
+        let path       = parent_dir.path.clone();
         let ext        = File::ext(&path);
 
         debug!("Statting file {:?}", &path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,10 @@
 #![warn(unused)]
 
 #![warn(clippy::all, clippy::pedantic)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_sign_loss)]
 #![allow(clippy::enum_glob_use)]
 #![allow(clippy::map_unwrap_or)]
 #![allow(clippy::match_same_arms)]
@@ -282,7 +286,7 @@ impl<'args> Exa<'args> {
 
                 let git_ignoring = self.options.filter.git_ignore == GitIgnore::CheckAndIgnore;
                 let git = self.git.as_ref();
-                let r = details::Render { dir, files, theme, file_style, opts, filter, recurse, git_ignoring, git };
+                let r = details::Render { dir, files, theme, file_style, opts, recurse, filter, git_ignoring, git };
                 r.render(&mut self.writer)
             }
 
@@ -306,7 +310,7 @@ impl<'args> Exa<'args> {
                 let git_ignoring = self.options.filter.git_ignore == GitIgnore::CheckAndIgnore;
 
                 let git = self.git.as_ref();
-                let r = details::Render { dir, files, theme, file_style, opts, filter, recurse, git_ignoring, git };
+                let r = details::Render { dir, files, theme, file_style, opts, recurse, filter, git_ignoring, git };
                 r.render(&mut self.writer)
             }
         }

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -32,13 +32,10 @@ impl Mode {
         let flag = matches.has_where_any(|f| f.matches(&flags::LONG) || f.matches(&flags::ONE_LINE)
                                           || f.matches(&flags::GRID) || f.matches(&flags::TREE));
 
-        let flag = match flag {
-            Some(f) => f,
-            None => {
-                Self::strict_check_long_flags(matches)?;
-                let grid = grid::Options::deduce(matches)?;
-                return Ok(Self::Grid(grid));
-            }
+        let flag = if let Some(f) = flag { f } else {
+            Self::strict_check_long_flags(matches)?;
+            let grid = grid::Options::deduce(matches)?;
+            return Ok(Self::Grid(grid));
         };
 
         if flag.matches(&flags::LONG)
@@ -194,7 +191,7 @@ impl TableOptions {
         let size_format = SizeFormat::deduce(matches)?;
         let user_format = UserFormat::deduce(matches)?;
         let columns = Columns::deduce(matches)?;
-        Ok(Self { time_format, size_format, columns , user_format})
+        Ok(Self { size_format, time_format, user_format, columns })
     }
 }
 
@@ -214,7 +211,7 @@ impl Columns {
         let filesize =    ! matches.has(&flags::NO_FILESIZE)?;
         let user =        ! matches.has(&flags::NO_USER)?;
 
-        Ok(Self { time_types, git, octal, blocks, group, inode, links, permissions, filesize, user })
+        Ok(Self { time_types, inode, links, blocks, group, git, octal, permissions, filesize, user })
     }
 }
 

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -350,9 +350,10 @@ impl<'a> Render<'a> {
     fn render_error(&self, error: &io::Error, tree: TreeParams, path: Option<PathBuf>) -> Row {
         use crate::output::file_name::Colours;
 
-        let error_message = match path {
-            Some(path) => format!("<{}: {}>", path.display(), error),
-            None       => format!("<{}>", error),
+        let error_message = if let Some(path) = path {
+            format!("<{}: {}>", path.display(), error)
+        } else {
+            format!("<{}>", error)
         };
 
         // TODO: broken_symlink() doesn’t quite seem like the right name for

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -298,7 +298,7 @@ impl Environment {
 
         let users = Mutex::new(UsersCache::new());
 
-        Self { tz, numeric, users }
+        Self { numeric, tz, users }
     }
 }
 


### PR DESCRIPTION
Follow-up of #862 and #865.

- Allow `clippy::cast_*`: generated warnings are mostly useless
- Fix the other warnings so using clippy is actually useful