### PR TITLE
Add terraform icon

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -328,6 +328,8 @@ pub fn icon_for_file(file: &File<'_>) -> char {
             "tbz"           => '\u{f410}', // 
             "tbz2"          => '\u{f410}', // 
             "tex"           => '\u{f034}', // 
+            "tf"            => '\u{f1062}', // 󱁢
+            "tfstate"       => '\u{f1062}', // 󱁢
             "tgz"           => '\u{f410}', // 
             "tiff"          => '\u{f1c5}', // 
             "tlz"           => '\u{f410}', // 


### PR DESCRIPTION
Hello 👋
This is just a quick PR to add a terraform icon for `*.tf` and `*.tfstate`files.

Quick preview:
<img width="264" alt="image" src="https://github.com/ogham/exa/assets/86676740/a393ba98-6b83-4c67-a205-7254a3945eba">


Have a good day !