### PR TITLE
Created colors explanation file based on @ogham's text

### DIFF
--- a/man/exa-colors-explanation.md
+++ b/man/exa-colors-explanation.md
@@ -1,0 +1,41 @@
+# Exa Color Explanation
+
+exa provides its own built\-in set of file extension mappings that cover a large range of common file extensions, including documents, archives, media, and temporary files.
+
+Any mappings in the environment variables will override this default set: running exa with `LS_COLORS="*.zip=32"` will turn zip files green but leave the colours of other compressed files alone.
+
+You can also disable this built\-in set entirely by including a
+`reset` entry at the beginning of `EXA_COLORS`.
+So setting `EXA_COLORS="reset:*.txt=31"` will highlight only text
+files; setting `EXA_COLORS="reset"` will highlight nothing.
+
+## Examples
+
+- Disable the "current user" highlighting: `EXA_COLORS="uu=0:gu=0"`
+- Turn the date column green: `EXA_COLORS="da=32"`
+- Highlight Vagrantfiles: `EXA_COLORS="Vagrantfile=1;4;33"`
+- Override the existing zip colour: `EXA_COLORS="*.zip=38;5;125"`
+- Markdown files a shade of green, log files a shade of grey:
+`EXA_COLORS="*.md=38;5;121:*.log=38;5;248"`
+
+## BUILT\-IN EXTENSIONS
+
+"Immediate" files are the files you should look at when downloading and building a project for the first time: READMEs, Makefiles, Cargo.toml, and others.
+They are highlighted in _yellow_ and _underlined_.
+
+- Images (png, jpeg, gif) are purple.
+- Videos (mp4, ogv, m2ts) are a slightly purpler purple.
+- Music (mp3, m4a, ogg) is a deeper purple.
+- Lossless music (flac, alac, wav) is deeper than *that* purple. In general, most media files are some shade of purple.
+- Cryptographic files (asc, enc, p12) are a faint blue.
+- Documents (pdf, doc, dvi) are a less faint blue.
+- Compressed files (zip, tgz, Z) are red.
+- Temporary files (tmp, swp, ~) are grey.
+- Compiled files (class, o, pyc) are faint orange. A file is also counted as compiled if it uses a common extension and is
+in the same directory as one of its source files: styles.css will count as compiled when next to styles.less or styles.sass, and scripts.js when next to scripts.ts or scripts.coffee.
+
+
+## See also
+
+- [exa.1.md](exa.1.md)
+- [exa_colors.5.md](exa_colors.5.md)

--- a/man/exa.1.md
+++ b/man/exa.1.md
@@ -234,7 +234,7 @@ See `https://no-color.org/` for details.
 
 Specifies the colour scheme used to highlight files based on their name and kind, as well as highlighting metadata and parts of the UI.
 
-For more information on the format of these environment variables, see the `exa_colors(5)` manual page.
+For more information on the format of these environment variables, see the [exa_colors.5.md](exa_colors.5.md) manual page.
 
 
 EXIT STATUSES
@@ -263,4 +263,5 @@ exa is maintained by Benjamin ‘ogham’ Sago and many other contributors.
 SEE ALSO
 ========
 
-- `exa_colors(5)`
+- [exa_colors.5.md](exa_colors.5.md)
+- [exa-colors-explanation.md](exa-colors-explanation.md)

--- a/man/exa_colors.5.md
+++ b/man/exa_colors.5.md
@@ -279,4 +279,5 @@ exa is maintained by Benjamin ‘ogham’ Sago and many other contributors.
 SEE ALSO
 ========
 
-- `exa(1)`
+- [exa.1.md](exa.1.md)
+- [exa-colors-explanation.md](exa-colors-explanation.md)


### PR DESCRIPTION
As stated in [this](https://github.com/ogham/exa/issues/200) and [this](https://github.com/ogham/exa/issues/261) issues, a lot of people don't understand which colors are used for the different file types.

@ogham has provided an [explanation ](https://github.com/ogham/exa/issues/200#issuecomment-333318131) but never merged it back to the main documentation.

I used his notes and put them into proper markdown and linked all the "manual" files together. I *did not* include any links on the main readme because I didn't know where to properly put it.

----

TLDR: One new readme file to help people understand the colors better. 