### PR TITLE
Add windows to GitHub CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [1.63.0, stable, beta, nightly]
 
     steps:


### PR DESCRIPTION
I've seen a few issues about building on windows (https://github.com/ogham/exa/issues/1163 https://github.com/ogham/exa/issues/1167), so I think it would be worth adding it to the CI.

Especially since the initial windows support PR https://github.com/ogham/exa/pull/820 was merged recently (Feb 21) 🎉

(Note that the checks passed on my fork https://github.com/domsleee/exa/pull/1)