### PR TITLE
Adding icons for .part and .torrent files

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -255,6 +255,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "ogg"           => '\u{f001}', // 
             "ogv"           => '\u{f03d}', // 
             "otf"           => '\u{f031}', // 
+            "part"          => '\u{f43a}', // 
             "patch"         => '\u{f440}', // 
             "pdf"           => '\u{f1c1}', // 
             "php"           => '\u{e73d}', // 
@@ -314,6 +315,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "tiff"          => '\u{f1c5}', // 
             "tlz"           => '\u{f410}', // 
             "toml"          => '\u{e615}', // 
+            "torrent"       => '\u{e275}', // 
             "ts"            => '\u{e628}', // 
             "tsv"           => '\u{f1c3}', // 
             "tsx"           => '\u{e7ba}', // 


### PR DESCRIPTION
I set the icons similar to what I found in this XFCE theme : 

https://www.pling.com/s/XFCE/p/1463720

Which looks like : 

![](https://github.com/cab-1729/Random-host/blob/main/Neonyt-Dark.png?raw=true)

A similar change has been accepted here : 

https://github.com/alexanderjeurissen/ranger_devicons/pull/101


