### PR TITLE
fix issue 1145

### DIFF
--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -23,14 +23,42 @@ impl FileExtensions {
     fn is_immediate(&self, file: &File<'_>) -> bool {
         file.name.to_lowercase().starts_with("readme") ||
         file.name.ends_with(".ninja") ||
-        file.name_is_one_of( &[
-            "GNUmakefile", "Makefile", "makefile", "Cargo.toml", "SConstruct", "CMakeLists.txt",
-            "build.gradle", "pom.xml", "Rakefile", "package.json", "Gruntfile.js",
-            "Gruntfile.coffee", "BUILD", "BUILD.bazel", "WORKSPACE", "build.xml", "Podfile",
-            "webpack.config.js", "meson.build", "composer.json", "RoboFile.php", "PKGBUILD",
-            "Justfile", "Procfile", "Dockerfile", "Containerfile", "Vagrantfile", "Brewfile",
-            "Gemfile", "Pipfile", "build.sbt", "mix.exs", "bsconfig.json", "tsconfig.json",
-        ])
+        [
+            "BUILD",
+            "BUILD.bazel",
+            "Brewfile",
+            "CMakeLists.txt",
+            "Cargo.toml",
+            "Containerfile",
+            "Dockerfile",
+            "GNUmakefile",
+            "Gemfile",
+            "Gruntfile.coffee",
+            "Gruntfile.js",
+            "Justfile",
+            "Makefile",
+            "PKGBUILD",
+            "Pipfile",
+            "Podfile",
+            "Procfile",
+            "Rakefile",
+            "RoboFile.php",
+            "SConstruct",
+            "Vagrantfile",
+            "WORKSPACE",
+            "bsconfig.json",
+            "build.gradle",
+            "build.sbt",
+            "build.xml",
+            "composer.json",
+            "makefile",
+            "meson.build",
+            "mix.exs",
+            "package.json",
+            "pom.xml",
+            "tsconfig.json",
+            "webpack.config.js",
+        ].binary_search(&file.name.as_str()).is_ok()
     }
 
     fn is_image(&self, file: &File<'_>) -> bool {

--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -22,10 +22,9 @@ impl FileExtensions {
     #[allow(clippy::case_sensitive_file_extension_comparisons)]
     fn is_immediate(&self, file: &File<'_>) -> bool {
         file.name.to_lowercase().starts_with("readme") ||
-        file.name.to_lowercase().starts_with("makefile") ||
         file.name.ends_with(".ninja") ||
         file.name_is_one_of( &[
-            "GNUmakefile", "Cargo.toml", "SConstruct", "CMakeLists.txt",
+            "GNUmakefile", "Makefile", "makefile", "Cargo.toml", "SConstruct", "CMakeLists.txt",
             "build.gradle", "pom.xml", "Rakefile", "package.json", "Gruntfile.js",
             "Gruntfile.coffee", "BUILD", "BUILD.bazel", "WORKSPACE", "build.xml", "Podfile",
             "webpack.config.js", "meson.build", "composer.json", "RoboFile.php", "PKGBUILD",

--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -21,44 +21,45 @@ impl FileExtensions {
     /// in directories full of source code.
     #[allow(clippy::case_sensitive_file_extension_comparisons)]
     fn is_immediate(&self, file: &File<'_>) -> bool {
-        file.name.to_lowercase().starts_with("readme") ||
-        file.name.ends_with(".ninja") ||
-        [
-            "BUILD",
-            "BUILD.bazel",
-            "Brewfile",
-            "CMakeLists.txt",
-            "Cargo.toml",
-            "Containerfile",
-            "Dockerfile",
-            "GNUmakefile",
-            "Gemfile",
-            "Gruntfile.coffee",
-            "Gruntfile.js",
-            "Justfile",
-            "Makefile",
-            "PKGBUILD",
-            "Pipfile",
-            "Podfile",
-            "Procfile",
-            "Rakefile",
-            "RoboFile.php",
-            "SConstruct",
-            "Vagrantfile",
-            "WORKSPACE",
-            "bsconfig.json",
-            "build.gradle",
-            "build.sbt",
-            "build.xml",
-            "composer.json",
-            "makefile",
-            "meson.build",
-            "mix.exs",
-            "package.json",
-            "pom.xml",
-            "tsconfig.json",
-            "webpack.config.js",
-        ].binary_search(&file.name.as_str()).is_ok()
+	file.name.to_lowercase().starts_with("readme")
+            || file.name.ends_with(".ninja")
+            || matches!(
+                file.name.as_str(),
+                "BUILD"
+                    | "BUILD.bazel"
+                    | "Brewfile"
+                    | "CMakeLists.txt"
+                    | "Cargo.toml"
+                    | "Containerfile"
+                    | "Dockerfile"
+                    | "GNUmakefile"
+                    | "Gemfile"
+                    | "Gruntfile.coffee"
+                    | "Gruntfile.js"
+                    | "Justfile"
+                    | "Makefile"
+                    | "PKGBUILD"
+                    | "Pipfile"
+                    | "Podfile"
+                    | "Procfile"
+                    | "Rakefile"
+                    | "RoboFile.php"
+                    | "SConstruct"
+                    | "Vagrantfile"
+                    | "WORKSPACE"
+                    | "bsconfig.json"
+                    | "build.gradle"
+                    | "build.sbt"
+                    | "build.xml"
+                    | "composer.json"
+                    | "makefile"
+                    | "meson.build"
+                    | "mix.exs"
+                    | "package.json"
+                    | "pom.xml"
+                    | "tsconfig.json"
+                    | "webpack.config.js"
+            )
     }
 
     fn is_image(&self, file: &File<'_>) -> bool {

--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -22,9 +22,10 @@ impl FileExtensions {
     #[allow(clippy::case_sensitive_file_extension_comparisons)]
     fn is_immediate(&self, file: &File<'_>) -> bool {
         file.name.to_lowercase().starts_with("readme") ||
+        file.name.to_lowercase().starts_with("makefile") ||
         file.name.ends_with(".ninja") ||
         file.name_is_one_of( &[
-            "Makefile", "Cargo.toml", "SConstruct", "CMakeLists.txt",
+            "GNUmakefile", "Cargo.toml", "SConstruct", "CMakeLists.txt",
             "build.gradle", "pom.xml", "Rakefile", "package.json", "Gruntfile.js",
             "Gruntfile.coffee", "BUILD", "BUILD.bazel", "WORKSPACE", "build.xml", "Podfile",
             "webpack.config.js", "meson.build", "composer.json", "RoboFile.php", "PKGBUILD",


### PR DESCRIPTION
fix issue [1145](https://github.com/ogham/exa/issues/1145)

according to the GNU [doc](https://web.mit.edu/gnu/doc/html/make_3.html#:~:text=By%20default%2C%20when%20make%20looks,makefile'%20or%20%60Makefile'.)

```
The default makefile names `GNUmakefile', `makefile' and `Makefile'
```

results
![image](https://user-images.githubusercontent.com/11532828/207558060-099033f3-be18-4773-959d-113570b73b71.png)
![image](https://user-images.githubusercontent.com/11532828/207558124-f13d2886-f613-4a33-af9b-289b733e4549.png)
