### PR TITLE
Try canonicalisation when converting File to Dir

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -162,7 +162,10 @@ impl<'dir> File<'dir> {
     /// Returns an IO error upon failure, but this shouldn’t be used to check
     /// if a `File` is a directory or not! For that, just use `is_directory()`.
     pub fn to_dir(&self) -> io::Result<Dir> {
-        Dir::read_dir(self.path.clone())
+        match self.path.canonicalize() {
+            Ok(path) => Dir::read_dir(path),
+            Err(_) => Dir::read_dir(self.path.clone()),
+        }
     }
 
     /// Whether this file is a regular file on the filesystem — that is, not a


### PR DESCRIPTION
Without this canonicalisation, if the directory is a symbolic link to
another directory, later at `reorient_target_path` [1], File and path
argument look like:

```
- self: File {
    name: "."
    ext: None
    path: "/tmp/test2"
    metadata: {...}
    parent_dir: Some({
      contents: vec![]
      path: "/tmp/test2"
    })
    is_all_all: true
  }
- path: "test1"
```

...where /tmp/test2 is a symlink to /tmp/test1 and command being used is
`exa -laa /tmp/test2`.

So the result of `dir.join(&*path)` becomes `/tmp/test2/test1`, which
doesn't exist.

The canonicalisation also makes the behaviours of `exa -laa /tmp/test2`
and `exa -laa /tmp/test2/` consistent, where `.` is not treated as a
symlink in either case. This is a bit different from coreutils `ls`
though.

Closes #952.

[1] https://github.com/ogham/exa/blob/42659f93456d9ff7cc1096cbd84d778ede26d76e/src/fs/file.rs#L215-L217
