### PR TITLE
Add icon for ocaml (.ml extension)

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -245,6 +245,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "lzma"          => '\u{f410}', // 
             "lzo"           => '\u{f410}', // 
             "m"             => '\u{e61e}', // 
+            "ml"            => '\u{1d77a}',// 𝝺
             "mm"            => '\u{e61d}', // 
             "m4a"           => '\u{f001}', // 
             "markdown"      => '\u{f48a}', // 


### PR DESCRIPTION
I have recently been writing a lot of OCaml. But there was no icon for .ml files.
Since there is no OCaml icon in Nerd Fonts, I settled for a lambda symbol, which is also used by nvim-web-devicons.