### PR TITLE
Make sort more consistent accross uses and flags

### DIFF
--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -31,7 +31,7 @@ pub struct Render<'a> {
 }
 
 impl<'a> Render<'a> {
-    pub fn render<W: Write>(mut self, w: &mut W) -> io::Result<()> {
+    pub fn render<W: Write>(mut self, w: &mut W, maybe_different_parents: bool) -> io::Result<()> {
         let mut grid = tg::Grid::new(tg::GridOptions {
             direction:  self.opts.direction(),
             filling:    tg::Filling::Spaces(2),
@@ -39,7 +39,7 @@ impl<'a> Render<'a> {
 
         grid.reserve(self.files.len());
 
-        self.filter.sort_files(&mut self.files);
+        self.filter.sort_files(&mut self.files, maybe_different_parents);
         for file in &self.files {
             let filename = self.file_style.for_file(file, self.theme).paint();
 

--- a/src/output/grid_details.rs
+++ b/src/output/grid_details.rs
@@ -133,12 +133,13 @@ impl<'a> Render<'a> {
     // This doesn’t take an IgnoreCache even though the details one does
     // because grid-details has no tree view.
 
-    pub fn render<W: Write>(mut self, w: &mut W) -> io::Result<()> {
+    pub fn render<W: Write>(mut self, w: &mut W, maybe_different_parents: bool) -> io::Result<()> {
+        self.filter.sort_files(&mut self.files, maybe_different_parents);
         if let Some((grid, width)) = self.find_fitting_grid() {
             write!(w, "{}", grid.fit_into_columns(width))
         }
         else {
-            self.give_up().render(w)
+            self.give_up().render(w, maybe_different_parents)
         }
     }
 

--- a/src/output/lines.rs
+++ b/src/output/lines.rs
@@ -18,8 +18,8 @@ pub struct Render<'a> {
 }
 
 impl<'a> Render<'a> {
-    pub fn render<W: Write>(mut self, w: &mut W) -> io::Result<()> {
-        self.filter.sort_files(&mut self.files);
+    pub fn render<W: Write>(mut self, w: &mut W, maybe_different_parents: bool) -> io::Result<()> {
+        self.filter.sort_files(&mut self.files, maybe_different_parents);
         for file in &self.files {
             let name_cell = self.render_file(file);
             writeln!(w, "{}", ANSIStrings(&name_cell))?;


### PR DESCRIPTION
Fix #863

In some cases, files were sorted twice, which in most cases is harmless.
But when two files are determined equal, their order is unchanged (because the sort is stable).
With `--reverse`, equal elements order, which wasn’t changed by the sort, were reversed twice (unchanged).

Also, command lines arguments are now sorted by their path.

---

I still need to check the xtests to see if anything’s wrong with my changes, and update the tests that needs it.