### PR TITLE
Added -E --only-files filtering option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ exa’s options are almost, but not quite, entirely unlike `ls`’s.
 - **-s**, **--sort=(field)**: which field to sort by
 - **--group-directories-first**: list directories before other files
 - **-D**, **--only-dirs**: list only directories
-- **-E**, **--only-files**: list only files
+- **-E**, **--only-files**: list only files, recursion not available
 - **--git-ignore**: ignore files mentioned in `.gitignore`
 - **-I**, **--ignore-glob=(globs)**: glob patterns (pipe-separated) of files to ignore
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ exa’s options are almost, but not quite, entirely unlike `ls`’s.
 - **-s**, **--sort=(field)**: which field to sort by
 - **--group-directories-first**: list directories before other files
 - **-D**, **--only-dirs**: list only directories
+- **-E**, **--only-files**: list only files
 - **--git-ignore**: ignore files mentioned in `.gitignore`
 - **-I**, **--ignore-glob=(globs)**: glob patterns (pipe-separated) of files to ignore
 

--- a/completions/fish/exa.fish
+++ b/completions/fish/exa.fish
@@ -50,7 +50,7 @@ complete -c exa -s 's' -l 'sort'   -x -d "Which field to sort by" -a "
 
 complete -c exa -s 'I' -l 'ignore-glob' -d "Ignore files that match these glob patterns" -r
 complete -c exa -s 'D' -l 'only-dirs'   -d "List only directories"
-complete -c exa -s 'E' -l 'only-files'  -d "List only files"
+complete -c exa -s 'E' -l 'only-files'  -d "List only files, recursion not available"
 
 # Long view options
 complete -c exa -s 'b' -l 'binary'   -d "List file sizes with binary prefixes"

--- a/completions/fish/exa.fish
+++ b/completions/fish/exa.fish
@@ -50,6 +50,7 @@ complete -c exa -s 's' -l 'sort'   -x -d "Which field to sort by" -a "
 
 complete -c exa -s 'I' -l 'ignore-glob' -d "Ignore files that match these glob patterns" -r
 complete -c exa -s 'D' -l 'only-dirs'   -d "List only directories"
+complete -c exa -s 'E' -l 'only-files'  -d "List only files"
 
 # Long view options
 complete -c exa -s 'b' -l 'binary'   -d "List file sizes with binary prefixes"

--- a/completions/zsh/_exa
+++ b/completions/zsh/_exa
@@ -28,7 +28,7 @@ __exa() {
         {-a,--all}"[Show hidden and 'dot' files]" \
         {-d,--list-dirs}"[List directories like regular files]" \
         {-D,--only-dirs}"[List only directories]" \
-        {-E,--only-files}"[List only files]" \
+        {-E,--only-files}"[List only files, recursion not available]" \
         {-L,--level}"+[Limit the depth of recursion]" \
         {-r,--reverse}"[Reverse the sort order]" \
         {-s,--sort}="[Which field to sort by]:(sort field):(accessed age changed created date extension Extension filename Filename inode modified oldest name Name newest none size time type)" \

--- a/completions/zsh/_exa
+++ b/completions/zsh/_exa
@@ -28,6 +28,7 @@ __exa() {
         {-a,--all}"[Show hidden and 'dot' files]" \
         {-d,--list-dirs}"[List directories like regular files]" \
         {-D,--only-dirs}"[List only directories]" \
+        {-E,--only-files}"[List only files]" \
         {-L,--level}"+[Limit the depth of recursion]" \
         {-r,--reverse}"[Reverse the sort order]" \
         {-s,--sort}="[Which field to sort by]:(sort field):(accessed age changed created date extension Extension filename Filename inode modified oldest name Name newest none size time type)" \

--- a/man/exa.1.md
+++ b/man/exa.1.md
@@ -114,7 +114,7 @@ Sort fields starting with a capital letter will sort uppercase before lowercase:
 : List only directories, not files.
 
 `-E`, `--only-files`
-: List only files, not directories.
+: List only files, not directories. Recursion not available.
 
 LONG VIEW OPTIONS
 =================

--- a/man/exa.1.md
+++ b/man/exa.1.md
@@ -113,6 +113,8 @@ Sort fields starting with a capital letter will sort uppercase before lowercase:
 `-D`, `--only-dirs`
 : List only directories, not files.
 
+`-E`, `--only-files`
+: List only files, not directories.
 
 LONG VIEW OPTIONS
 =================

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -40,6 +40,9 @@ pub struct FileFilter {
     /// Whether to only show directories.
     pub only_dirs: bool,
 
+    /// Whether to only show files.
+    pub only_files: bool,
+
     /// Which invisible “dot” files to include when listing a directory.
     ///
     /// Files starting with a single “.” are used to determine “system” or
@@ -69,6 +72,10 @@ impl FileFilter {
 
         if self.only_dirs {
             files.retain(File::is_directory);
+        }
+
+        if self.only_files {
+            files.retain(File::is_file);
         }
     }
 

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -15,6 +15,7 @@ impl FileFilter {
             list_dirs_first:  matches.has(&flags::DIRS_FIRST)?,
             reverse:          matches.has(&flags::REVERSE)?,
             only_dirs:        matches.has(&flags::ONLY_DIRS)?,
+            only_files:       matches.has(&flags::ONLY_FILES)?,
             sort_field:       SortField::deduce(matches)?,
             dot_filter:       DotFilter::deduce(matches)?,
             ignore_patterns:  IgnorePatterns::deduce(matches)?,

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -31,6 +31,7 @@ pub static IGNORE_GLOB: Arg = Arg { short: Some(b'I'), long: "ignore-glob", take
 pub static GIT_IGNORE:  Arg = Arg { short: None, long: "git-ignore",           takes_value: TakesValue::Forbidden };
 pub static DIRS_FIRST:  Arg = Arg { short: None, long: "group-directories-first",  takes_value: TakesValue::Forbidden };
 pub static ONLY_DIRS:   Arg = Arg { short: Some(b'D'), long: "only-dirs", takes_value: TakesValue::Forbidden };
+pub static ONLY_FILES:  Arg = Arg { short: Some(b'E'), long: "only-files", takes_value: TakesValue::Forbidden };
 const SORTS: Values = &[ "name", "Name", "size", "extension",
                          "Extension", "modified", "changed", "accessed",
                          "created", "inode", "type", "none" ];
@@ -74,7 +75,7 @@ pub static ALL_ARGS: Args = Args(&[
     &COLOR, &COLOUR, &COLOR_SCALE, &COLOUR_SCALE,
 
     &ALL, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST,
-    &IGNORE_GLOB, &GIT_IGNORE, &ONLY_DIRS,
+    &IGNORE_GLOB, &GIT_IGNORE, &ONLY_DIRS, &ONLY_FILES,
 
     &BINARY, &BYTES, &GROUP, &NUMERIC, &HEADER, &ICONS, &INODE, &LINKS, &MODIFIED, &CHANGED,
     &BLOCKS, &TIME, &ACCESSED, &CREATED, &TIME_STYLE,

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -33,7 +33,7 @@ FILTERING AND SORTING OPTIONS
   -s, --sort SORT_FIELD      which field to sort by
   --group-directories-first  list directories before other files
   -D, --only-dirs            list only directories
-  -E, --only-files           list only files
+  -E, --only-files           list only files, recursion not available
   -I, --ignore-glob GLOBS    glob patterns (pipe-separated) of files to ignore";
 
   static USAGE_PART2: &str = "  \

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -33,6 +33,7 @@ FILTERING AND SORTING OPTIONS
   -s, --sort SORT_FIELD      which field to sort by
   --group-directories-first  list directories before other files
   -D, --only-dirs            list only directories
+  -E, --only-files           list only files
   -I, --ignore-glob GLOBS    glob patterns (pipe-separated) of files to ignore";
 
   static USAGE_PART2: &str = "  \

--- a/xtests/outputs/help.ansitxt
+++ b/xtests/outputs/help.ansitxt
@@ -26,6 +26,7 @@ FILTERING AND SORTING OPTIONS
   -s, --sort SORT_FIELD      which field to sort by
   --group-directories-first  list directories before other files
   -D, --only-dirs            list only directories
+  -E, --only-files           list only files
   -I, --ignore-glob GLOBS    glob patterns (pipe-separated) of files to ignore
   --git-ignore               ignore files mentioned in '.gitignore'
   Valid sort fields:         name, Name, extension, Extension, size, type,

--- a/xtests/outputs/help.ansitxt
+++ b/xtests/outputs/help.ansitxt
@@ -26,7 +26,7 @@ FILTERING AND SORTING OPTIONS
   -s, --sort SORT_FIELD      which field to sort by
   --group-directories-first  list directories before other files
   -D, --only-dirs            list only directories
-  -E, --only-files           list only files
+  -E, --only-files           list only files, recursion not available
   -I, --ignore-glob GLOBS    glob patterns (pipe-separated) of files to ignore
   --git-ignore               ignore files mentioned in '.gitignore'
   Valid sort fields:         name, Name, extension, Extension, size, type,


### PR DESCRIPTION
-F was already taken, -E seemed like a good enough compromise.
There's a funny effect when both `--only-files`, `--only-dirs` are used.
For more clarity the options could be mutually exclusive, or this behaviour could simply be documented.