### PR TITLE
Added icon for img files

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -206,6 +206,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "hxx"           => '\u{f0fd}', // 
             "ico"           => '\u{f1c5}', // 
             "image"         => '\u{f1c5}', // 
+            "img"           => '\u{e271}', // 
             "iml"           => '\u{e7b5}', // 
             "ini"           => '\u{f17a}', // 
             "ipynb"         => '\u{e606}', // 


### PR DESCRIPTION
The new icon added for ```img``` is the same icon used by ``iso``` files.

```img``` files are used in the same way as ```iso``` files, for things like burning to storage devices, etc. The only difference being ```img``` files result in persistent storage devices unlike ```iso``` files. ```img``` files are also used for storing virtual machines.

Some operating systems use ```img``` files for their installers, most notably [NomadBSD](https://nomadbsd.org/download.html).

[Ranger devicons](https://github.com/alexanderjeurissen/ranger_devicons) uses the same icons for ```iso``` and ```img``` files, even though exa uses a different icon.