### PR TITLE
add icon for .bats files

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -118,6 +118,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "bash_profile"  => '\u{f489}', // 
             "bashrc"        => '\u{f489}', // 
             "bat"           => '\u{f17a}', // 
+            "bats"          => '\u{f489}', // 
             "bmp"           => '\u{f1c5}', // 
             "bz"            => '\u{f410}', // 
             "bz2"           => '\u{f410}', // 

--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -118,7 +118,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "bash_profile"  => '\u{f489}', // 
             "bashrc"        => '\u{f489}', // 
             "bat"           => '\u{f17a}', // 
-            "bats"          => '\u{f489}', // 
+            "bats"          => '\u{f489}', // 
             "bmp"           => '\u{f1c5}', // 
             "bz"            => '\u{f410}', // 
             "bz2"           => '\u{f410}', // 


### PR DESCRIPTION
This adds the same icon as BASH for `.bats` files.