### PR TITLE
Don't show an error on stdout when there is no timezone info

### DIFF
--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -288,7 +288,7 @@ impl Environment {
                 Some(t)
             }
             Err(ref e) => {
-                println!("Unable to determine time zone: {}", e);
+                debug!("Unable to determine time zone: {}", e);
                 None
             }
         };


### PR DESCRIPTION
This fixes issue #980.