### PR TITLE
Make symlinks report their target's size, if valid

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -315,6 +315,12 @@ impl<'dir> File<'dir> {
     /// Block and character devices return their device IDs, because they
     /// usually just have a file size of zero.
     pub fn size(&self) -> f::Size {
+        if self.is_link() {
+            let target = self.link_target();
+            if let FileTarget::Ok(target) = target {
+                return target.size();
+            }
+        }
         if self.is_directory() {
             f::Size::None
         }


### PR DESCRIPTION
The size that exa lists for symlinks is currently equal to the size of the link itself (roughly, the number of characters in the name of the target), rather than the size of the target. This is consistent with `ls -l`, but is not particularly useful. The symlink's own size is necessarily quite small, and is self-evident if the target path is printed. On the other hand, displaying the size of the target could be useful, for example when comparing sizes of files in a symlink-based file store[^1].

This PR sets the size of a symlink to be the size of its target, as long as the symlink points to an existing, non-cyclic location. I can't think of a use case where showing the symlink's own size is relevant, so in the interest of keeping the code simple, this PR does not add any flags; the new behaviour always applies.

Partially addresses #393.

```
$ mkdir wk
$ cd wk
$ head -c123456789 /dev/urandom > foo
$ ln -s foo bar
$ ln -s bar baz
$ ln -s oops qux
$ ln -s self self
$ ln -s /dev/sda dev
$
$ # before
$
$ exa -lab
lrwxrwxrwx     3 wlritchi 20 May 03:55 bar -> foo
lrwxrwxrwx     3 wlritchi 20 May 03:55 baz -> bar
lrwxrwxrwx     8 wlritchi 20 May 03:55 dev -> /dev/sda
.rw-r--r-- 118Mi wlritchi 20 May 03:55 foo
lrwxrwxrwx     4 wlritchi 20 May 03:55 qux -> oops
lrwxrwxrwx     4 wlritchi 20 May 03:55 self -> self
$
$ # after
$
$ ../target/debug/exa -lab
lrwxrwxrwx 118Mi wlritchi 20 May 03:55 bar -> foo
lrwxrwxrwx 118Mi wlritchi 20 May 03:55 baz -> bar
lrwxrwxrwx   8,0 wlritchi 20 May 03:55 dev -> /dev/sda
.rw-r--r-- 118Mi wlritchi 20 May 03:55 foo
lrwxrwxrwx     0 wlritchi 20 May 03:55 qux -> oops
lrwxrwxrwx     4 wlritchi 20 May 03:55 self -> self
$
```
[^1]: It's certainly much easier than typing `stat -c'%s' $(realpath foo) $(realpath bar) $(realpath baz)`, especially since target file names aren't meaningful in my file store.