### PR TITLE
Add git icon to .gitignore_global file

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -57,6 +57,7 @@ lazy_static! {
         m.insert(".gitconfig", '\u{f1d3}'); // 
         m.insert(".github", '\u{f408}'); // 
         m.insert(".gitignore", '\u{f1d3}'); // 
+        m.insert(".gitignore_global", '\u{f1d3}'); // 
         m.insert(".gitmodules", '\u{f1d3}'); // 
         m.insert(".rvm", '\u{e21e}'); // 
         m.insert(".vimrc", '\u{e62b}'); // 


### PR DESCRIPTION
We already have it for `gitignore_global` but not `.gitignore_global`.