### PR TITLE
Fix broken link to Ubuntu Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ On openSUSE, install the [`exa`](https://software.opensuse.org/package/exa) pack
 
 ### Ubuntu
 
-On Ubuntu 20.10 (Groovy Gorilla) and later, install the [`exa`](https://packages.ubuntu.com/groovy/exa) package.
+On Ubuntu 21.04 (Hirsute Hippo), install the [`exa`](https://packages.ubuntu.com/hirsute/exa) package.
 
     $ sudo apt install exa
 


### PR DESCRIPTION

This PR includes:
- Fix broken link to Ubuntu Package

It seems that Ubuntu provides `exa` package only for Ubuntu 21.04 and 21.10 and 22.04 (hirsute, impish, jammy). For reference, see https://packages.ubuntu.com/search?keywords=exa&searchon=names&exact=1&suite=all&section=all .

closes: https://github.com/ogham/exa/issues/1014

-------------------------

Signed-off-by: KOSHIKAWA Kenichi <reishoku.misc ~~@~~ pm.me>