### PR TITLE
Fix file extension for versioned shared libraries

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -132,9 +132,30 @@ impl<'dir> File<'dir> {
     fn ext(path: &Path) -> Option<String> {
         let name = path.file_name().map(|f| f.to_string_lossy().to_string())?;
 
-        name.rfind('.')
+        match name.rfind('.')
             .map(|p| name[p + 1 ..]
             .to_ascii_lowercase())
+        {
+            Some(ext) => {
+                if ext.chars().all(char::is_numeric) {
+                    for word in name.split('.').rev().skip(1) {
+                        if !word.chars().all(char::is_numeric) {
+                            if word == "so" {
+                                return Some("so".into());
+                            }
+                            else {
+                                break;
+                            }
+                        }
+                    }
+                    Some(ext)
+                }
+                else {
+                    Some(ext)
+                }
+            },
+            _ => None, 
+        }
     }
 
     /// Whether this file is a directory on the filesystem.


### PR DESCRIPTION
Revise File::ext to extract "so" extension from versioned shared libraries, so instead of returning "3" for "libtest.so.1.2.3" it returns "so".

The parsing only kicks in when the last extension is a numeric value, and then keeps on going back through the numbers until it finds the "so" or not. Only checking for numbers after the "so" should be sufficient for nearly all libs. I only found two exceptions in my `/usr/lib`, some `.so.owner` and a `.so.sign`. Trying to match those would require a much more general approach which doesn't seem to be worth it here.

Resolves #1105