### PR TITLE
Quote file names containing spaces and/or single quotes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ use crate::fs::{Dir, File};
 use crate::fs::feature::git::GitCache;
 use crate::fs::filter::GitIgnore;
 use crate::options::{Options, Vars, vars, OptionsResult};
-use crate::output::{escape, lines, grid, grid_details, details, View, Mode};
+use crate::output::{escape, lines, grid, grid_details, details, View, Mode, file_name};
 use crate::theme::Theme;
 
 mod fs;
@@ -211,6 +211,8 @@ impl<'args> Exa<'args> {
     }
 
     fn print_dirs(&mut self, dir_files: Vec<Dir>, mut first: bool, is_only_dir: bool, exit_status: i32) -> io::Result<i32> {
+        let View { file_style: file_name::Options { quote_style, .. }, .. } = self.options.view;
+
         for dir in dir_files {
 
             // Put a gap between directories, or between the list of files and
@@ -224,7 +226,7 @@ impl<'args> Exa<'args> {
 
             if ! is_only_dir {
                 let mut bits = Vec::new();
-                escape(dir.path.display().to_string(), &mut bits, Style::default(), Style::default());
+                escape(dir.path.display().to_string(), &mut bits, Style::default(), Style::default(), quote_style == output::file_name::QuoteStyle::NoQuotes);
                 writeln!(&mut self.writer, "{}:", ANSIStrings(&bits))?;
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,7 +226,7 @@ impl<'args> Exa<'args> {
 
             if ! is_only_dir {
                 let mut bits = Vec::new();
-                escape(dir.path.display().to_string(), &mut bits, Style::default(), Style::default(), quote_style == output::file_name::QuoteStyle::NoQuotes);
+                escape(dir.path.display().to_string(), &mut bits, Style::default(), Style::default(), quote_style);
                 writeln!(&mut self.writer, "{}:", ANSIStrings(&bits))?;
             }
 

--- a/src/options/file_name.rs
+++ b/src/options/file_name.rs
@@ -2,15 +2,16 @@ use crate::options::{flags, OptionsError, NumberSource};
 use crate::options::parser::MatchedFlags;
 use crate::options::vars::{self, Vars};
 
-use crate::output::file_name::{Options, Classify, ShowIcons};
+use crate::output::file_name::{Options, Classify, ShowIcons, QuoteStyle};
 
 
 impl Options {
     pub fn deduce<V: Vars>(matches: &MatchedFlags<'_>, vars: &V) -> Result<Self, OptionsError> {
         let classify = Classify::deduce(matches)?;
         let show_icons = ShowIcons::deduce(matches, vars)?;
+        let quote_style = QuoteStyle::deduce(matches)?;
 
-        Ok(Self { classify, show_icons })
+        Ok(Self { classify, show_icons, quote_style })
     }
 }
 
@@ -41,6 +42,17 @@ impl ShowIcons {
         }
         else {
             Ok(Self::On(1))
+        }
+    }
+}
+
+impl QuoteStyle {
+    pub fn deduce(matches: &MatchedFlags<'_>) -> Result<Self, OptionsError> {
+        if matches.has(&flags::NO_QUOTES)? {
+            Ok(Self::NoQuotes)
+        }
+        else {
+            Ok(Self::QuoteSpaces)
         }
     }
 }

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -13,6 +13,7 @@ pub static ACROSS:   Arg = Arg { short: Some(b'x'), long: "across",   takes_valu
 pub static RECURSE:  Arg = Arg { short: Some(b'R'), long: "recurse",  takes_value: TakesValue::Forbidden };
 pub static TREE:     Arg = Arg { short: Some(b'T'), long: "tree",     takes_value: TakesValue::Forbidden };
 pub static CLASSIFY: Arg = Arg { short: Some(b'F'), long: "classify", takes_value: TakesValue::Forbidden };
+pub static NO_QUOTES:Arg = Arg { short: None,       long: "no-quotes",takes_value: TakesValue::Forbidden };
 
 pub static COLOR:  Arg = Arg { short: None, long: "color",  takes_value: TakesValue::Necessary(Some(COLOURS)) };
 pub static COLOUR: Arg = Arg { short: None, long: "colour", takes_value: TakesValue::Necessary(Some(COLOURS)) };
@@ -70,7 +71,7 @@ pub static OCTAL:     Arg = Arg { short: None,       long: "octal-permissions", 
 pub static ALL_ARGS: Args = Args(&[
     &VERSION, &HELP,
 
-    &ONE_LINE, &LONG, &GRID, &ACROSS, &RECURSE, &TREE, &CLASSIFY,
+    &ONE_LINE, &LONG, &GRID, &ACROSS, &RECURSE, &TREE, &CLASSIFY, &NO_QUOTES,
     &COLOR, &COLOUR, &COLOR_SCALE, &COLOUR_SCALE,
 
     &ALL, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST,

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -24,6 +24,7 @@ DISPLAY OPTIONS
   --colo[u]r-scale   highlight levels of file sizes distinctly
   --icons            display icons
   --no-icons         don't display icons (always overrides --icons)
+  --no-quotes        don't quote file names with spaces
 
 FILTERING AND SORTING OPTIONS
   -a, --all                  show hidden and 'dot' files

--- a/src/output/escape.rs
+++ b/src/output/escape.rs
@@ -13,16 +13,13 @@ pub fn escape(string: String, bits: &mut Vec<ANSIString<'_>>, good: Style, bad: 
             // The `escape_default` method on `char` is *almost* what we want here, but
             // it still escapes non-ASCII UTF-8 characters, which are still printable.
 
+            // TODO: This allocates way too much,
+            // hence the `all` check above.
             if c >= 0x20 as char && c != 0x7f as char {
-                // TODO: This allocates way too much,
-                // hence the `all` check above.
-                let mut s = String::new();
-                s.push(c);
-                bits.push(good.paint(s));
+                bits.push(good.paint(c.to_string()));
             }
             else {
-                let s = c.escape_default().collect::<String>();
-                bits.push(bad.paint(s));
+                bits.push(bad.paint(c.escape_default().to_string()));
             }
         }
     }

--- a/src/output/escape.rs
+++ b/src/output/escape.rs
@@ -1,7 +1,7 @@
 use ansi_term::{ANSIString, Style};
 
 
-pub fn escape(string: String, bits: &mut Vec<ANSIString<'_>>, good: Style, bad: Style) {
+pub fn escape(string: String, bits: &mut Vec<ANSIString<'_>>, good: Style, bad: Style, no_quotes: bool) {
     let needs_quotes = string.contains(' ') || string.contains('\'');
     let quote_bit = good.paint(if string.contains('\'') { "\"" } else { "\'" });
 
@@ -24,7 +24,7 @@ pub fn escape(string: String, bits: &mut Vec<ANSIString<'_>>, good: Style, bad: 
         }
     }
 
-    if needs_quotes {
+    if !no_quotes && needs_quotes {
         bits.insert(0, quote_bit.clone());
         bits.push(quote_bit);
     }

--- a/src/output/escape.rs
+++ b/src/output/escape.rs
@@ -1,7 +1,9 @@
 use ansi_term::{ANSIString, Style};
 
+use super::file_name::QuoteStyle;
 
-pub fn escape(string: String, bits: &mut Vec<ANSIString<'_>>, good: Style, bad: Style, no_quotes: bool) {
+
+pub fn escape(string: String, bits: &mut Vec<ANSIString<'_>>, good: Style, bad: Style, quote_style: QuoteStyle) {
     let needs_quotes = string.contains(' ') || string.contains('\'');
     let quote_bit = good.paint(if string.contains('\'') { "\"" } else { "\'" });
 
@@ -24,7 +26,7 @@ pub fn escape(string: String, bits: &mut Vec<ANSIString<'_>>, good: Style, bad: 
         }
     }
 
-    if !no_quotes && needs_quotes {
+    if quote_style != QuoteStyle::NoQuotes && needs_quotes {
         bits.insert(0, quote_bit.clone());
         bits.push(quote_bit);
     }

--- a/src/output/escape.rs
+++ b/src/output/escape.rs
@@ -2,6 +2,11 @@ use ansi_term::{ANSIString, Style};
 
 
 pub fn escape(string: String, bits: &mut Vec<ANSIString<'_>>, good: Style, bad: Style) {
+    if string.contains(' ') {
+        bits.push(good.paint(["'", &string, "'"].concat()));
+        return;
+    }
+
     if string.chars().all(|c| c >= 0x20 as char && c != 0x7f as char) {
         bits.push(good.paint(string));
         return;

--- a/src/output/escape.rs
+++ b/src/output/escape.rs
@@ -2,30 +2,33 @@ use ansi_term::{ANSIString, Style};
 
 
 pub fn escape(string: String, bits: &mut Vec<ANSIString<'_>>, good: Style, bad: Style) {
-    if string.contains(' ') {
-        bits.push(good.paint(["'", &string, "'"].concat()));
-        return;
-    }
+    let needs_quotes = string.contains(' ') || string.contains('\'');
+    let quote_bit = good.paint(if string.contains('\'') { "\"" } else { "\'" });
 
     if string.chars().all(|c| c >= 0x20 as char && c != 0x7f as char) {
         bits.push(good.paint(string));
-        return;
+    }
+    else {
+        for c in string.chars() {
+            // The `escape_default` method on `char` is *almost* what we want here, but
+            // it still escapes non-ASCII UTF-8 characters, which are still printable.
+
+            if c >= 0x20 as char && c != 0x7f as char {
+                // TODO: This allocates way too much,
+                // hence the `all` check above.
+                let mut s = String::new();
+                s.push(c);
+                bits.push(good.paint(s));
+            }
+            else {
+                let s = c.escape_default().collect::<String>();
+                bits.push(bad.paint(s));
+            }
+        }
     }
 
-    for c in string.chars() {
-        // The `escape_default` method on `char` is *almost* what we want here, but
-        // it still escapes non-ASCII UTF-8 characters, which are still printable.
-
-        if c >= 0x20 as char && c != 0x7f as char {
-            // TODO: This allocates way too much,
-            // hence the `all` check above.
-            let mut s = String::new();
-            s.push(c);
-            bits.push(good.paint(s));
-        }
-        else {
-            let s = c.escape_default().collect::<String>();
-            bits.push(bad.paint(s));
-        }
+    if needs_quotes {
+        bits.insert(0, quote_bit.clone());
+        bits.push(quote_bit);
     }
 }

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -19,6 +19,9 @@ pub struct Options {
 
     /// Whether to prepend icon characters before file names.
     pub show_icons: ShowIcons,
+
+    /// How to display file names with spaces (with or without quotes).
+    pub quote_style: QuoteStyle
 }
 
 impl Options {
@@ -82,6 +85,19 @@ pub enum ShowIcons {
     /// Show icons next to file names, with the given number of spaces between
     /// the icon and the file name.
     On(u32),
+}
+
+
+/// Whether or not to wrap file names with spaces in quotes.
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub enum QuoteStyle {
+
+    /// Don't ever quote file names.
+    NoQuotes,
+
+    /// Use single quotes for file names that contain spaces and no single quotes
+    /// Use double quotes for file names that contain single quotes.
+    QuoteSpaces,
 }
 
 
@@ -171,6 +187,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
                         let target_options = Options {
                             classify: Classify::JustFilenames,
                             show_icons: ShowIcons::Off,
+                            quote_style: QuoteStyle::QuoteSpaces
                         };
 
                         let target_name = FileName {
@@ -203,6 +220,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
                         &mut bits,
                         self.colours.broken_filename(),
                         self.colours.broken_control_char(),
+                        false
                     );
                 }
 
@@ -234,6 +252,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
                 bits,
                 self.colours.symlink_path(),
                 self.colours.control_char(),
+                self.options.quote_style == QuoteStyle::NoQuotes
             );
             bits.push(self.colours.symlink_path().paint(std::path::MAIN_SEPARATOR.to_string()));
         }
@@ -295,6 +314,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
             &mut bits,
             file_style,
             self.colours.control_char(),
+            self.options.quote_style == QuoteStyle::NoQuotes
         );
 
         bits

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -220,7 +220,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
                         &mut bits,
                         self.colours.broken_filename(),
                         self.colours.broken_control_char(),
-                        false
+                        self.options.quote_style
                     );
                 }
 
@@ -252,7 +252,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
                 bits,
                 self.colours.symlink_path(),
                 self.colours.control_char(),
-                self.options.quote_style == QuoteStyle::NoQuotes
+                self.options.quote_style
             );
             bits.push(self.colours.symlink_path().paint(std::path::MAIN_SEPARATOR.to_string()));
         }
@@ -314,7 +314,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
             &mut bits,
             file_style,
             self.colours.control_char(),
-            self.options.quote_style == QuoteStyle::NoQuotes
+            self.options.quote_style
         );
 
         bits


### PR DESCRIPTION
If a filename contains spaces, it will be wrapped in single quotes ('). If a filename contains literal single quotes, it will instead be wrapped in double quotes ("). This somewhat mimicks the default behaviour of modern-day GNU `ls`.

This resolves #216 and contributes to #211. It also cleans up the code in the non-printable characters loop a bit. I personally believe quotes should be the default, but a command-line switch (`--no-quotes`) exists for those who prefer not having them.

My intent with this PR is to resolve something that was bothering me personally, with minimal code changes, in a way that is satisfactory to myself. I believe it presents an improvement over the status quo, and further improvements may be the subject of future PRs.