### PR TITLE
feat: Add julia file extension icon

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -210,6 +210,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "jfi"           => '\u{f1c5}', // 
             "jfif"          => '\u{f1c5}', // 
             "jif"           => '\u{f1c5}', // 
+            "jl"            => '\u{e624}', // 
             "jpe"           => '\u{f1c5}', // 
             "jpeg"          => '\u{f1c5}', // 
             "jpg"           => '\u{f1c5}', // 


### PR DESCRIPTION
Icon for julia file extension '.jl' is added to the icons list.