### PR TITLE
Added ".out" files to list of compiled ".tex" files

### DIFF
--- a/src/info/sources.rs
+++ b/src/info/sources.rs
@@ -29,6 +29,7 @@ impl<'a> File<'a> {
                 "lof" |                                          // TeX list of figures
                 "log" |                                          // TeX log file
                 "lot" |                                          // TeX list of tables
+                "out" |                                          // hyperref list of bookmarks
                 "toc" => vec![self.path.with_extension("tex")],  // TeX table of contents
 
                 _ => vec![],  // No source files if none of the above


### PR DESCRIPTION
The popular "hyperref" LaTeX package produces ".out" files containing a list of bookmarks.
exa should recognize these as compiled ".tex" files and color them accordingly.