### PR TITLE
fix:  Compilation failed on aarch64

### DIFF
--- a/src/fs/feature/xattr.rs
+++ b/src/fs/feature/xattr.rs
@@ -258,7 +258,7 @@ mod lister {
                 FollowSymlinks::Yes  => listxattr,
                 FollowSymlinks::No   => llistxattr,
             };
-
+            #[cfg(not(target_arch = "aarch64"))]            
             unsafe {
                 listxattr(
                     c_path.as_ptr().cast(),
@@ -266,6 +266,15 @@ mod lister {
                     bufsize as size_t,
                 )
             }
+            #[cfg(target_arch = "aarch64")]            
+            unsafe {
+                listxattr(
+                    c_path.as_ptr().cast(),
+                    buf.as_mut_ptr().cast::<u8>(),
+                    bufsize as size_t,
+                )
+            }
+
         }
 
         pub fn getxattr(&self, c_path: &CString, buf: &[u8]) -> ssize_t {
@@ -274,10 +283,20 @@ mod lister {
                 FollowSymlinks::No   => lgetxattr,
             };
 
+            #[cfg(not(target_arch = "aarch64"))]            
             unsafe {
                 getxattr(
                     c_path.as_ptr().cast(),
                     buf.as_ptr().cast::<i8>(),
+                    ptr::null_mut(),
+                    0,
+                )
+            }
+            #[cfg(target_arch = "aarch64")]            
+            unsafe {
+                getxattr(
+                    c_path.as_ptr().cast(),
+                    buf.as_ptr().cast::<u8>(),
                     ptr::null_mut(),
                     0,
                 )


### PR DESCRIPTION
I fixed [this issue](https://github.com/ogham/exa/issues/887) with conditional compilation and its compile error hint.

But I'm new to rust, I can compile successfully now under linux with x86_64 and aarch64 architecture, I don't know if it will affect other operating systems or architectures.

Thank you, code reviewer!