### PR TITLE
Add MP2 audio format icon

### DIFF
--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -52,7 +52,7 @@ impl FileExtensions {
 
     fn is_music(&self, file: &File<'_>) -> bool {
         file.extension_is_one_of( &[
-            "aac", "m4a", "mp3", "ogg", "wma", "mka", "opus",
+            "aac", "m4a", "mp2", "mp3", "ogg", "wma", "mka", "opus",
         ])
     }
 

--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -255,6 +255,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "mkv"           => '\u{f03d}', // 
             "mobi"          => '\u{e28b}', // 
             "mov"           => '\u{f03d}', // 
+            "mp2"           => '\u{f001}', // 
             "mp3"           => '\u{f001}', // 
             "mp4"           => '\u{f03d}', // 
             "msi"           => '\u{e70f}', // 


### PR DESCRIPTION
This PR adds MP2 audio file extension and the icon. For more information about MP2 (MPEG-1), see [here](https://en.wikipedia.org/wiki/MPEG-1_Audio_Layer_II)
Official standard webpage: [here](https://mpeg.chiariglione.org/standards/mpeg-1/audio)