### PR TITLE
Call `{symlink_,}metadata` only when really needed

### DIFF
--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -2,7 +2,6 @@
 
 use std::cmp::Ordering;
 use std::iter::FromIterator;
-use std::os::unix::fs::MetadataExt;
 
 use crate::fs::DotFilter;
 use crate::fs::File;
@@ -222,8 +221,8 @@ impl SortField {
             Self::Name(ABCabc)  => natord::compare(&a.name, &b.name),
             Self::Name(AaBbCc)  => natord::compare_ignore_case(&a.name, &b.name),
 
-            Self::Size          => a.metadata.len().cmp(&b.metadata.len()),
-            Self::FileInode     => a.metadata.ino().cmp(&b.metadata.ino()),
+            Self::Size          => a.file_len().cmp(&b.file_len()),
+            Self::FileInode     => a.inode().0.cmp(&b.inode().0),
             Self::ModifiedDate  => a.modified_time().cmp(&b.modified_time()),
             Self::AccessedDate  => a.accessed_time().cmp(&b.accessed_time()),
             Self::ChangedDate   => a.changed_time().cmp(&b.changed_time()),

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -74,7 +74,7 @@ use crate::fs::feature::git::GitCache;
 use crate::fs::feature::xattr::{Attribute, FileAttributes};
 use crate::fs::filter::FileFilter;
 use crate::output::cell::TextCell;
-use crate::output::file_name::Options as FileStyle;
+use crate::output::file_name::{LinkStyle, Options as FileStyle};
 use crate::output::table::{Table, Options as TableOptions, Row as TableRow};
 use crate::output::tree::{TreeTrunk, TreeParams, TreeDepth};
 use crate::theme::Theme;
@@ -282,8 +282,7 @@ impl<'a> Render<'a> {
                 t.add_widths(row);
             }
 
-            let file_name = self.file_style.for_file(egg.file, self.theme)
-                                .with_link_paths()
+            let file_name = self.file_style.for_file(egg.file, self.theme, LinkStyle::FullLinkPaths)
                                 .paint()
                                 .promote();
 
@@ -296,7 +295,7 @@ impl<'a> Render<'a> {
             rows.push(row);
 
             if let Some(ref dir) = egg.dir {
-                for file_to_add in dir.files(self.filter.dot_filter, self.git, self.git_ignoring) {
+                for file_to_add in dir.files(self.filter.dot_filter, self.git, self.git_ignoring, true) {
                     match file_to_add {
                         Ok(f) => {
                             files.push(f);

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -4,7 +4,7 @@ use term_grid as tg;
 
 use crate::fs::File;
 use crate::fs::filter::FileFilter;
-use crate::output::file_name::Options as FileStyle;
+use crate::output::file_name::{LinkStyle, Options as FileStyle};
 use crate::theme::Theme;
 
 
@@ -41,7 +41,7 @@ impl<'a> Render<'a> {
 
         self.filter.sort_files(&mut self.files);
         for file in &self.files {
-            let filename = self.file_style.for_file(file, self.theme).paint();
+            let filename = self.file_style.for_file(file, self.theme, LinkStyle::JustFilenames).paint();
 
             grid.add(tg::Cell {
                 contents:  filename.strings().to_string(),
@@ -57,7 +57,7 @@ impl<'a> Render<'a> {
             // This isn’t *quite* the same as the lines view, which also
             // displays full link paths.
             for file in &self.files {
-                let name_cell = self.file_style.for_file(file, self.theme).paint();
+                let name_cell = self.file_style.for_file(file, self.theme, LinkStyle::JustFilenames).paint();
                 writeln!(w, "{}", name_cell.strings())?;
             }
 

--- a/src/output/grid_details.rs
+++ b/src/output/grid_details.rs
@@ -11,7 +11,7 @@ use crate::fs::feature::xattr::FileAttributes;
 use crate::fs::filter::FileFilter;
 use crate::output::cell::TextCell;
 use crate::output::details::{Options as DetailsOptions, Row as DetailsRow, Render as DetailsRender};
-use crate::output::file_name::Options as FileStyle;
+use crate::output::file_name::{LinkStyle, Options as FileStyle};
 use crate::output::grid::Options as GridOptions;
 use crate::output::table::{Table, Row as TableRow, Options as TableOptions};
 use crate::output::tree::{TreeParams, TreeDepth};
@@ -154,11 +154,11 @@ impl<'a> Render<'a> {
                        .collect::<Vec<_>>();
 
         let file_names = self.files.iter()
-                             .map(|file| self.file_style.for_file(file, self.theme).paint().promote())
+                             .map(|file| self.file_style.for_file(file, self.theme, LinkStyle::JustFilenames).paint().promote())
                              .collect::<Vec<_>>();
 
         let mut last_working_grid = self.make_grid(1, options, &file_names, rows.clone(), &drender);
-        
+
         if file_names.len() == 1 {
             return Some((last_working_grid, 1));
         }
@@ -176,7 +176,7 @@ impl<'a> Render<'a> {
             if the_grid_fits {
                 last_working_grid = grid;
             }
-            
+
             if !the_grid_fits || column_count == file_names.len() {
                 let last_column_count = if the_grid_fits { column_count } else { column_count - 1 };
                 // If we’ve figured out how many columns can fit in the user’s terminal,

--- a/src/output/lines.rs
+++ b/src/output/lines.rs
@@ -5,7 +5,7 @@ use ansi_term::ANSIStrings;
 use crate::fs::File;
 use crate::fs::filter::FileFilter;
 use crate::output::cell::TextCellContents;
-use crate::output::file_name::{Options as FileStyle};
+use crate::output::file_name::{LinkStyle, Options as FileStyle};
 use crate::theme::Theme;
 
 
@@ -30,8 +30,7 @@ impl<'a> Render<'a> {
 
     fn render_file<'f>(&self, file: &'f File<'a>) -> TextCellContents {
         self.file_style
-            .for_file(file, self.theme)
-            .with_link_paths()
+            .for_file(file, self.theme, LinkStyle::FullLinkPaths)
             .paint()
     }
 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -293,6 +293,10 @@ impl render::UserColours for Theme {
 }
 
 impl FileNameColours for Theme {
+    fn colourful(&self) -> bool {
+        self.ui.colourful
+    }
+
     fn normal_arrow(&self)        -> Style { self.ui.punctuation }
     fn broken_symlink(&self)      -> Style { self.ui.broken_symlink }
     fn broken_filename(&self)     -> Style { apply_overlay(self.ui.broken_symlink, self.ui.broken_path_overlay) }


### PR DESCRIPTION
As we know `lstat` is very slow when metadata is not in cache.
When simply listing files and color is diabled (stdout is piped), all information from `read_dir` is enough. We can reduce tons of `lstat`/`statx` in case of lots of files in a single directory, and speeds up about 10x when listing a directory with 25k+ files.

```
$ echo 3 | sudo tee /proc/sys/vm/drop_caches
3

$ time target/release/exa /nix/store | wc -l # <- after this patch
26227
target/release/exa /nix/store  0.07s user 0.03s system 69% cpu 0.147 total
wc -l  0.01s user 0.01s system 11% cpu 0.147 total

$ echo 3 | sudo tee /proc/sys/vm/drop_caches
3

$ time exa /nix/store | wc -l # <- before this patch
26227
exa /nix/store  0.08s user 0.29s system 27% cpu 1.367 total
wc -l  0.00s user 0.02s system 1% cpu 1.367 total

$ echo 3 | sudo tee /proc/sys/vm/drop_caches
3

$ time ls /nix/store | wc -l # <- for comparison 
26227
ls /nix/store  0.04s user 0.01s system 60% cpu 0.084 total
wc -l  0.00s user 0.00s system 4% cpu 0.084 total
```