### PR TITLE
Update Cargo.toml to optimise binaries for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ debug = false
 # use LTO for smaller binaries (that take longer to build)
 [profile.release]
 lto = true
+strip = true
+opt-level = "z"
+codegen-units = 1
 
 
 [package.metadata.deb]


### PR DESCRIPTION
Strip binaries, change optimisation level to heavily optimise for size, change codegen units to 1, which slows compile times but adds maximum size optimisations.