### PR TITLE
Added icons for .pm similar to .pl

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -272,8 +272,10 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "pdf"           => '\u{f1c1}', // 
             "php"           => '\u{e73d}', // 
             "pl"            => '\u{e769}', // 
+            "plx"           => '\u{e769}', // 
             "pm"            => '\u{e769}', // 
             "png"           => '\u{f1c5}', // 
+            "pod"           => '\u{e769}', // 
             "ppt"           => '\u{f1c4}', // 
             "pptx"          => '\u{f1c4}', // 
             "procfile"      => '\u{e21e}', // 
@@ -319,6 +321,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "stylus"        => '\u{e600}', // 
             "svg"           => '\u{f1c5}', // 
             "swift"         => '\u{e755}', // 
+            "t"             => '\u{e769}', // 
             "tar"           => '\u{f410}', // 
             "taz"           => '\u{f410}', // 
             "tbz"           => '\u{f410}', // 

--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -272,6 +272,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "pdf"           => '\u{f1c1}', // 
             "php"           => '\u{e73d}', // 
             "pl"            => '\u{e769}', // 
+            "pm"            => '\u{e769}', // 
             "png"           => '\u{f1c5}', // 
             "ppt"           => '\u{f1c4}', // 
             "pptx"          => '\u{f1c4}', // 


### PR DESCRIPTION
Perl modules end with the _.pm_ extension. These are files imported by Perl scripts as objects. Most file managers I know display the same icon for .pm and .pl files.