### PR TITLE
Add -o shorcut to --octal-permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ These options are available when running with `--long` (`-l`):
 - **--git**: list each file’s Git status, if tracked or ignored
 - **--time-style**: how to format timestamps
 - **--no-permissions**: suppress the permissions field
-- **--octal-permissions**: list each file's permission in octal format
+- **-o**, **--octal-permissions**: list each file's permission in octal format
 - **--no-filesize**: suppress the filesize field
 - **--no-user**: suppress the user field
 - **--no-time**: suppress the time field

--- a/completions/fish/exa.fish
+++ b/completions/fish/exa.fish
@@ -80,11 +80,11 @@ complete -c exa        -l 'time-style'    -d "How to format timestamps" -x -a "
     long-iso\t'Display longer ISO timestaps, up to the minute'
     full-iso\t'Display full ISO timestamps, up to the nanosecond'
 "
-complete -c exa        -l 'no-permissions' -d "Suppress the permissions field"
-complete -c exa        -l 'octal-permissions' -d "List each file's permission in octal format"
-complete -c exa        -l 'no-filesize'    -d "Suppress the filesize field"
-complete -c exa        -l 'no-user'        -d "Suppress the user field"
-complete -c exa        -l 'no-time'        -d "Suppress the time field"
+complete -c exa        -l 'no-permissions'    -d "Suppress the permissions field"
+complete -c exa -s 'o' -l 'octal-permissions' -d "List each file's permission in octal format"
+complete -c exa        -l 'no-filesize'       -d "Suppress the filesize field"
+complete -c exa        -l 'no-user'           -d "Suppress the user field"
+complete -c exa        -l 'no-time'           -d "Suppress the time field"
 
 # Optional extras
 complete -c exa -l 'git' -d "List each file's Git status, if tracked"

--- a/completions/zsh/_exa
+++ b/completions/zsh/_exa
@@ -45,7 +45,7 @@ __exa() {
         {-t,--time}="[Which time field to show]:(time field):(accessed changed created modified)" \
         --time-style="[How to format timestamps]:(time style):(default iso long-iso full-iso)" \
         --no-permissions"[Suppress the permissions field]" \
-        --octal-permissions"[List each file's permission in octal format]" \
+        {-o, --octal-permissions}"[List each file's permission in octal format]" \
         --no-filesize"[Suppress the filesize field]" \
         --no-user"[Suppress the user field]" \
         --no-time"[Suppress the time field]" \

--- a/man/exa.1.md
+++ b/man/exa.1.md
@@ -168,6 +168,9 @@ These options are available when running with `--long` (`-l`):
 `--no-permissions`
 : Suppress the permissions field.
 
+`-o`, `--octal-permissions`
+: List each file's permissions in octal format.
+
 `--no-filesize`
 : Suppress the file size field.
 

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -64,7 +64,7 @@ pub static NO_ICONS: Arg = Arg { short: None, long: "no-icons", takes_value: Tak
 // optional feature options
 pub static GIT:       Arg = Arg { short: None,       long: "git",               takes_value: TakesValue::Forbidden };
 pub static EXTENDED:  Arg = Arg { short: Some(b'@'), long: "extended",          takes_value: TakesValue::Forbidden };
-pub static OCTAL:     Arg = Arg { short: None,       long: "octal-permissions", takes_value: TakesValue::Forbidden };
+pub static OCTAL:     Arg = Arg { short: Some(b'o'), long: "octal-permissions", takes_value: TakesValue::Forbidden };
 
 
 pub static ALL_ARGS: Args = Args(&[

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -41,29 +41,29 @@ FILTERING AND SORTING OPTIONS
                              date, time, old, and new all refer to modified.
 
 LONG VIEW OPTIONS
-  -b, --binary         list file sizes with binary prefixes
-  -B, --bytes          list file sizes in bytes, without any prefixes
-  -g, --group          list each file's group
-  -h, --header         add a header row to each column
-  -H, --links          list each file's number of hard links
-  -i, --inode          list each file's inode number
-  -m, --modified       use the modified timestamp field
-  -n, --numeric        list numeric user and group IDs
-  -S, --blocks         show number of file system blocks
-  -t, --time FIELD     which timestamp field to list (modified, accessed, created)
-  -u, --accessed       use the accessed timestamp field
-  -U, --created        use the created timestamp field
-  --changed            use the changed timestamp field
-  --time-style         how to format timestamps (default, iso, long-iso, full-iso)
-  --no-permissions     suppress the permissions field
-  --octal-permissions  list each file's permission in octal format
-  --no-filesize        suppress the filesize field
-  --no-user            suppress the user field
-  --no-time            suppress the time field";
+  -b, --binary             list file sizes with binary prefixes
+  -B, --bytes              list file sizes in bytes, without any prefixes
+  -g, --group              list each file's group
+  -h, --header             add a header row to each column
+  -H, --links              list each file's number of hard links
+  -i, --inode              list each file's inode number
+  -m, --modified           use the modified timestamp field
+  -n, --numeric            list numeric user and group IDs
+  -S, --blocks             show number of file system blocks
+  -t, --time FIELD         which timestamp field to list (modified, accessed, created)
+  -u, --accessed           use the accessed timestamp field
+  -U, --created            use the created timestamp field
+  --changed                use the changed timestamp field
+  --time-style             how to format timestamps (default, iso, long-iso, full-iso)
+  --no-permissions         suppress the permissions field
+  -o, --octal-permissions  list each file's permission in octal format
+  --no-filesize            suppress the filesize field
+  --no-user                suppress the user field
+  --no-time                suppress the time field";
 
 static GIT_FILTER_HELP: &str = "  --git-ignore               ignore files mentioned in '.gitignore'";
-static GIT_VIEW_HELP:   &str = "  --git                list each file's Git status, if tracked or ignored";
-static EXTENDED_HELP:   &str = "  -@, --extended       list each file's extended attributes and sizes";
+static GIT_VIEW_HELP:   &str = "  --git                    list each file's Git status, if tracked or ignored";
+static EXTENDED_HELP:   &str = "  -@, --extended           list each file's extended attributes and sizes";
 
 
 /// All the information needed to display the help text, which depends

--- a/xtests/outputs/help.ansitxt
+++ b/xtests/outputs/help.ansitxt
@@ -33,24 +33,24 @@ FILTERING AND SORTING OPTIONS
                              date, time, old, and new all refer to modified.
 
 LONG VIEW OPTIONS
-  -b, --binary         list file sizes with binary prefixes
-  -B, --bytes          list file sizes in bytes, without any prefixes
-  -g, --group          list each file's group
-  -h, --header         add a header row to each column
-  -H, --links          list each file's number of hard links
-  -i, --inode          list each file's inode number
-  -m, --modified       use the modified timestamp field
-  -n, --numeric        list numeric user and group IDs
-  -S, --blocks         show number of file system blocks
-  -t, --time FIELD     which timestamp field to list (modified, accessed, created)
-  -u, --accessed       use the accessed timestamp field
-  -U, --created        use the created timestamp field
-  --changed            use the changed timestamp field
-  --time-style         how to format timestamps (default, iso, long-iso, full-iso)
-  --no-permissions     suppress the permissions field
-  --octal-permissions  list each file's permission in octal format
-  --no-filesize        suppress the filesize field
-  --no-user            suppress the user field
-  --no-time            suppress the time field
-  --git                list each file's Git status, if tracked or ignored
-  -@, --extended       list each file's extended attributes and sizes
+  -b, --binary             list file sizes with binary prefixes
+  -B, --bytes              list file sizes in bytes, without any prefixes
+  -g, --group              list each file's group
+  -h, --header             add a header row to each column
+  -H, --links              list each file's number of hard links
+  -i, --inode              list each file's inode number
+  -m, --modified           use the modified timestamp field
+  -n, --numeric            list numeric user and group IDs
+  -S, --blocks             show number of file system blocks
+  -t, --time FIELD         which timestamp field to list (modified, accessed, created)
+  -u, --accessed           use the accessed timestamp field
+  -U, --created            use the created timestamp field
+  --changed                use the changed timestamp field
+  --time-style             how to format timestamps (default, iso, long-iso, full-iso)
+  --no-permissions         suppress the permissions field
+  -o, --octal-permissions  list each file's permission in octal format
+  --no-filesize            suppress the filesize field
+  --no-user                suppress the user field
+  --no-time                suppress the time field
+  --git                    list each file's Git status, if tracked or ignored
+  -@, --extended           list each file's extended attributes and sizes


### PR DESCRIPTION
Added -o shortcut to --octal-permissions option. Requested by issue #1157 
Also updated the help documentation and fish/zsh completion.

### Results
Before
```
$ exa --long -o
exa: Unknown argument -o
```
After
```
$ exa --long -o
0664 .rw-rw-r-- 3,7k utiiz 23 févr. 23:33 build.rs
0664 .rw-rw-r--  10k utiiz 23 févr. 23:33 Cargo.lock
0664 .rw-rw-r-- 2,0k utiiz 23 févr. 23:33 Cargo.toml
0775 drwxrwxr-x    - utiiz 23 févr. 23:33 completions
0775 drwxrwxr-x    - utiiz 23 févr. 23:33 devtools
0664 .rw-rw-r-- 2,6k utiiz 23 févr. 23:33 Justfile
0664 .rw-rw-r-- 1,1k utiiz 23 févr. 23:33 LICENCE
0775 drwxrwxr-x    - utiiz 23 févr. 23:51 man
0664 .rw-rw-r--  11k utiiz 23 févr. 23:41 README.md
0664 .rw-rw-r--   31 utiiz 23 févr. 23:33 rust-toolchain.toml
0664 .rw-rw-r-- 455k utiiz 23 févr. 23:33 screenshots.png
0775 drwxrwxr-x    - utiiz 23 févr. 23:33 snap
0775 drwxrwxr-x    - utiiz 23 févr. 23:33 src
0775 drwxrwxr-x    - utiiz 23 févr. 23:35 target
0664 .rw-rw-r-- 6,1k utiiz 23 févr. 23:33 Vagrantfile
0775 drwxrwxr-x    - utiiz 23 févr. 23:33 xtests
```