### PR TITLE
Change ipynb icon

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -209,7 +209,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "img"           => '\u{e271}', // 
             "iml"           => '\u{e7b5}', // 
             "ini"           => '\u{f17a}', // 
-            "ipynb"         => '\u{e606}', // 
+            "ipynb"         => '\u{e678}', // 
             "iso"           => '\u{e271}', // 
             "j2c"           => '\u{f1c5}', // 
             "j2k"           => '\u{f1c5}', // 


### PR DESCRIPTION
Jupyter notebooks are often in the same folder as plain Python files. Having a different icon would be useful. Since there is no Jupyter Notebook icon in Nerd fonts, I chose an icon of a notebook.