### PR TITLE
`exa` is in "stable" since Debian 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,7 @@ On Android / Termux, install the [`exa`](https://github.com/termux/termux-packag
 
 ### Debian
 
-On Debian, install the [`exa`](https://packages.debian.org/unstable/exa) package.
-For now, exa is in the _unstable_ repository.
+On Debian, install the [`exa`](https://packages.debian.org/stable/exa) package.
 
     $ apt install exa
 


### PR DESCRIPTION
The Readme previously stated that it was only in unstable