### PR TITLE
add icon support for .mjs, .cjs, .mts, .cts files 

### DIFF
--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -27,9 +27,9 @@ impl FileExtensions {
             "Makefile", "Cargo.toml", "SConstruct", "CMakeLists.txt",
             "build.gradle", "pom.xml", "Rakefile", "package.json", "Gruntfile.js",
             "Gruntfile.coffee", "BUILD", "BUILD.bazel", "WORKSPACE", "build.xml", "Podfile",
-            "webpack.config.js", "meson.build", "composer.json", "RoboFile.php", "PKGBUILD",
-            "Justfile", "Procfile", "Dockerfile", "Containerfile", "Vagrantfile", "Brewfile",
-            "Gemfile", "Pipfile", "build.sbt", "mix.exs", "bsconfig.json", "tsconfig.json",
+            "webpack.config.js", "webpack.config.cjs", "meson.build", "composer.json", "RoboFile.php",
+            "PKGBUILD", "Justfile", "Procfile", "Dockerfile", "Containerfile", "Vagrantfile",
+            "Brewfile", "Gemfile", "Pipfile", "build.sbt", "mix.exs", "bsconfig.json", "tsconfig.json",
         ])
     }
 

--- a/src/info/sources.rs
+++ b/src/info/sources.rs
@@ -18,6 +18,8 @@ impl<'a> File<'a> {
             match &ext[..] {
                 "css"   => vec![self.path.with_extension("sass"), self.path.with_extension("scss"),  // SASS, SCSS
                                 self.path.with_extension("styl"), self.path.with_extension("less")],  // Stylus, Less
+                "mjs"   => vec![self.path.with_extension("mts")],  // JavaScript ES Modules source
+                "cjs"   => vec![self.path.with_extension("cts")],  // JavaScript Commonjs Modules source
                 "js"    => vec![self.path.with_extension("coffee"), self.path.with_extension("ts")],  // CoffeeScript, TypeScript
 
                 "aux" |                                          // TeX: auxiliary file

--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -130,6 +130,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "cab"           => '\u{e70f}', // 
             "cc"            => '\u{e61d}', // 
             "cfg"           => '\u{e615}', // 
+            "cjs"           => '\u{e74e}', // 
             "class"         => '\u{e256}', // 
             "clj"           => '\u{e768}', // 
             "cljs"          => '\u{e76a}', // 
@@ -147,6 +148,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "css"           => '\u{e749}', // 
             "csv"           => '\u{f1c3}', // 
             "csx"           => '\u{f81a}', // 
+            "cts"           => '\u{e628}', // 
             "cxx"           => '\u{e61d}', // 
             "d"             => '\u{e7af}', // 
             "dart"          => '\u{e798}', // 
@@ -258,6 +260,7 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "mp3"           => '\u{f001}', // 
             "mp4"           => '\u{f03d}', // 
             "msi"           => '\u{e70f}', // 
+            "mts"           => '\u{e628}', // 
             "mustache"      => '\u{e60f}', // 
             "nix"           => '\u{f313}', // 
             "node"          => '\u{f898}', // 


### PR DESCRIPTION
These are javascript/typescript files that specify the module type (in NodeJS). Thusly, they should have icons matching their language (JS/TS).