### PR TITLE
updated links with markdown highlighting

### DIFF
--- a/src/fs/fields.rs
+++ b/src/fs/fields.rs
@@ -162,7 +162,7 @@ pub enum Size {
     /// data is rarely useful — I can’t think of a time when I’ve seen it and
     /// learnt something. So we discard it and just output “-” instead.
     ///
-    /// See this answer for more: http://unix.stackexchange.com/a/68266
+    /// See this answer for more: <http://unix.stackexchange.com/a/68266>
     None,
 
     /// This file is a block or character device, so instead of a size, print

--- a/src/fs/fields.rs
+++ b/src/fs/fields.rs
@@ -162,7 +162,7 @@ pub enum Size {
     /// data is rarely useful — I can’t think of a time when I’ve seen it and
     /// learnt something. So we discard it and just output “-” instead.
     ///
-    /// See this answer for more: <http://unix.stackexchange.com/a/68266>
+    /// See this answer for more: <https://unix.stackexchange.com/a/68266>
     None,
 
     /// This file is a block or character device, so instead of a size, print

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -146,7 +146,7 @@ pub enum SortField {
     /// slows the whole operation down, so many systems will only update the
     /// timestamp in certain circumstances. This has become common enough that
     /// it’s now expected behaviour!
-    /// <http://unix.stackexchange.com/a/8842>
+    /// <https://unix.stackexchange.com/a/8842>
     AccessedDate,
 
     /// The time the file was changed (the “ctime”).

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -146,7 +146,7 @@ pub enum SortField {
     /// slows the whole operation down, so many systems will only update the
     /// timestamp in certain circumstances. This has become common enough that
     /// it’s now expected behaviour!
-    /// http://unix.stackexchange.com/a/8842
+    /// <http://unix.stackexchange.com/a/8842>
     AccessedDate,
 
     /// The time the file was changed (the “ctime”).
@@ -155,7 +155,7 @@ pub enum SortField {
     /// changed — its permissions, owners, or link count.
     ///
     /// In original Unix, this was, however, meant as creation time.
-    /// https://www.bell-labs.com/usr/dmr/www/cacm.html
+    /// <https://www.bell-labs.com/usr/dmr/www/cacm.html>
     ChangedDate,
 
     /// The time the file was created (the “btime” or “birthtime”).

--- a/src/options/vars.rs
+++ b/src/options/vars.rs
@@ -16,7 +16,7 @@ pub static COLUMNS: &str = "COLUMNS";
 pub static TIME_STYLE: &str = "TIME_STYLE";
 
 /// Environment variable used to disable colors.
-/// See: https://no-color.org/
+/// See: <https://no-color.org/>
 pub static NO_COLOR: &str = "NO_COLOR";
 
 // exa-specific variables


### PR DESCRIPTION
Hello, updated the links in the comments to be highlighted in markdown, so it can help with generating docs and directly clicking on the link.