### PR TITLE
Add dependabot config for cargo updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
Merging this opens update PRs like they can be seen here https://github.com/dbast/exa/pulls

Proposed updates can be merged if CI is green or closed to be ignored.