### PR TITLE
Make buildable on aarch64

### DIFF
--- a/src/fs/feature/xattr.rs
+++ b/src/fs/feature/xattr.rs
@@ -262,7 +262,7 @@ mod lister {
             unsafe {
                 listxattr(
                     c_path.as_ptr().cast(),
-                    buf.as_mut_ptr().cast::<i8>(),
+                    buf.as_mut_ptr().cast::<std::os::raw::c_char>(),
                     bufsize as size_t,
                 )
             }
@@ -277,7 +277,7 @@ mod lister {
             unsafe {
                 getxattr(
                     c_path.as_ptr().cast(),
-                    buf.as_ptr().cast::<i8>(),
+                    buf.as_ptr().cast::<std::os::raw::c_char>(),
                     ptr::null_mut(),
                     0,
                 )


### PR DESCRIPTION
Hi,

I had to make this change to make it build on aarch64.

char is an u8 on aarch64. Use the low level char representation
instead of i8 to make it build on Arm64.

Regards,
Sojan