### PR TITLE
src/main.rs: remove clippy::unnested_or_patterns

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,6 @@
 #![allow(clippy::non_ascii_literal)]
 #![allow(clippy::option_if_let_else)]
 #![allow(clippy::too_many_lines)]
-#![allow(clippy::unnested_or_patterns)] // TODO: remove this when we support Rust 1.53.0
 #![allow(clippy::unused_self)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::wildcard_imports)]


### PR DESCRIPTION
This patch removes clippy::unnested_or_patterns from src/main.rs.

I can confirm that with this change, `exa` build without any problem.

```bash
$ cargo --version
cargo 1.53.0
```

```bash
$ cargo build
<snip>
    Finished dev [unoptimized] target(s) in 33.88s
```

```bash
$ cargo test
<snip>
test result: ok. 406 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
```

---------------------------
I thought `exa` supports Rust 1.53.0 since `README.md` describes as follows:

> exa is written in Rust. You will need rustc version 1.56.1 or higher.