### PR TITLE
Don't assume connection to a tty when number of columns is set

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ fn main() {
             let writer = io::stdout();
 
             let console_width = options.view.width.actual_terminal_width();
-            let theme = options.theme.to_theme(console_width.is_some());
+            let theme = options.theme.to_theme(unsafe {libc::isatty(1)} != 0);
             let exa = Exa { options, writer, input_paths, theme, console_width, git };
 
             match exa.run() {


### PR DESCRIPTION
This fixes the colorization issue from #955. Im not sure about introducing an unsafe block for that libc call though, can I get an opinion on that?