### PR TITLE
Replace datetime and zoneinfo_compiled crates with chrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,12 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,15 +39,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "datetime"
-version = "0.5.2"
+name = "chrono"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c3f7a77f3e57fedf80e09136f2d8777ebf621207306f6d96d610af048354bc"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
- "locale",
- "pad",
- "redox_syscall",
+ "num-integer",
+ "num-traits",
+ "time",
  "winapi",
 ]
 
@@ -62,7 +56,7 @@ name = "exa"
 version = "0.10.1"
 dependencies = [
  "ansi_term",
- "datetime",
+ "chrono",
  "git2",
  "glob",
  "lazy_static",
@@ -77,7 +71,6 @@ dependencies = [
  "terminal_size",
  "unicode-width",
  "users",
- "zoneinfo_compiled",
 ]
 
 [[package]]
@@ -206,6 +199,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,15 +257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pad"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,12 +267,6 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
-
-[[package]]
-name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "scoped_threadpool"
@@ -293,6 +290,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
 dependencies = [
  "libc",
+ "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
  "winapi",
 ]
 
@@ -364,6 +372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
 
 [[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,13 +398,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "zoneinfo_compiled"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fbebe65e899530f43bd760b23fda8f141118f4db49952b02998cbd0907a5de"
-dependencies = [
- "byteorder",
- "datetime",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ name = "exa"
 
 [dependencies]
 ansi_term = "0.12"
+chrono = "0.4"
 glob = "0.3"
 lazy_static = "1.3"
 libc = "0.2"
@@ -31,21 +32,14 @@ term_grid = "0.2.0"
 terminal_size = "0.1.16"
 unicode-width = "0.1"
 users = "0.11"
-zoneinfo_compiled = "0.5.1"
-
-[dependencies.datetime]
-version = "0.5.2"
-default-features = false
-features = ["format"]
 
 [dependencies.git2]
 version = "0.13"
 optional = true
 default-features = false
 
-[build-dependencies.datetime]
-version = "0.5.2"
-default-features = false
+[build-dependencies]
+chrono = "0.4"
 
 [features]
 default = [ "git" ]

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ use std::fs::File;
 use std::io::{self, Write};
 use std::path::PathBuf;
 
-use datetime::{LocalDateTime, ISO};
+use chrono::prelude::*;
 
 
 /// The build script entry point.
@@ -118,6 +118,6 @@ fn nonstandard_features_string() -> String {
 
 /// Formats the current date as an ISO 8601 string.
 fn build_date() -> String {
-    let now = LocalDateTime::now();
-    format!("{}", now.date().iso())
+    let now = Local::now();
+    now.date().format("%Y-%m-%d").to_string()
 }

--- a/src/output/render/times.rs
+++ b/src/output/render/times.rs
@@ -1,27 +1,19 @@
-use std::time::SystemTime;
-
-use datetime::TimeZone;
-use ansi_term::Style;
-
 use crate::output::cell::TextCell;
 use crate::output::time::TimeFormat;
 
+use ansi_term::Style;
+use chrono::prelude::*;
+
 
 pub trait Render {
-    fn render(self, style: Style, tz: &Option<TimeZone>, format: TimeFormat) -> TextCell;
+    fn render(self, style: Style, time_offset: FixedOffset, time_format: TimeFormat) -> TextCell;
 }
 
-impl Render for Option<SystemTime> {
-    fn render(self, style: Style, tz: &Option<TimeZone>, format: TimeFormat) -> TextCell {
+impl Render for Option<NaiveDateTime> {
+    fn render(self, style: Style, time_offset: FixedOffset, time_format: TimeFormat) -> TextCell {
         let datestamp = if let Some(time) = self {
-            if let Some(ref tz) = tz {
-                format.format_zoned(time, tz)
-            }
-            else {
-                format.format_local(time)
-            }
-        }
-        else {
+            time_format.format(&DateTime::<FixedOffset>::from_utc(time, time_offset))
+        } else {
             String::from("-")
         };
 


### PR DESCRIPTION
After hours of pain trying to retro-engineer several libc including glibc, musl and Bionic (Android), I’ve come to the conclusion that it’s the wrong approach. But I couldn’t understand the mess that’s time and timezone handling in C, much less investigate every OS we would like exa to support.

Fortunately, [`chrono`](https://crates.io/crates/chrono) already provides us a nice Rust layer on top of all the nasty C platform-dependent code. Apart from Android, chrono also supports Windows.

- Improve compatibility with other OSes, timezone are handled for us
- Reduce significantly code handling and rendering time

Fix #620 
Fix #712 
Fix #856
Fix #1047 

Close #846
Close #857