### PR TITLE
Use safer method of pointer casting when getting extended attributes.

### DIFF
--- a/src/fs/feature/xattr.rs
+++ b/src/fs/feature/xattr.rs
@@ -167,7 +167,7 @@ mod lister {
             unsafe {
                 listxattr(
                     c_path.as_ptr(),
-                    buf.as_mut_ptr() as *mut c_char,
+                    buf.as_mut_ptr().cast::<i8>(),
                     bufsize as size_t,
                     self.c_flags,
                 )
@@ -178,7 +178,7 @@ mod lister {
             unsafe {
                 getxattr(
                     c_path.as_ptr(),
-                    buf.as_ptr() as *const c_char,
+                    buf.as_ptr().cast::<i8>(),
                     ptr::null_mut(),
                     0,
                     0,


### PR DESCRIPTION
Hey. I'm new to rust (and using exa which is _amazing_). I ran clippy and it suggested these changes to the unsafe pointer casting that's happening. 

I ran the cargo tests and they all but, but I noticed I didn't see anything explicitly in the list about xattrs when running. 

I'd be willing to *try* write some tests ,and test on macOS and linux, if needed to verify these changes are OK.