### PR TITLE
Fixed issue #1106: added icon for '.gpg' files

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -191,6 +191,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "gitignore"     => '\u{f1d3}', // 
             "gitmodules"    => '\u{f1d3}', // 
             "go"            => '\u{e626}', // 
+            "gpg"           => '\u{ea75}', // 
             "gradle"        => '\u{e256}', // 
             "groovy"        => '\u{e775}', // 
             "gsheet"        => '\u{f1c3}', // 


### PR DESCRIPTION
Added lock icon ('ea75') for files with '.gpg' extension, fixing issue #1106.
Below a test output:
```sh
~/gpg_icon
λ exa --icons
 test.gpg
```