### PR TITLE
Implement 393: dereferencing links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ These options are available when running with `--long` (`-l`):
 - **-t**, **--time=(field)**: which timestamp field to use
 - **-u**, **--accessed**: use the accessed timestamp field
 - **-U**, **--created**: use the created timestamp field
+- **-X**, **--dereference**: dereference symlinks for file information
 - **-@**, **--extended**: list each file’s extended attributes and sizes
 - **--changed**: use the changed timestamp field
 - **--git**: list each file’s Git status, if tracked or ignored

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -47,7 +47,7 @@ impl Dir {
 
     /// Produce an iterator of IO results of trying to read all the files in
     /// this directory.
-    pub fn files<'dir, 'ig>(&'dir self, dots: DotFilter, git: Option<&'ig GitCache>, git_ignoring: bool) -> Files<'dir, 'ig> {
+    pub fn files<'dir, 'ig>(&'dir self, dots: DotFilter, git: Option<&'ig GitCache>, git_ignoring: bool, deref_links: bool) -> Files<'dir, 'ig> {
         Files {
             inner:     self.contents.iter(),
             dir:       self,
@@ -55,6 +55,7 @@ impl Dir {
             dots:      dots.dots(),
             git,
             git_ignoring,
+            deref_links,
         }
     }
 
@@ -89,6 +90,9 @@ pub struct Files<'dir, 'ig> {
     git: Option<&'ig GitCache>,
 
     git_ignoring: bool,
+
+    /// Whether symbolic links should be dereferenced when querying information.
+    deref_links: bool,
 }
 
 impl<'dir, 'ig> Files<'dir, 'ig> {
@@ -118,7 +122,7 @@ impl<'dir, 'ig> Files<'dir, 'ig> {
                     }
                 }
 
-                return Some(File::from_args(path.clone(), self.dir, filename)
+                return Some(File::from_args(path.clone(), self.dir, filename, self.deref_links)
                                  .map_err(|e| (path.clone(), e)))
             }
 

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -388,11 +388,25 @@ impl<'dir> File<'dir> {
 
     /// This file’s last modified timestamp, if available on this platform.
     pub fn modified_time(&self) -> Option<SystemTime> {
-        self.metadata.modified().ok()
+        if self.is_link() && self.deref_links {
+            match self.link_target_recurse() {
+                FileTarget::Ok(f) => f.metadata.modified().ok(),
+                _ => None, 
+            }
+        } else {
+            self.metadata.modified().ok()
+        }
     }
 
     /// This file’s last changed timestamp, if available on this platform.
     pub fn changed_time(&self) -> Option<SystemTime> {
+        if self.is_link() && self.deref_links {
+            match self.link_target_recurse() {
+                FileTarget::Ok(f) => return f.changed_time(),
+                _ => return None,
+            }
+        }
+        
         let (mut sec, mut nanosec) = (self.metadata.ctime(), self.metadata.ctime_nsec());
 
         if sec < 0 {
@@ -412,12 +426,26 @@ impl<'dir> File<'dir> {
 
     /// This file’s last accessed timestamp, if available on this platform.
     pub fn accessed_time(&self) -> Option<SystemTime> {
-        self.metadata.accessed().ok()
+        if self.is_link() && self.deref_links {
+            match self.link_target_recurse() {
+                FileTarget::Ok(f) => f.metadata.accessed().ok(),
+                _ => None, 
+            }
+        } else {
+            self.metadata.accessed().ok()
+        }
     }
 
     /// This file’s created timestamp, if available on this platform.
     pub fn created_time(&self) -> Option<SystemTime> {
-        self.metadata.created().ok()
+        if self.is_link() && self.deref_links {
+            match self.link_target_recurse() {
+                FileTarget::Ok(f) => f.metadata.created().ok(),
+                _ => None, 
+            }
+        } else {
+            self.metadata.created().ok()
+        }
     }
 
     /// This file’s ‘type’.

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -338,8 +338,14 @@ impl<'dir> File<'dir> {
     }
 
     /// The ID of the group that owns this file.
-    pub fn group(&self) -> f::Group {
-        f::Group(self.metadata.gid())
+    pub fn group(&self) -> Option<f::Group> {
+        if self.is_link() && self.deref_links {
+            match self.link_target_recurse() {
+               FileTarget::Ok(f) => return f.group(),
+               _ => return None,
+            }
+        }
+        Some(f::Group(self.metadata.gid()))
     }
 
     /// This file’s size, if it’s a regular file.

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -325,9 +325,16 @@ impl<'dir> File<'dir> {
         }
     }
 
-    /// The ID of the user that own this file.
-    pub fn user(&self) -> f::User {
-        f::User(self.metadata.uid())
+    /// The ID of the user that own this file. If dereferencing links, the links
+    /// may be broken, in which case `None` will be returned.
+    pub fn user(&self) -> Option<f::User> {
+        if self.is_link() && self.deref_links {
+            match self.link_target_recurse() {
+               FileTarget::Ok(f) => return f.user(),
+               _ => return None,
+            }
+        }
+        Some(f::User(self.metadata.uid()))
     }
 
     /// The ID of the group that owns this file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ impl<'args> Exa<'args> {
         let mut exit_status = 0;
 
         for file_path in &self.input_paths {
-            match File::from_args(PathBuf::from(file_path), None, None) {
+            match File::from_args(PathBuf::from(file_path), None, None, self.options.view.deref_links) {
                 Err(e) => {
                     exit_status = 2;
                     writeln!(io::stderr(), "{:?}: {}", file_path, e)?;
@@ -224,7 +224,7 @@ impl<'args> Exa<'args> {
 
             let mut children = Vec::new();
             let git_ignore = self.options.filter.git_ignore == GitIgnore::CheckAndIgnore;
-            for file in dir.files(self.options.filter.dot_filter, self.git.as_ref(), git_ignore) {
+            for file in dir.files(self.options.filter.dot_filter, self.git.as_ref(), git_ignore, self.options.view.deref_links) {
                 match file {
                     Ok(file)        => children.push(file),
                     Err((path, e))  => writeln!(io::stderr(), "[{}: {}]", path.display(), e)?,

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -6,13 +6,14 @@ pub static VERSION: Arg = Arg { short: Some(b'v'), long: "version",  takes_value
 pub static HELP:    Arg = Arg { short: Some(b'?'), long: "help",     takes_value: TakesValue::Forbidden };
 
 // display options
-pub static ONE_LINE: Arg = Arg { short: Some(b'1'), long: "oneline",  takes_value: TakesValue::Forbidden };
-pub static LONG:     Arg = Arg { short: Some(b'l'), long: "long",     takes_value: TakesValue::Forbidden };
-pub static GRID:     Arg = Arg { short: Some(b'G'), long: "grid",     takes_value: TakesValue::Forbidden };
-pub static ACROSS:   Arg = Arg { short: Some(b'x'), long: "across",   takes_value: TakesValue::Forbidden };
-pub static RECURSE:  Arg = Arg { short: Some(b'R'), long: "recurse",  takes_value: TakesValue::Forbidden };
-pub static TREE:     Arg = Arg { short: Some(b'T'), long: "tree",     takes_value: TakesValue::Forbidden };
-pub static CLASSIFY: Arg = Arg { short: Some(b'F'), long: "classify", takes_value: TakesValue::Forbidden };
+pub static ONE_LINE:    Arg = Arg { short: Some(b'1'), long: "oneline",     takes_value: TakesValue::Forbidden };
+pub static LONG:        Arg = Arg { short: Some(b'l'), long: "long",        takes_value: TakesValue::Forbidden };
+pub static GRID:        Arg = Arg { short: Some(b'G'), long: "grid",        takes_value: TakesValue::Forbidden };
+pub static ACROSS:      Arg = Arg { short: Some(b'x'), long: "across",      takes_value: TakesValue::Forbidden };
+pub static RECURSE:     Arg = Arg { short: Some(b'R'), long: "recurse",     takes_value: TakesValue::Forbidden };
+pub static TREE:        Arg = Arg { short: Some(b'T'), long: "tree",        takes_value: TakesValue::Forbidden };
+pub static CLASSIFY:    Arg = Arg { short: Some(b'F'), long: "classify",    takes_value: TakesValue::Forbidden };
+pub static DEREF_LINKS: Arg = Arg { short: Some(b'X'), long: "dereference", takes_value: TakesValue::Forbidden };
 
 pub static COLOR:  Arg = Arg { short: None, long: "color",  takes_value: TakesValue::Necessary(Some(COLOURS)) };
 pub static COLOUR: Arg = Arg { short: None, long: "colour", takes_value: TakesValue::Necessary(Some(COLOURS)) };
@@ -70,7 +71,7 @@ pub static OCTAL:     Arg = Arg { short: None,       long: "octal-permissions", 
 pub static ALL_ARGS: Args = Args(&[
     &VERSION, &HELP,
 
-    &ONE_LINE, &LONG, &GRID, &ACROSS, &RECURSE, &TREE, &CLASSIFY,
+    &ONE_LINE, &LONG, &GRID, &ACROSS, &RECURSE, &TREE, &CLASSIFY, &DEREF_LINKS,
     &COLOR, &COLOUR, &COLOR_SCALE, &COLOUR_SCALE,
 
     &ALL, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST,

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -13,7 +13,8 @@ impl View {
         let mode = Mode::deduce(matches, vars)?;
         let width = TerminalWidth::deduce(vars)?;
         let file_style = FileStyle::deduce(matches, vars)?;
-        Ok(Self { mode, width, file_style })
+        let deref_links = matches.has(&flags::DEREF_LINKS)?;
+        Ok(Self { mode, width, file_style, deref_links })
     }
 }
 

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -300,7 +300,7 @@ impl<'a> Render<'a> {
             rows.push(row);
 
             if let Some(ref dir) = egg.dir {
-                for file_to_add in dir.files(self.filter.dot_filter, self.git, self.git_ignoring) {
+                for file_to_add in dir.files(self.filter.dot_filter, self.git, self.git_ignoring, egg.file.deref_links) {
                     match file_to_add {
                         Ok(f) => {
                             files.push(f);

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -22,6 +22,7 @@ pub struct View {
     pub mode: Mode,
     pub width: TerminalWidth,
     pub file_style: file_name::Options,
+    pub deref_links: bool,
 }
 
 

--- a/src/output/render/mod.rs
+++ b/src/output/render/mod.rs
@@ -28,6 +28,7 @@ pub use self::times::Render as TimeRender;
 
 mod users;
 pub use self::users::Colours as UserColours;
+pub use self::users::Render as UserRender;
 
 mod octal;
 // octal uses just one colour

--- a/src/output/render/mod.rs
+++ b/src/output/render/mod.rs
@@ -8,7 +8,7 @@ mod git;
 pub use self::git::Colours as GitColours;
 
 mod groups;
-pub use self::groups::Colours as GroupColours;
+pub use self::groups::{Colours as GroupColours, Render as GroupRender};
 
 mod inode;
 // inode uses just one colour

--- a/src/output/render/mod.rs
+++ b/src/output/render/mod.rs
@@ -17,7 +17,7 @@ mod links;
 pub use self::links::Colours as LinksColours;
 
 mod permissions;
-pub use self::permissions::Colours as PermissionsColours;
+pub use self::permissions::{Colours as PermissionsColours, PermissionsPlusRender};
 
 mod size;
 pub use self::size::Colours as SizeColours;
@@ -31,4 +31,5 @@ pub use self::users::Colours as UserColours;
 pub use self::users::Render as UserRender;
 
 mod octal;
+pub use self::octal::Render as OctalPermissionsRender;
 // octal uses just one colour

--- a/src/output/render/octal.rs
+++ b/src/output/render/octal.rs
@@ -3,26 +3,37 @@ use ansi_term::Style;
 use crate::fs::fields as f;
 use crate::output::cell::TextCell;
 
+pub trait Render {
+    fn render(&self, style: Style) -> TextCell;
+}
+
+impl Render for Option<f::OctalPermissions> {
+    fn render(&self, style: Style) -> TextCell {
+        match self {
+            Some(p) => {
+                let perm = &p.permissions;
+                let octal_sticky = f::OctalPermissions::bits_to_octal(perm.setuid, perm.setgid, perm.sticky);
+                let octal_owner  = f::OctalPermissions::bits_to_octal(perm.user_read, perm.user_write, perm.user_execute);
+                let octal_group  = f::OctalPermissions::bits_to_octal(perm.group_read, perm.group_write, perm.group_execute);
+                let octal_other  = f::OctalPermissions::bits_to_octal(perm.other_read, perm.other_write, perm.other_execute);
+
+                TextCell::paint(style, format!("{}{}{}{}", octal_sticky, octal_owner, octal_group, octal_other))
+            },
+            None => TextCell::paint(style, "----".into())
+        }
+    }
+}
 
 impl f::OctalPermissions {
     fn bits_to_octal(r: bool, w: bool, x: bool) -> u8 {
         (r as u8) * 4 + (w as u8) * 2 + (x as u8)
-    }
-
-    pub fn render(&self, style: Style) -> TextCell {
-        let perm = &self.permissions;
-        let octal_sticky = Self::bits_to_octal(perm.setuid, perm.setgid, perm.sticky);
-        let octal_owner  = Self::bits_to_octal(perm.user_read, perm.user_write, perm.user_execute);
-        let octal_group  = Self::bits_to_octal(perm.group_read, perm.group_write, perm.group_execute);
-        let octal_other  = Self::bits_to_octal(perm.other_read, perm.other_write, perm.other_execute);
-
-        TextCell::paint(style, format!("{}{}{}{}", octal_sticky, octal_owner, octal_group, octal_other))
     }
 }
 
 
 #[cfg(test)]
 pub mod test {
+    use super::Render;
     use crate::output::cell::TextCell;
     use crate::fs::fields as f;
 
@@ -37,7 +48,7 @@ pub mod test {
             other_read: true, other_write: false, other_execute: true, sticky: false,
         };
 
-        let octal = f::OctalPermissions{ permissions: bits };
+        let octal = Some(f::OctalPermissions{ permissions: bits });
 
         let expected = TextCell::paint_str(Purple.bold(), "0755");
         assert_eq!(expected, octal.render(Purple.bold()).into());
@@ -51,7 +62,7 @@ pub mod test {
             other_read: true, other_write: false, other_execute: false, sticky: false,
         };
 
-        let octal = f::OctalPermissions{ permissions: bits };
+        let octal = Some(f::OctalPermissions{ permissions: bits });
 
         let expected = TextCell::paint_str(Purple.bold(), "0644");
         assert_eq!(expected, octal.render(Purple.bold()).into());
@@ -65,7 +76,7 @@ pub mod test {
             other_read: false, other_write: false, other_execute: false, sticky: false,
         };
 
-        let octal = f::OctalPermissions{ permissions: bits };
+        let octal = Some(f::OctalPermissions{ permissions: bits });
 
         let expected = TextCell::paint_str(Purple.bold(), "0600");
         assert_eq!(expected, octal.render(Purple.bold()).into());
@@ -79,7 +90,7 @@ pub mod test {
             other_read: true, other_write: true,  other_execute: true, sticky: false,
         };
 
-        let octal = f::OctalPermissions{ permissions: bits };
+        let octal = Some(f::OctalPermissions{ permissions: bits });
 
         let expected = TextCell::paint_str(Purple.bold(), "4777");
         assert_eq!(expected, octal.render(Purple.bold()).into());
@@ -94,7 +105,7 @@ pub mod test {
             other_read: true, other_write: true,  other_execute: true, sticky: false,
         };
 
-        let octal = f::OctalPermissions{ permissions: bits };
+        let octal = Some(f::OctalPermissions{ permissions: bits });
 
         let expected = TextCell::paint_str(Purple.bold(), "2777");
         assert_eq!(expected, octal.render(Purple.bold()).into());
@@ -108,7 +119,7 @@ pub mod test {
             other_read: true, other_write: true,  other_execute: true, sticky: true,
         };
 
-        let octal = f::OctalPermissions{ permissions: bits };
+        let octal = Some(f::OctalPermissions{ permissions: bits });
 
         let expected = TextCell::paint_str(Purple.bold(), "1777");
         assert_eq!(expected, octal.render(Purple.bold()).into());

--- a/src/output/render/users.rs
+++ b/src/output/render/users.rs
@@ -5,16 +5,23 @@ use crate::fs::fields as f;
 use crate::output::cell::TextCell;
 use crate::output::table::UserFormat;
 
+pub trait Render {
+    fn render<C: Colours, U: Users>(self, colours: &C, users: &U, format: UserFormat) -> TextCell;
+}
 
-impl f::User {
-    pub fn render<C: Colours, U: Users>(self, colours: &C, users: &U, format: UserFormat) -> TextCell {
-        let user_name = match (format, users.get_user_by_uid(self.0)) {
-            (_, None)                      => self.0.to_string(),
-            (UserFormat::Numeric, _)       => self.0.to_string(),
+impl Render for Option<f::User> {
+    fn render<C: Colours, U: Users>(self, colours: &C, users: &U, format: UserFormat) -> TextCell {
+        let uid = match self {
+            Some(u) => u.0,
+            None    => return TextCell::blank(colours.no_user()),
+        };
+        let user_name = match (format, users.get_user_by_uid(uid)) {
+            (_, None)                      => uid.to_string(),
+            (UserFormat::Numeric, _)       => uid.to_string(),
             (UserFormat::Name, Some(user)) => user.name().to_string_lossy().into(),
         };
 
-        let style = if users.get_current_uid() == self.0 { colours.you() }
+        let style = if users.get_current_uid() == uid { colours.you() }
                                                     else { colours.someone_else() };
         TextCell::paint(style, user_name)
     }
@@ -24,13 +31,14 @@ impl f::User {
 pub trait Colours {
     fn you(&self) -> Style;
     fn someone_else(&self) -> Style;
+    fn no_user(&self) -> Style;
 }
 
 
 #[cfg(test)]
 #[allow(unused_results)]
 pub mod test {
-    use super::Colours;
+    use super::{Colours, Render};
     use crate::fs::fields as f;
     use crate::output::cell::TextCell;
     use crate::output::table::UserFormat;
@@ -46,6 +54,7 @@ pub mod test {
     impl Colours for TestColours {
         fn you(&self)          -> Style { Red.bold() }
         fn someone_else(&self) -> Style { Blue.underline() }
+        fn no_user(&self)      -> Style { Black.italic() }
     }
 
 
@@ -54,7 +63,7 @@ pub mod test {
         let mut users = MockUsers::with_current_uid(1000);
         users.add_user(User::new(1000, "enoch", 100));
 
-        let user = f::User(1000);
+        let user = Some(f::User(1000));
         let expected = TextCell::paint_str(Red.bold(), "enoch");
         assert_eq!(expected, user.render(&TestColours, &users, UserFormat::Name));
 
@@ -66,7 +75,7 @@ pub mod test {
     fn unnamed() {
         let users = MockUsers::with_current_uid(1000);
 
-        let user = f::User(1000);
+        let user = Some(f::User(1000));
         let expected = TextCell::paint_str(Red.bold(), "1000");
         assert_eq!(expected, user.render(&TestColours, &users, UserFormat::Name));
         assert_eq!(expected, user.render(&TestColours, &users, UserFormat::Numeric));
@@ -77,21 +86,21 @@ pub mod test {
         let mut users = MockUsers::with_current_uid(0);
         users.add_user(User::new(1000, "enoch", 100));
 
-        let user = f::User(1000);
+        let user = Some(f::User(1000));
         let expected = TextCell::paint_str(Blue.underline(), "enoch");
         assert_eq!(expected, user.render(&TestColours, &users, UserFormat::Name));
     }
 
     #[test]
     fn different_unnamed() {
-        let user = f::User(1000);
+        let user = Some(f::User(1000));
         let expected = TextCell::paint_str(Blue.underline(), "1000");
         assert_eq!(expected, user.render(&TestColours, &MockUsers::with_current_uid(0), UserFormat::Numeric));
     }
 
     #[test]
     fn overflow() {
-        let user = f::User(2_147_483_648);
+        let user = Some(f::User(2_147_483_648));
         let expected = TextCell::paint_str(Blue.underline(), "2147483648");
         assert_eq!(expected, user.render(&TestColours, &MockUsers::with_current_uid(0), UserFormat::Numeric));
     }

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -13,9 +13,17 @@ use users::UsersCache;
 use crate::fs::{File, fields as f};
 use crate::fs::feature::git::GitCache;
 use crate::output::cell::TextCell;
-use crate::output::render::{GroupRender, TimeRender, UserRender};
+use crate::output::render::{
+    GroupRender,
+    OctalPermissionsRender,
+    PermissionsPlusRender,
+    TimeRender,
+    UserRender
+};
 use crate::output::time::TimeFormat;
 use crate::theme::Theme;
+
+
 
 
 /// Options for displaying a table.
@@ -385,17 +393,23 @@ impl<'a, 'f> Table<'a> {
         self.widths.add_widths(row)
     }
 
-    fn permissions_plus(&self, file: &File<'_>, xattrs: bool) -> f::PermissionsPlus {
-        f::PermissionsPlus {
-            file_type: file.type_char(),
-            permissions: file.permissions(),
-            xattrs,
+    fn permissions_plus(&self, file: &File<'_>, xattrs: bool) -> Option<f::PermissionsPlus> {
+        match file.permissions() {
+            Some(p) => Some(f::PermissionsPlus {
+                file_type: file.type_char(),
+                permissions: p,
+                xattrs
+            }),
+            None => None,
         }
     }
 
-    fn octal_permissions(&self, file: &File<'_>) -> f::OctalPermissions {
-        f::OctalPermissions {
-            permissions: file.permissions(),
+    fn octal_permissions(&self, file: &File<'_>) -> Option<f::OctalPermissions> {
+        match file.permissions() {
+            Some(p) => Some(f::OctalPermissions {
+                permissions: p,
+            }),
+            None => None,
         }
     }
 

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -13,7 +13,7 @@ use users::UsersCache;
 use crate::fs::{File, fields as f};
 use crate::fs::feature::git::GitCache;
 use crate::output::cell::TextCell;
-use crate::output::render::{TimeRender, UserRender};
+use crate::output::render::{GroupRender, TimeRender, UserRender};
 use crate::output::time::TimeFormat;
 use crate::theme::Theme;
 

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -13,7 +13,7 @@ use users::UsersCache;
 use crate::fs::{File, fields as f};
 use crate::fs::feature::git::GitCache;
 use crate::output::cell::TextCell;
-use crate::output::render::TimeRender;
+use crate::output::render::{TimeRender, UserRender};
 use crate::output::time::TimeFormat;
 use crate::theme::Theme;
 

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -232,6 +232,7 @@ impl render::GitColours for Theme {
 impl render::GroupColours for Theme {
     fn yours(&self)      -> Style { self.ui.users.group_yours }
     fn not_yours(&self)  -> Style { self.ui.users.group_not_yours }
+    fn no_group(&self)   -> Style { self.ui.punctuation }
 }
 
 impl render::LinksColours for Theme {

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -290,6 +290,7 @@ impl render::SizeColours for Theme {
 impl render::UserColours for Theme {
     fn you(&self)           -> Style { self.ui.users.user_you }
     fn someone_else(&self)  -> Style { self.ui.users.user_someone_else }
+    fn no_user(&self)       -> Style { self.ui.punctuation }
 }
 
 impl FileNameColours for Theme {


### PR DESCRIPTION
This PR seeks to address https://github.com/ogham/exa/issues/393, which explains that there is currently no equivalent to `ls`'s `-L`/`--dereference` flag. This is often undesirable, as it is rare that a user is interested in the details of the link itself. As such, the `-X`/`--dereference` flag has been added which implements this functionality. I have chosen `-X` as `-L` was already taken, and in my mind `-X` was similar to "across", in the sense that you are traversing "across" the link. I am more than happy to accomodate other suggestions, or change my implementation in any way that would be more palatable to the maintainers.

Output **without** the `-X` flag (identical to before this PR):

```bash
cargo run -- -l
drwxr-xr-x   - root    23 Sep 14:39 dir
.rw-r--r-- 450 root    23 Sep 12:24 file.txt
lrwxrwxrwx  14 andrzej 27 Sep 14:17 symlink-loop-0 -> symlink-loop-1
lrwxrwxrwx  14 andrzej 27 Sep 14:17 symlink-loop-1 -> symlink-loop-0
lrwxrwxrwx  20 andrzej 23 Sep 12:26 symlink-to-another-file -> dir/another-file.txt
lrwxrwxrwx   3 andrzej 23 Sep 12:26 symlink-to-dir -> dir
lrwxrwxrwx   8 andrzej 23 Sep 12:23 symlink-to-file -> file.txt
lrwxrwxrwx  15 andrzej 27 Sep 14:15 symlink-to-symlink-to-file -> symlink-to-file
```

Output **with** the `-X` flag (links are now dereferenced):

```bash
cargo run -- -lX
drwxr-xr-x   - root 23 Sep 14:39 dir
.rw-r--r-- 450 root 23 Sep 12:24 file.txt
----------   - -    -            symlink-loop-0 -> symlink-loop-1
----------   - -    -            symlink-loop-1 -> symlink-loop-0
lrw-r--r--   0 root 27 Sep 16:16 symlink-to-another-file -> dir/another-file.txt
lrwxr-xr-x   - root 23 Sep 14:39 symlink-to-dir -> dir
lrw-r--r-- 450 root 23 Sep 12:24 symlink-to-file -> file.txt
lrw-r--r-- 450 root 23 Sep 12:24 symlink-to-symlink-to-file -> symlink-to-file
```

Output when using the analogous `-L` flag within `ls`, with the only noticable difference being that `ls` noisily states that there is a loop of links:

```bash
/usr/bin/ls -lL
/usr/bin/ls: cannot access 'symlink-loop-0': Too many levels of symbolic links
/usr/bin/ls: cannot access 'symlink-loop-1': Too many levels of symbolic links
total 20
drwxr-xr-x 2 root root 4096 Sep 23 14:39 dir
-rw-r--r-- 1 root root  450 Sep 23 12:24 file.txt
l????????? ? ?    ?       ?            ? symlink-loop-0
l????????? ? ?    ?       ?            ? symlink-loop-1
-rw-r--r-- 1 root root    0 Sep 27 16:16 symlink-to-another-file
drwxr-xr-x 2 root root 4096 Sep 23 14:39 symlink-to-dir
-rw-r--r-- 1 root root  450 Sep 23 12:24 symlink-to-file
-rw-r--r-- 1 root root  450 Sep 23 12:24 symlink-to-symlink-to-file
```