### PR TITLE
Add Dockerfile to enable running end-to-end tests with docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+.git
+Dockerfile
+
+# Rust stuff
+target
+
+# Vagrant stuff
+.vagrant
+*.log
+
+# Compiled artifacts
+# (see devtools/*-package-for-*.sh)
+/exa-linux-x86_64
+/exa-linux-x86_64-*.zip
+/exa-macos-x86_64
+/exa-macos-x86_64-*.zip
+/MD5SUMS
+/SHA1SUMS
+
+# Snap stuff
+parts
+prime
+stage
+*.snap

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,10 @@ RUN cargo install -q cargo-hack
 RUN cargo install -q --git https://github.com/ogham/specsheet
 
 # Install Just, the command runner.
-RUN wget -q "https://github.com/casey/just/releases/download/v0.8.3/just-v0.8.3-x86_64-unknown-linux-musl.tar.gz"
-RUN tar -xf "just-v0.8.3-x86_64-unknown-linux-musl.tar.gz"
-RUN cp just /usr/local/bin
+RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
 
-# Guarantee that the timezone is UTC — some of the tests depend on this (for now).
-RUN timedatectl set-timezone UTC
+# TODO: Guarantee that the timezone is UTC — some of the tests depend on this (for now).
+# RUN timedatectl set-timezone UTC
 
 ARG DEVELOPER=root
 # Use a different ‘target’ directory on the VM than on the host.
@@ -50,16 +48,18 @@ RUN ln -sf /usr/bin/run-xtests /usr/bin/x
 RUN echo -e "#!/bin/sh\nbuild-exa && test-exa && run-xtests" > /usr/bin/compile-exa
 RUN ln -sf /usr/bin/compile-exa /usr/bin/c
 
+ADD --chmod=+x devtools/dev-package-for-linux.sh /vagrant/devtools/dev-package-for-linux.sh
 RUN echo -e "#!/bin/sh\nbash /vagrant/devtools/dev-package-for-linux.sh \\$@" > /usr/bin/package-exa
 RUN echo -e "#!/bin/sh\ncat /etc/motd" > /usr/bin/halp
 
-RUN chmod +x /usr/bin/{exa,rexa,b,t,x,c,build-exa,test-exa,run-xtests,compile-exa,package-exa,halp}
+# RUN chmod +x /usr/bin/{exa,rexa,b,t,x,c,build-exa,test-exa,run-xtests,compile-exa,package-exa,halp}
 
 
 # Configure the welcoming text that gets shown:
 
 # Capture the help text so it gets displayed first
 RUN rm -f /etc/update-motd.d/*
+ADD --chmod=+x devtools/dev-help.sh /vagrant/devtools/dev-help.sh
 RUN bash /vagrant/devtools/dev-help.sh > /etc/motd
 
 # Tell bash to execute a bunch of stuff when a session starts

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,14 +106,14 @@ RUN bash /vagrant/devtools/dev-set-up-environment.sh
 RUN bash /vagrant/devtools/dev-create-test-filesystem.sh
 
 WORKDIR /vagrant
-COPY --from=exa /app/target /vagrant/target
+COPY --link --from=exa /app/target /vagrant/target
 
 # TODO: remove this once tests don't depend on it
 RUN ln -s /vagrant/* ${HOME}
 
-COPY --from=specsheet /usr/local/cargo/bin/specsheet /usr/bin/specsheet
-COPY --from=cargo-hack /usr/local/cargo/bin/cargo-hack /usr/bin/cargo-hack
-COPY --from=just /usr/bin/just /usr/bin/just
+COPY --link --from=specsheet /usr/local/cargo/bin/specsheet /usr/bin/specsheet
+COPY --link --from=cargo-hack /usr/local/cargo/bin/cargo-hack /usr/bin/cargo-hack
+COPY --link --from=just /usr/bin/just /usr/bin/just
 
 FROM base AS test
 CMD ["/vagrant/xtests/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
-FROM rust:1.71.1 AS just
+ARG base-rust=rust:1.71.1
+
+FROM base-rust AS just
 # Install Just, the command runner.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 
-FROM rust:1.71.1 AS specsheet
+FROM base-rust AS specsheet
 RUN cargo install -q --git https://github.com/ogham/specsheet
 
-FROM rust:1.71.1 AS cargo-hack
+FROM base-rust AS cargo-hack
 RUN cargo install -q cargo-hack
 
-FROM rust:1.71.1 AS cargo-kcov
+FROM base-rust AS cargo-kcov
 RUN cargo install -q cargo-kcov
 
-FROM rust:1.71.1 AS exa
+FROM base-rust AS exa
 WORKDIR /app
 # Copy the source code into the image
 COPY . .
@@ -21,7 +23,7 @@ RUN cargo build
 # We use Ubuntu instead of Debian because the image comes with two-way
 # shared folder support by default.
 # This image is based from Ubuntu
-FROM rust:1.71.1 AS base
+FROM base-rust AS base
 
 # Install the dependencies needed for exa to build
 RUN apt-get update -qq

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,11 @@ RUN apt-get install -y \
 RUN ln -s $(which python3) /usr/bin/python
 RUN cargo kcov --print-install-kcov-sh | sh
 
-ADD --chmod=+x devtools/* /vagrant/devtools/
+COPY --chmod=+x . /vagrant/
+
+# Make sudo dummy replacement, so we don't weaken docker security
+RUN echo -e "#!/bin/bash\n\$@" > /usr/bin/sudo
+RUN chmod +x /usr/bin/sudo
 
 RUN bash /vagrant/devtools/dev-set-up-environment.sh
 RUN bash /vagrant/devtools/dev-create-test-filesystem.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,25 +51,27 @@ RUN ln -s $(which python3) /usr/bin/python
 RUN cargo kcov --print-install-kcov-sh | sh
 
 # Create a variety of misc scripts.
+RUN <<EOF
+  ln -sf /vagrant/devtools/dev-run-debug.sh /usr/bin/exa
+  ln -sf /vagrant/devtools/dev-run-release.sh /usr/bin/rexa
 
-RUN ln -sf /vagrant/devtools/dev-run-debug.sh /usr/bin/exa
-RUN ln -sf /vagrant/devtools/dev-run-release.sh /usr/bin/rexa
+  echo -e "#!/bin/sh\ncargo build --manifest-path /vagrant/Cargo.toml \\$@" > /usr/bin/build-exa
+  ln -sf /usr/bin/build-exa /usr/bin/b
 
-RUN echo -e "#!/bin/sh\ncargo build --manifest-path /vagrant/Cargo.toml \\$@" > /usr/bin/build-exa
-RUN ln -sf /usr/bin/build-exa /usr/bin/b
+  echo -e "#!/bin/sh\ncargo test --manifest-path /vagrant/Cargo.toml \\$@ -- --quiet" > /usr/bin/test-exa
+  ln -sf /usr/bin/test-exa /usr/bin/t
 
-RUN echo -e "#!/bin/sh\ncargo test --manifest-path /vagrant/Cargo.toml \\$@ -- --quiet" > /usr/bin/test-exa
-RUN ln -sf /usr/bin/test-exa /usr/bin/t
+  echo -e "#!/bin/sh\n/vagrant/xtests/run.sh" > /usr/bin/run-xtests
+  ln -sf /usr/bin/run-xtests /usr/bin/x
 
-RUN echo -e "#!/bin/sh\n/vagrant/xtests/run.sh" > /usr/bin/run-xtests
-RUN ln -sf /usr/bin/run-xtests /usr/bin/x
+  echo -e "#!/bin/sh\nbuild-exa && test-exa && run-xtests" > /usr/bin/compile-exa
+  ln -sf /usr/bin/compile-exa /usr/bin/c
 
-RUN echo -e "#!/bin/sh\nbuild-exa && test-exa && run-xtests" > /usr/bin/compile-exa
-RUN ln -sf /usr/bin/compile-exa /usr/bin/c
-
-ADD --chmod=+x devtools/dev-package-for-linux.sh /vagrant/devtools/dev-package-for-linux.sh
-RUN echo -e "#!/bin/sh\nbash /vagrant/devtools/dev-package-for-linux.sh \\$@" > /usr/bin/package-exa
-RUN echo -e "#!/bin/sh\ncat /etc/motd" > /usr/bin/halp
+  echo -e "#!/bin/sh\nbash /vagrant/devtools/dev-package-for-linux.sh \\$@" > /usr/bin/package-exa
+  echo -e "#!/bin/sh\ncat /etc/motd" > /usr/bin/halp
+  
+  chmod +x /usr/bin/{exa,rexa,b,t,x,c,build-exa,test-exa,run-xtests,compile-exa,package-exa,halp}
+EOF  
 
 # Configure the welcoming text that gets shown:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,26 +74,26 @@ RUN <<EOF
 EOF  
 
 # Configure the welcoming text that gets shown:
+RUN <<EOF
+  # Capture the help text so it gets displayed first
+  rm -f /etc/update-motd.d/*
+  bash /vagrant/devtools/dev-help.sh > /etc/motd
 
-# Capture the help text so it gets displayed first
-RUN rm -f /etc/update-motd.d/*
-ADD --chmod=+x devtools/dev-help.sh /vagrant/devtools/dev-help.sh
-RUN bash /vagrant/devtools/dev-help.sh > /etc/motd
+  # Tell bash to execute a bunch of stuff when a session starts
+  echo "source /vagrant/devtools/dev-bash.sh" > ${HOME}/.bash_profile
 
-# Tell bash to execute a bunch of stuff when a session starts
-RUN echo "source /vagrant/devtools/dev-bash.sh" > ${HOME}/.bash_profile
+  # Link the completion files so they’re “installed”:
 
-# Link the completion files so they’re “installed”:
+  # bash
+  ln -s /vagrant/completions/bash/exa /etc/bash_completion.d/exa
+  ln -s /vagrant/completions/bash/exa /usr/share/bash-completion/completions/exa
 
-# bash
-RUN ln -s /vagrant/completions/bash/exa /etc/bash_completion.d/exa
-RUN ln -s /vagrant/completions/bash/exa /usr/share/bash-completion/completions/exa
+  # zsh
+  ln -s /vagrant/completions/zsh/_exa /usr/share/zsh/vendor-completions/_exa
 
-# zsh
-RUN ln -s /vagrant/completions/zsh/_exa /usr/share/zsh/vendor-completions/_exa
-
-# fish
-RUN ln -s /vagrant/completions/fish/exa.fish /usr/share/fish/completions/exa.fish
+  # fish
+  ln -s /vagrant/completions/fish/exa.fish /usr/share/fish/completions/exa.fish
+EOF
 
 
 # Copy the source code into the image

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ RUN --mount=type=cache,target=/var/cache/apt apt-get install -y \
 RUN ln -s $(which python3) /usr/bin/python
 RUN cargo kcov --print-install-kcov-sh | sh
 
+# Copy the source code into the image
+COPY --chmod=+x . /vagrant/
+
 # Create a variety of misc scripts.
 RUN <<EOF
   ln -sf /vagrant/devtools/dev-run-debug.sh /usr/bin/exa
@@ -96,10 +99,6 @@ RUN <<EOF
   # fish
   ln -s /vagrant/completions/fish/exa.fish /usr/share/fish/completions/exa.fish
 EOF
-
-
-# Copy the source code into the image
-COPY --chmod=+x . /vagrant/
 
 # Make sudo dummy replacement
 # This is needed for some tests that use sudo

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,6 @@ RUN apt-get install -y \
 RUN ln -s $(which python3) /usr/bin/python
 RUN cargo kcov --print-install-kcov-sh | sh
 
-# TODO: Guarantee that the timezone is UTC — some of the tests depend on this (for now).
-# RUN timedatectl set-timezone UTC
-
 # Create a variety of misc scripts.
 
 RUN ln -sf /vagrant/devtools/dev-run-debug.sh /usr/bin/exa
@@ -64,9 +61,6 @@ ADD --chmod=+x devtools/dev-package-for-linux.sh /vagrant/devtools/dev-package-f
 RUN echo -e "#!/bin/sh\nbash /vagrant/devtools/dev-package-for-linux.sh \\$@" > /usr/bin/package-exa
 RUN echo -e "#!/bin/sh\ncat /etc/motd" > /usr/bin/halp
 
-# RUN chmod +x /usr/bin/{exa,rexa,b,t,x,c,build-exa,test-exa,run-xtests,compile-exa,package-exa,halp}
-
-
 # Configure the welcoming text that gets shown:
 
 # Capture the help text so it gets displayed first
@@ -76,11 +70,6 @@ RUN bash /vagrant/devtools/dev-help.sh > /etc/motd
 
 # Tell bash to execute a bunch of stuff when a session starts
 RUN echo "source /vagrant/devtools/dev-bash.sh" > ${HOME}/.bash_profile
-
-# Disable last login date in sshd
-# RUN sed -i '/PrintLastLog yes/c\PrintLastLog no' /etc/ssh/sshd_config
-# RUN systemctl restart sshd
-
 
 # Link the completion files so they’re “installed”:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,10 @@ RUN <<EOF
 
   echo -e "#!/bin/sh\nbash /vagrant/devtools/dev-package-for-linux.sh \\$@" > /usr/bin/package-exa
   echo -e "#!/bin/sh\ncat /etc/motd" > /usr/bin/halp
-  
+
   chmod +x /usr/bin/{exa,rexa,b,t,x,c,build-exa,test-exa,run-xtests,compile-exa,package-exa,halp}
+
+  exit 0
 EOF
 
 # Configure the welcoming text that gets shown:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ RUN apt-get install -qq -o=Dpkg::Use-Pty=0 \
     fish zsh bash bash-completion
 
 # Install Rust (cargo + rustup) and the Rust tools we need.
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -- --profile minimal --component rustc,rust-std,cargo,clippy -y > /dev/null
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --component rustc,rust-std,cargo,clippy -y
+
+# Add Rust binaries to path
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN cargo install -q cargo-hack
 RUN cargo install -q --git https://github.com/ogham/specsheet

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,5 +110,11 @@ WORKDIR /vagrant
 RUN cargo build
 RUN bash /usr/bin/build-exa
 
+# TODO: remove this and do it the other way around: create a link from /vagrant to /root
+RUN ln -s /vagrant/* /root
+
+RUN git clone https://github.com/ogham/specsheet --depth 1
+RUN cd specsheet && cargo build --release --target-dir /usr/bin
+
 FROM base AS test
 CMD ["/vagrant/xtests/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN cargo build
 FROM ${BASE_RUST} AS base
 
 # Install the dependencies needed for exa to build
-RUN apt-get update -qq
-RUN apt-get install -qq -o=Dpkg::Use-Pty=0 \
+RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq
+RUN --mount=type=cache,target=/var/cache/apt apt-get install -qq -o=Dpkg::Use-Pty=0 \
     git gcc curl attr libgit2-dev zip \
     fish zsh bash bash-completion
 
@@ -43,7 +43,7 @@ RUN apt-get install -qq -o=Dpkg::Use-Pty=0 \
 # This doesn’t run coverage over the xtests so it’s less useful for now
 COPY --from=cargo-kcov /usr/local/cargo/bin/cargo-kcov /usr/bin/cargo-kcov
 
-RUN apt-get install -y \
+RUN --mount=type=cache,target=/var/cache/apt apt-get install -y \
     cmake g++ pkg-config \
     libcurl4-openssl-dev libdw-dev binutils-dev libiberty-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ RUN bash /vagrant/devtools/dev-create-test-filesystem.sh
 
 WORKDIR /vagrant
 RUN cargo build
-RUN ./xtests/run
+RUN bash /usr/bin/build-exa
 
 FROM base AS test
-CMD []
+CMD ["/vagrant/xtests/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,7 @@ RUN ln -s /vagrant/completions/fish/exa.fish /usr/share/fish/completions/exa.fis
 COPY --chmod=+x . /vagrant/
 
 # Make sudo dummy replacement, so we don't weaken docker security
+# This is needed for some tests that use sudo
 RUN echo -e "#!/bin/bash\n\$@" > /usr/bin/sudo
 RUN chmod +x /usr/bin/sudo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN <<EOF
 
   chmod +x /usr/bin/{exa,rexa,b,t,x,c,build-exa,test-exa,run-xtests,compile-exa,package-exa,halp}
 
-  exit 0
+  exit 0 # for some weird reason, the chmod fails if it's the last command
 EOF
 
 # Configure the welcoming text that gets shown:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+FROM rust:1.71.1 AS specsheet
+RUN git clone https://github.com/ogham/specsheet --depth 1
+WORKDIR /specsheet
+RUN cargo build --release --target-dir /usr/bin 
+
 # We use Ubuntu instead of Debian because the image comes with two-way
 # shared folder support by default.
 FROM ubuntu:22.04 AS base
@@ -113,8 +118,8 @@ RUN bash /usr/bin/build-exa
 # TODO: remove this and do it the other way around: create a link from /vagrant to /root
 RUN ln -s /vagrant/* /root
 
-RUN git clone https://github.com/ogham/specsheet --depth 1
-RUN cd specsheet && cargo build --release --target-dir /usr/bin
+COPY --from=specsheet /usr/bin/release/specsheet /usr/bin/specsheet
+
 
 FROM base AS test
 CMD ["/vagrant/xtests/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get install -qq -o=Dpkg::Use-Pty=0 \
 
 # Create a variety of misc scripts.
 
-RUN ln -sf /vagrant/devtools/dev-run-debug.sh   /usr/bin/exa
+RUN ln -sf /vagrant/devtools/dev-run-debug.sh /usr/bin/exa
 RUN ln -sf /vagrant/devtools/dev-run-release.sh /usr/bin/rexa
 
 RUN echo -e "#!/bin/sh\ncargo build --manifest-path /vagrant/Cargo.toml \\$@" > /usr/bin/build-exa
@@ -71,13 +71,14 @@ RUN echo "source /vagrant/devtools/dev-bash.sh" > ${HOME}/.bash_profile
 # Link the completion files so they’re “installed”:
 
 # bash
-RUN ln -s /vagrant/contrib/completions.bash /etc/bash_completion.d/exa
+RUN ln -s /vagrant/completions/bash/exa /etc/bash_completion.d/exa
+RUN ln -s /vagrant/completions/bash/exa /usr/share/bash-completion/completions/exa
 
 # zsh
-RUN ln -s /vagrant/contrib/completions.zsh /usr/share/zsh/vendor-completions/_exa
+RUN ln -s /vagrant/completions/zsh/_exa /usr/share/zsh/vendor-completions/_exa
 
 # fish
-RUN ln -s /vagrant/contrib/completions.fish /usr/share/fish/completions/exa.fish
+RUN ln -s /vagrant/completions/fish/exa.fish /usr/share/fish/completions/exa.fish
 
 # Install kcov for test coverage
 # This doesn’t run coverage over the xtests so it’s less useful for now

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN ln -s /vagrant/completions/fish/exa.fish /usr/share/fish/completions/exa.fis
 # Copy the source code into the image
 COPY --chmod=+x . /vagrant/
 
-# Make sudo dummy replacement, so we don't weaken docker security
+# Make sudo dummy replacement
 # This is needed for some tests that use sudo
 RUN echo -e '#!/bin/sh\n"$@"' > /usr/bin/sudo
 RUN chmod +x /usr/bin/sudo

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,22 +71,18 @@ RUN echo "source /vagrant/devtools/dev-bash.sh" > ${HOME}/.bash_profile
 # Link the completion files so they’re “installed”:
 
 # bash
-RUN test -h /etc/bash_completion.d/exa \
-    || ln -s /vagrant/contrib/completions.bash /etc/bash_completion.d/exa
+RUN ln -s /vagrant/contrib/completions.bash /etc/bash_completion.d/exa
 
 # zsh
-RUN test -h /usr/share/zsh/vendor-completions/_exa \
-    || ln -s /vagrant/contrib/completions.zsh /usr/share/zsh/vendor-completions/_exa
+RUN ln -s /vagrant/contrib/completions.zsh /usr/share/zsh/vendor-completions/_exa
 
 # fish
-RUN test -h /usr/share/fish/completions/exa.fish \
-    || ln -s /vagrant/contrib/completions.fish /usr/share/fish/completions/exa.fish
+RUN ln -s /vagrant/contrib/completions.fish /usr/share/fish/completions/exa.fish
 
 # Install kcov for test coverage
 # This doesn’t run coverage over the xtests so it’s less useful for now
 
-RUN test -e ~/.cargo/bin/cargo-kcov \
-    || cargo install cargo-kcov
+RUN cargo install cargo-kcov
 
 RUN apt-get install -y \
     cmake g++ pkg-config \
@@ -107,7 +103,6 @@ RUN bash /vagrant/devtools/dev-create-test-filesystem.sh
 
 WORKDIR /vagrant
 COPY --from=exa /app/target /vagrant/target
-RUN bash /usr/bin/build-exa
 
 # TODO: remove this once tests don't depend on it
 RUN ln -s /vagrant/* ${HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,13 @@ RUN cargo install -q --git https://github.com/ogham/specsheet
 FROM rust:1.71.1 AS cargo-hack
 RUN cargo install -q cargo-hack
 
+FROM rust:1.71.1 AS exa
+WORKDIR /app
+# Copy the source code into the image
+COPY . .
+# Build exa
+RUN cargo build
+
 # We use Ubuntu instead of Debian because the image comes with two-way
 # shared folder support by default.
 # This image is based from Ubuntu
@@ -99,7 +106,7 @@ RUN bash /vagrant/devtools/dev-set-up-environment.sh
 RUN bash /vagrant/devtools/dev-create-test-filesystem.sh
 
 WORKDIR /vagrant
-RUN cargo build
+COPY --from=exa /app/target /vagrant/target
 RUN bash /usr/bin/build-exa
 
 # TODO: remove this once tests don't depend on it

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN <<EOF
   echo -e "#!/bin/sh\ncat /etc/motd" > /usr/bin/halp
   
   chmod +x /usr/bin/{exa,rexa,b,t,x,c,build-exa,test-exa,run-xtests,compile-exa,package-exa,halp}
-EOF  
+EOF
 
 # Configure the welcoming text that gets shown:
 RUN <<EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,108 @@
+# We use Ubuntu instead of Debian because the image comes with two-way
+# shared folder support by default.
+FROM ubuntu:22.04 AS base
+
+# Install the dependencies needed for exa to build
+RUN apt-get update -qq
+RUN apt-get install -qq -o=Dpkg::Use-Pty=0 \
+    git gcc curl attr libgit2-dev zip \
+    fish zsh bash bash-completion
+
+# Install Rust (cargo + rustup) and the Rust tools we need.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -- --profile minimal --component rustc,rust-std,cargo,clippy -y > /dev/null
+
+RUN cargo install -q cargo-hack
+RUN cargo install -q --git https://github.com/ogham/specsheet
+
+# Install Just, the command runner.
+RUN wget -q "https://github.com/casey/just/releases/download/v0.8.3/just-v0.8.3-x86_64-unknown-linux-musl.tar.gz"
+RUN tar -xf "just-v0.8.3-x86_64-unknown-linux-musl.tar.gz"
+RUN cp just /usr/local/bin
+
+# Guarantee that the timezone is UTC — some of the tests depend on this (for now).
+RUN timedatectl set-timezone UTC
+
+ARG DEVELOPER=root
+# Use a different ‘target’ directory on the VM than on the host.
+# By default it just uses the one in /vagrant/target, which can
+# cause problems if it has different permissions than the other
+# directories, or contains object files compiled for the host.
+RUN echo 'PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/${DEVELOPER}/.cargo/bin"' > /etc/environment
+RUN echo 'CARGO_TARGET_DIR="/home/${DEVELOPER}/target"' >> /etc/environment
+
+# Create a variety of misc scripts.
+
+RUN ln -sf /vagrant/devtools/dev-run-debug.sh   /usr/bin/exa
+RUN ln -sf /vagrant/devtools/dev-run-release.sh /usr/bin/rexa
+
+RUN echo -e "#!/bin/sh\ncargo build --manifest-path /vagrant/Cargo.toml \\$@" > /usr/bin/build-exa
+RUN ln -sf /usr/bin/build-exa /usr/bin/b
+
+RUN echo -e "#!/bin/sh\ncargo test --manifest-path /vagrant/Cargo.toml \\$@ -- --quiet" > /usr/bin/test-exa
+RUN ln -sf /usr/bin/test-exa /usr/bin/t
+
+RUN echo -e "#!/bin/sh\n/vagrant/xtests/run.sh" > /usr/bin/run-xtests
+RUN ln -sf /usr/bin/run-xtests /usr/bin/x
+
+RUN echo -e "#!/bin/sh\nbuild-exa && test-exa && run-xtests" > /usr/bin/compile-exa
+RUN ln -sf /usr/bin/compile-exa /usr/bin/c
+
+RUN echo -e "#!/bin/sh\nbash /vagrant/devtools/dev-package-for-linux.sh \\$@" > /usr/bin/package-exa
+RUN echo -e "#!/bin/sh\ncat /etc/motd" > /usr/bin/halp
+
+RUN chmod +x /usr/bin/{exa,rexa,b,t,x,c,build-exa,test-exa,run-xtests,compile-exa,package-exa,halp}
+
+
+# Configure the welcoming text that gets shown:
+
+# Capture the help text so it gets displayed first
+RUN rm -f /etc/update-motd.d/*
+RUN bash /vagrant/devtools/dev-help.sh > /etc/motd
+
+# Tell bash to execute a bunch of stuff when a session starts
+RUN echo "source /vagrant/devtools/dev-bash.sh" > /home/#{developer}/.bash_profile
+RUN chown #{developer} /home/#{developer}/.bash_profile
+
+# Disable last login date in sshd
+RUN sed -i '/PrintLastLog yes/c\PrintLastLog no' /etc/ssh/sshd_config
+RUN systemctl restart sshd
+
+
+# Link the completion files so they’re “installed”:
+
+# bash
+RUN test -h /etc/bash_completion.d/exa \
+    || ln -s /vagrant/contrib/completions.bash /etc/bash_completion.d/exa
+
+# zsh
+RUN test -h /usr/share/zsh/vendor-completions/_exa \
+    || ln -s /vagrant/contrib/completions.zsh /usr/share/zsh/vendor-completions/_exa
+
+# fish
+RUN test -h /usr/share/fish/completions/exa.fish \
+    || ln -s /vagrant/contrib/completions.fish /usr/share/fish/completions/exa.fish
+
+# Install kcov for test coverage
+# This doesn’t run coverage over the xtests so it’s less useful for now
+
+RUN test -e ~/.cargo/bin/cargo-kcov \
+    || cargo install cargo-kcov
+
+RUN sudo apt-get install -qq -o=Dpkg::Use-Pty=0 -y \
+    cmake g++ pkg-config \
+    libcurl4-openssl-dev libdw-dev binutils-dev libiberty-dev
+
+RUN cargo kcov --print-install-kcov-sh | sudo sh
+
+ADD --chmod=+x devtools/dev-set-up-environment.sh /vagrant/devtools/dev-set-up-environment.sh
+ADD --chmod=+x devtools/dev-create-test-filesystem.sh /vagrant/devtools/dev-create-test-filesystem.sh
+
+RUN sh /vagrant/devtools/dev-set-up-environment.sh
+RUN sh /vagrant/devtools/dev-create-test-filesystem.sh
+
+WORKDIR /vagrant
+RUN cargo build
+RUN ./xtests/run
+
+FROM base AS test
+CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ COPY --chmod=+x . /vagrant/
 
 # Make sudo dummy replacement, so we don't weaken docker security
 # This is needed for some tests that use sudo
-RUN echo -e "#!/bin/bash\n\$@" > /usr/bin/sudo
+RUN echo -e '#!/bin/sh\n"$@"' > /usr/bin/sudo
 RUN chmod +x /usr/bin/sudo
 
 RUN bash /vagrant/devtools/dev-set-up-environment.sh

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 
 [![Unit tests](https://github.com/ogham/exa/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/ogham/exa/actions/workflows/unit-tests.yml)
 [![Say thanks!](https://img.shields.io/badge/Say%20Thanks-!-1EAEDB.svg)](https://saythanks.io/to/ogham%40bsago.me)
-
 </div>
 
 ![Screenshots of exa](screenshots.png)
@@ -22,6 +21,7 @@ And it’s **small**, **fast**, and just **one single binary**.
 
 By deliberately making some decisions differently, exa attempts to be a more featureful, more user-friendly version of `ls`.
 For more information, see [exa’s website](https://the.exa.website/).
+
 
 ---
 
@@ -90,6 +90,7 @@ Some of the options accept parameters:
 - Valid sort fields are **accessed**, **changed**, **created**, **extension**, **Extension**, **inode**, **modified**, **name**, **Name**, **size**, **type**, and **none**. Fields starting with a capital letter sort uppercase before lowercase. The modified field has the aliases **date**, **time**, and **newest**, while its reverse has the aliases **age** and **oldest**.
 - Valid time fields are **modified**, **changed**, **accessed**, and **created**.
 - Valid time styles are **default**, **iso**, **long-iso**, and **full-iso**.
+
 
 ---
 
@@ -189,6 +190,7 @@ Cargo will build the `exa` binary and place it in `$HOME/.cargo`.
 
 To build without Git support, run `cargo install --no-default-features exa` is also available, if the requisite dependencies are not installed.
 
+
 ---
 
 <a id="development">
@@ -213,22 +215,22 @@ Once Rust is installed, you can compile exa with Cargo:
     cargo test
 
 - The [just](https://github.com/casey/just) command runner can be used to run some helpful development commands, in a manner similar to `make`.
-  Run `just --list` to get an overview of what’s available.
+Run `just --list` to get an overview of what’s available.
 
 - If you are compiling a copy for yourself, be sure to run `cargo build --release` or `just build-release` to benefit from release-mode optimisations.
-  Copy the resulting binary, which will be in the `target/release` directory, into a folder in your `$PATH`.
-  `/usr/local/bin` is usually a good choice.
+Copy the resulting binary, which will be in the `target/release` directory, into a folder in your `$PATH`.
+`/usr/local/bin` is usually a good choice.
 
 - To compile and install the manual pages, you will need [pandoc](https://pandoc.org/).
-  The `just man` command will compile the Markdown into manual pages, which it will place in the `target/man` directory.
-  To use them, copy them into a directory that `man` will read.
-  `/usr/local/share/man` is usually a good choice.
+The `just man` command will compile the Markdown into manual pages, which it will place in the `target/man` directory.
+To use them, copy them into a directory that `man` will read.
+`/usr/local/share/man` is usually a good choice.
 
 - exa depends on [libgit2](https://github.com/rust-lang/git2-rs) for certain features.
-  If you’re unable to compile libgit2, you can opt out of Git support by running `cargo build --no-default-features`.
+If you’re unable to compile libgit2, you can opt out of Git support by running `cargo build --no-default-features`.
 
 - If you intend to compile for musl, you will need to use the flag `vendored-openssl` if you want to get the Git feature working.
-  The full command is `cargo build --release --target=x86_64-unknown-linux-musl --features vendored-openssl,git`.
+The full command is `cargo build --release --target=x86_64-unknown-linux-musl --features vendored-openssl,git`.
 
 For more information, see the [Building from Source page](https://the.exa.website/install/source).
 
@@ -252,7 +254,6 @@ docker run -it exa-test fish
 > Note: You should be able to run this with any container runtime you'd like. You are welcome to add a PR documenting how to do this with other runtimes.
 
 #### Testing with Vagrant
-
 exa uses [Vagrant][] to configure virtual machines for testing.
 
 Programs such as exa that are basically interfaces to the system are [notoriously difficult to test][testing].
@@ -263,7 +264,7 @@ The initial attempt to solve the problem was just to create a directory of “aw
 But even this output would change if, say, the user’s locale formats dates in a different way.
 These can be mocked inside the code, but at the cost of making that code more complicated to read and understand.
 
-An alternative solution is to fake _everything_: create a virtual machine with a known state and run the tests on _that_.
+An alternative solution is to fake *everything*: create a virtual machine with a known state and run the tests on *that*.
 This is what Vagrant does.
 Although it takes a while to download and set up, it gives everyone the same development environment to test for any obvious regressions.
 
@@ -284,5 +285,5 @@ Once this is done, you can SSH in, and build and test:
     All the tests passed!
 
 Of course, the drawback of having a standard development environment is that you stop noticing bugs that occur outside of it.
-For this reason, Vagrant isn’t a _necessary_ development step — it’s there if you’d like to use it, but exa still gets used and tested on other platforms.
+For this reason, Vagrant isn’t a *necessary* development step — it’s there if you’d like to use it, but exa still gets used and tested on other platforms.
 It can still be built and compiled on any target triple that it supports, VM or no VM, with `cargo build` and `cargo test`.

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ For more information, see the [Building from Source page](https://the.exa.websit
 
 ### End to end testing
 
-## Testing with containers
+#### Testing with containers
 
 You can use [Docker](https://www.docker.com/) to run exa in a container, and test it against a known state.
 
@@ -251,7 +251,7 @@ docker run -it exa-test fish
 
 > Note: You should be able to run this with any container runtime you'd like. You are welcome to add a PR documenting how to do this with other runtimes.
 
-## Testing with Vagrant
+#### Testing with Vagrant
 
 exa uses [Vagrant][] to configure virtual machines for testing.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![Unit tests](https://github.com/ogham/exa/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/ogham/exa/actions/workflows/unit-tests.yml)
 [![Say thanks!](https://img.shields.io/badge/Say%20Thanks-!-1EAEDB.svg)](https://saythanks.io/to/ogham%40bsago.me)
+
 </div>
 
 ![Screenshots of exa](screenshots.png)
@@ -21,7 +22,6 @@ And it’s **small**, **fast**, and just **one single binary**.
 
 By deliberately making some decisions differently, exa attempts to be a more featureful, more user-friendly version of `ls`.
 For more information, see [exa’s website](https://the.exa.website/).
-
 
 ---
 
@@ -90,7 +90,6 @@ Some of the options accept parameters:
 - Valid sort fields are **accessed**, **changed**, **created**, **extension**, **Extension**, **inode**, **modified**, **name**, **Name**, **size**, **type**, and **none**. Fields starting with a capital letter sort uppercase before lowercase. The modified field has the aliases **date**, **time**, and **newest**, while its reverse has the aliases **age** and **oldest**.
 - Valid time fields are **modified**, **changed**, **accessed**, and **created**.
 - Valid time styles are **default**, **iso**, **long-iso**, and **full-iso**.
-
 
 ---
 
@@ -190,7 +189,6 @@ Cargo will build the `exa` binary and place it in `$HOME/.cargo`.
 
 To build without Git support, run `cargo install --no-default-features exa` is also available, if the requisite dependencies are not installed.
 
-
 ---
 
 <a id="development">
@@ -215,27 +213,45 @@ Once Rust is installed, you can compile exa with Cargo:
     cargo test
 
 - The [just](https://github.com/casey/just) command runner can be used to run some helpful development commands, in a manner similar to `make`.
-Run `just --list` to get an overview of what’s available.
+  Run `just --list` to get an overview of what’s available.
 
 - If you are compiling a copy for yourself, be sure to run `cargo build --release` or `just build-release` to benefit from release-mode optimisations.
-Copy the resulting binary, which will be in the `target/release` directory, into a folder in your `$PATH`.
-`/usr/local/bin` is usually a good choice.
+  Copy the resulting binary, which will be in the `target/release` directory, into a folder in your `$PATH`.
+  `/usr/local/bin` is usually a good choice.
 
 - To compile and install the manual pages, you will need [pandoc](https://pandoc.org/).
-The `just man` command will compile the Markdown into manual pages, which it will place in the `target/man` directory.
-To use them, copy them into a directory that `man` will read.
-`/usr/local/share/man` is usually a good choice.
+  The `just man` command will compile the Markdown into manual pages, which it will place in the `target/man` directory.
+  To use them, copy them into a directory that `man` will read.
+  `/usr/local/share/man` is usually a good choice.
 
 - exa depends on [libgit2](https://github.com/rust-lang/git2-rs) for certain features.
-If you’re unable to compile libgit2, you can opt out of Git support by running `cargo build --no-default-features`.
+  If you’re unable to compile libgit2, you can opt out of Git support by running `cargo build --no-default-features`.
 
 - If you intend to compile for musl, you will need to use the flag `vendored-openssl` if you want to get the Git feature working.
-The full command is `cargo build --release --target=x86_64-unknown-linux-musl --features vendored-openssl,git`.
+  The full command is `cargo build --release --target=x86_64-unknown-linux-musl --features vendored-openssl,git`.
 
 For more information, see the [Building from Source page](https://the.exa.website/install/source).
 
+### End to end testing
 
-### Testing with Vagrant
+## Testing with containers
+
+You can use [Docker](https://www.docker.com/) to run exa in a container, and test it against a known state.
+
+```fish
+# Build the container image
+docker build . -t exa-test --target test
+
+# Run the tests in the container
+docker run -it exa-test
+
+# In case you want to get into the container to test something
+docker run -it exa-test fish
+```
+
+> Note: You should be able to run this with any container runtime you'd like. You are welcome to add a PR documenting how to do this with other runtimes.
+
+## Testing with Vagrant
 
 exa uses [Vagrant][] to configure virtual machines for testing.
 
@@ -247,7 +263,7 @@ The initial attempt to solve the problem was just to create a directory of “aw
 But even this output would change if, say, the user’s locale formats dates in a different way.
 These can be mocked inside the code, but at the cost of making that code more complicated to read and understand.
 
-An alternative solution is to fake *everything*: create a virtual machine with a known state and run the tests on *that*.
+An alternative solution is to fake _everything_: create a virtual machine with a known state and run the tests on _that_.
 This is what Vagrant does.
 Although it takes a while to download and set up, it gives everyone the same development environment to test for any obvious regressions.
 
@@ -268,5 +284,5 @@ Once this is done, you can SSH in, and build and test:
     All the tests passed!
 
 Of course, the drawback of having a standard development environment is that you stop noticing bugs that occur outside of it.
-For this reason, Vagrant isn’t a *necessary* development step — it’s there if you’d like to use it, but exa still gets used and tested on other platforms.
+For this reason, Vagrant isn’t a _necessary_ development step — it’s there if you’d like to use it, but exa still gets used and tested on other platforms.
 It can still be built and compiled on any target triple that it supports, VM or no VM, with `cargo build` and `cargo test`.


### PR DESCRIPTION
# Context
Fixes https://github.com/ogham/exa/issues/1225

# Reviewer tips
The commit history is a bit dirty (if we go forward we should squash it), so look at the final picture
- Added `Dockerfile` and `.dockerignore`
- Documented a bit in the `README.md`

I also encourage you to run the tests in your local machine to see how it works. Documentation on how to do this in the `README.md`

# Notes
- This is my first time contributing here, I'm open to receive all your feedback
- The tests are failing at the moment in the tip of `master`. If someone is able to run vagrant, please notify me if this is also the case so I know if it's an issue with the `Dockerfile` configuration