### PR TITLE
add icons for go.mod and go.sum

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -69,6 +69,8 @@ lazy_static! {
         m.insert("Dockerfile", '\u{f308}'); // 
         m.insert("ds_store", '\u{f179}'); // 
         m.insert("gitignore_global", '\u{f1d3}'); // 
+        m.insert("go.mod", '\u{e626}'); // 
+        m.insert("go.sum", '\u{e626}'); // 
         m.insert("gradle", '\u{e256}'); // 
         m.insert("gruntfile.coffee", '\u{e611}'); // 
         m.insert("gruntfile.js", '\u{e611}'); // 


### PR DESCRIPTION
<img width="280" alt="スクリーンショット 2022-04-23 10 21 10" src="https://user-images.githubusercontent.com/10097437/164854391-1c40f064-1999-4e12-8f83-c179e09eb7a7.png">
