### PR TITLE
feat: Add a time style with better human readability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ term_grid = "0.2.0"
 terminal_size = "0.1.16"
 unicode-width = "0.1"
 zoneinfo_compiled = "0.5.1"
+chrono = "0.4.26"
+chrono-humanize = "0.2.2"
 
 [target.'cfg(unix)'.dependencies]
 users = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ name = "exa"
 
 [dependencies]
 ansi_term = "0.12"
+chrono = "0.4.26"
+chrono-humanize = "0.2.2"
 glob = "0.3"
 lazy_static = "1.3"
 libc = "0.2"
@@ -32,8 +34,6 @@ term_grid = "0.2.0"
 terminal_size = "0.1.16"
 unicode-width = "0.1"
 zoneinfo_compiled = "0.5.1"
-chrono = "0.4.26"
-chrono-humanize = "0.2.2"
 
 [target.'cfg(unix)'.dependencies]
 users = "0.11"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Some of the options accept parameters:
 - Valid **--color** options are **always**, **automatic**, and **never**.
 - Valid sort fields are **accessed**, **changed**, **created**, **extension**, **Extension**, **inode**, **modified**, **name**, **Name**, **size**, **type**, and **none**. Fields starting with a capital letter sort uppercase before lowercase. The modified field has the aliases **date**, **time**, and **newest**, while its reverse has the aliases **age** and **oldest**.
 - Valid time fields are **modified**, **changed**, **accessed**, and **created**.
-- Valid time styles are **default**, **iso**, **long-iso**, and **full-iso**.
+- Valid time styles are **default**, **iso**, **long-iso**, **full-iso** and **hu**.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Some of the options accept parameters:
 - Valid **--color** options are **always**, **automatic**, and **never**.
 - Valid sort fields are **accessed**, **changed**, **created**, **extension**, **Extension**, **inode**, **modified**, **name**, **Name**, **size**, **type**, and **none**. Fields starting with a capital letter sort uppercase before lowercase. The modified field has the aliases **date**, **time**, and **newest**, while its reverse has the aliases **age** and **oldest**.
 - Valid time fields are **modified**, **changed**, **accessed**, and **created**.
-- Valid time styles are **default**, **iso**, **long-iso**, **full-iso** and **hu**.
+- Valid time styles are **default**, **iso**, **long-iso**, **full-iso** and **relative**.
 
 
 ---

--- a/completions/bash/exa
+++ b/completions/bash/exa
@@ -29,7 +29,7 @@ _exa()
             ;;
 
         --time-style)
-            COMPREPLY=( $( compgen -W 'default iso long-iso full-iso --' -- "$cur" ) )
+            COMPREPLY=( $( compgen -W 'default iso long-iso full-iso hu --' -- "$cur" ) )
             return
             ;;
     esac

--- a/completions/bash/exa
+++ b/completions/bash/exa
@@ -29,7 +29,7 @@ _exa()
             ;;
 
         --time-style)
-            COMPREPLY=( $( compgen -W 'default iso long-iso full-iso hu --' -- "$cur" ) )
+            COMPREPLY=( $( compgen -W 'default iso long-iso full-iso relative --' -- "$cur" ) )
             return
             ;;
     esac

--- a/completions/fish/exa.fish
+++ b/completions/fish/exa.fish
@@ -79,7 +79,7 @@ complete -c exa        -l 'time-style'    -d "How to format timestamps" -x -a "
     iso\t'Display brief ISO timestamps'
     long-iso\t'Display longer ISO timestaps, up to the minute'
     full-iso\t'Display full ISO timestamps, up to the nanosecond'
-    hu\t'Display more readable date forms for humans'
+    relative\t'Display more readable date forms for humans'
 "
 complete -c exa        -l 'no-permissions' -d "Suppress the permissions field"
 complete -c exa        -l 'octal-permissions' -d "List each file's permission in octal format"

--- a/completions/fish/exa.fish
+++ b/completions/fish/exa.fish
@@ -79,6 +79,7 @@ complete -c exa        -l 'time-style'    -d "How to format timestamps" -x -a "
     iso\t'Display brief ISO timestamps'
     long-iso\t'Display longer ISO timestaps, up to the minute'
     full-iso\t'Display full ISO timestamps, up to the nanosecond'
+    hu\t'Display more readable date forms for humans'
 "
 complete -c exa        -l 'no-permissions' -d "Suppress the permissions field"
 complete -c exa        -l 'octal-permissions' -d "List each file's permission in octal format"

--- a/completions/zsh/_exa
+++ b/completions/zsh/_exa
@@ -43,7 +43,7 @@ __exa() {
         {-n,--numeric}"[List numeric user and group IDs.]" \
         {-S,--blocks}"[List each file's number of filesystem blocks]" \
         {-t,--time}="[Which time field to show]:(time field):(accessed changed created modified)" \
-        --time-style="[How to format timestamps]:(time style):(default iso long-iso full-iso)" \
+        --time-style="[How to format timestamps]:(time style):(default iso long-iso full-iso hu)" \
         --no-permissions"[Suppress the permissions field]" \
         --octal-permissions"[List each file's permission in octal format]" \
         --no-filesize"[Suppress the filesize field]" \

--- a/completions/zsh/_exa
+++ b/completions/zsh/_exa
@@ -43,7 +43,7 @@ __exa() {
         {-n,--numeric}"[List numeric user and group IDs.]" \
         {-S,--blocks}"[List each file's number of filesystem blocks]" \
         {-t,--time}="[Which time field to show]:(time field):(accessed changed created modified)" \
-        --time-style="[How to format timestamps]:(time style):(default iso long-iso full-iso hu)" \
+        --time-style="[How to format timestamps]:(time style):(default iso long-iso full-iso relative)" \
         --no-permissions"[Suppress the permissions field]" \
         --octal-permissions"[List each file's permission in octal format]" \
         --no-filesize"[Suppress the filesize field]" \

--- a/man/exa.1.md
+++ b/man/exa.1.md
@@ -157,7 +157,7 @@ These options are available when running with `--long` (`-l`):
 `--time-style=STYLE`
 : How to format timestamps.
 
-: Valid timestamp styles are ‘`default`’, ‘`iso`’, ‘`long-iso`’, and ‘`full-iso`’.
+: Valid timestamp styles are ‘`default`’, ‘`iso`’, ‘`long-iso`’, ‘`full-iso`’, and ‘`relative`’.
 
 `-u`, `--accessed`
 : Use the accessed timestamp field.

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -52,7 +52,7 @@ pub static ACCESSED:   Arg = Arg { short: Some(b'u'), long: "accessed",   takes_
 pub static CREATED:    Arg = Arg { short: Some(b'U'), long: "created",    takes_value: TakesValue::Forbidden };
 pub static TIME_STYLE: Arg = Arg { short: None,       long: "time-style", takes_value: TakesValue::Necessary(Some(TIME_STYLES)) };
 const TIMES: Values = &["modified", "changed", "accessed", "created"];
-const TIME_STYLES: Values = &["default", "long-iso", "full-iso", "iso"];
+const TIME_STYLES: Values = &["default", "long-iso", "full-iso", "iso", "relative"];
 
 // suppressing columns
 pub static NO_PERMISSIONS: Arg = Arg { short: None, long: "no-permissions", takes_value: TakesValue::Forbidden };

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -54,7 +54,7 @@ LONG VIEW OPTIONS
   -u, --accessed       use the accessed timestamp field
   -U, --created        use the created timestamp field
   --changed            use the changed timestamp field
-  --time-style         how to format timestamps (default, iso, long-iso, full-iso)
+  --time-style         how to format timestamps (default, iso, long-iso, full-iso, relative)
   --no-permissions     suppress the permissions field
   --octal-permissions  list each file's permission in octal format
   --no-filesize        suppress the filesize field

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -469,6 +469,7 @@ mod test {
         test!(iso:       TimeFormat <- ["--time-style", "iso"], None;       Both => like Ok(TimeFormat::ISOFormat));
         test!(long_iso:  TimeFormat <- ["--time-style=long-iso"], None;     Both => like Ok(TimeFormat::LongISO));
         test!(full_iso:  TimeFormat <- ["--time-style", "full-iso"], None;  Both => like Ok(TimeFormat::FullISO));
+        test!(relative:  TimeFormat <- ["--time-style=relative"], None;     Both => like Ok(TimeFormat::Human));
 
         // Overriding
         test!(actually:  TimeFormat <- ["--time-style=default", "--time-style", "iso"], None;  Last => like Ok(TimeFormat::ISOFormat));

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -266,6 +266,9 @@ impl TimeFormat {
         else if &word == "full-iso" {
             Ok(Self::FullISO)
         }
+        else if &word == "hu" {
+            Ok(Self::Human)
+        }
         else {
             Err(OptionsError::BadArgument(&flags::TIME_STYLE, word))
         }

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -266,7 +266,7 @@ impl TimeFormat {
         else if &word == "full-iso" {
             Ok(Self::FullISO)
         }
-        else if &word == "hu" {
+        else if &word == "relative" {
             Ok(Self::Human)
         }
         else {

--- a/src/output/time.rs
+++ b/src/output/time.rs
@@ -2,6 +2,7 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use chrono_humanize::HumanTime;
 use datetime::{LocalDateTime, TimeZone, DatePiece, TimePiece};
 use datetime::fmt::DateFormat;
 
@@ -24,7 +25,7 @@ use unicode_width::UnicodeWidthStr;
 /// prints month names as numbers.
 ///
 /// Currently exa does not support *custom* styles, where the user enters a
-/// format string in an environment variable or something. Just these four.
+/// format string in an environment variable or something. Just these five.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum TimeFormat {
 
@@ -46,6 +47,10 @@ pub enum TimeFormat {
     /// millisecond and includes its offset down to the minute. This too uses
     /// only numbers so doesn’t require any special consideration.
     FullISO,
+
+    /// The **Human format** converts the time form into a more human readable form, 
+    /// such as one month ago, three weeks ago
+    Human,
 }
 
 // There are two different formatting functions because local and zoned
@@ -58,6 +63,7 @@ impl TimeFormat {
             Self::ISOFormat      => iso_local(time),
             Self::LongISO        => long_local(time),
             Self::FullISO        => full_local(time),
+            Self::Human          => hu_local(time),
         }
     }
 
@@ -67,6 +73,7 @@ impl TimeFormat {
             Self::ISOFormat      => iso_zoned(time, zone),
             Self::LongISO        => long_zoned(time, zone),
             Self::FullISO        => full_zoned(time, zone),
+            Self::Human          => hu_zoned(time, zone),
         }
     }
 }
@@ -95,6 +102,19 @@ fn get_dateformat(date: &LocalDateTime) -> &'static DateFormat<'static> {
         (false, 5)  => &FIVE_WIDE_DATE_YEAR,
         (false, _)  => &OTHER_WIDE_DATE_YEAR,
     }
+}
+
+#[allow(trivial_numeric_casts)]
+fn hu_local(time: SystemTime) -> String {
+    format!("{}", HumanTime::from(time))
+}
+
+#[allow(trivial_numeric_casts)]
+fn hu_zoned(time: SystemTime, _: &TimeZone) -> String {
+
+    let dt: chrono::DateTime<chrono::Utc> = time.clone().into();
+    let tt: chrono::DateTime<chrono::Local> = dt.with_timezone(&chrono::Local);
+    format!("{}", HumanTime::from(tt))
 }
 
 #[allow(trivial_numeric_casts)]

--- a/xtests/input-options.toml
+++ b/xtests/input-options.toml
@@ -42,7 +42,7 @@ tags = [ 'options' ]
 name = "exa displays an error for option that takes the wrong parameter"
 shell = "exa -l --time-style=24"
 stdout = { empty = true }
-stderr = { string = "Option --time-style has no \"24\" setting (choices: default, long-iso, full-iso, iso)" }
+stderr = { string = "Option --time-style has no \"24\" setting (choices: default, long-iso, full-iso, iso, relative)" }
 status = 3
 tags = [ 'options' ]
 

--- a/xtests/outputs/help.ansitxt
+++ b/xtests/outputs/help.ansitxt
@@ -46,7 +46,7 @@ LONG VIEW OPTIONS
   -u, --accessed       use the accessed timestamp field
   -U, --created        use the created timestamp field
   --changed            use the changed timestamp field
-  --time-style         how to format timestamps (default, iso, long-iso, full-iso)
+  --time-style         how to format timestamps (default, iso, long-iso, full-iso, relative)
   --no-permissions     suppress the permissions field
   --octal-permissions  list each file's permission in octal format
   --no-filesize        suppress the filesize field


### PR DESCRIPTION
Because when using the built-in command ls of nushell, I found that it has a more readable date display, so I hope that Exa can also support it
The following is the result of running ls in a nushell
![nushell](https://github.com/ogham/exa/assets/73155828/4161920e-9511-481c-b4c5-3a25204c3d2b)
Here are the results of running exa
![exa](https://github.com/ogham/exa/assets/73155828/473da84c-c038-49c7-ad78-2ad16ff73483)
