### PR TITLE
Recognize .jxl and .avif as image files

### DIFF
--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -38,7 +38,7 @@ impl FileExtensions {
             "png", "jfi", "jfif", "jif", "jpe", "jpeg", "jpg", "gif", "bmp",
             "tiff", "tif", "ppm", "pgm", "pbm", "pnm", "webp", "raw", "arw",
             "svg", "stl", "eps", "dvi", "ps", "cbr", "jpf", "cbz", "xpm",
-            "ico", "cr2", "orf", "nef", "heif",
+            "ico", "cr2", "orf", "nef", "heif", "avif", "jxl",
         ])
     }
 

--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -110,6 +110,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "apk"           => '\u{e70e}', // 
             "apple"         => '\u{f179}', // 
             "avi"           => '\u{f03d}', // 
+            "avif"          => '\u{f1c5}', // 
             "avro"          => '\u{e60b}', // 
             "awk"           => '\u{f489}', // 
             "bash"          => '\u{f489}', // 
@@ -215,6 +216,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "js"            => '\u{e74e}', // 
             "json"          => '\u{e60b}', // 
             "jsx"           => '\u{e7ba}', // 
+            "jxl"           => '\u{f1c5}', // 
             "ksh"           => '\u{f489}', // 
             "latex"         => '\u{f034}', // 
             "less"          => '\u{e758}', // 


### PR DESCRIPTION
Adds .jxl and .avif as images in `src/filetype.rs`. Fixes #954.