### PR TITLE
Add --no-git option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ These options are available when running with `--long` (`-l`):
 - **-@**, **--extended**: list each file’s extended attributes and sizes
 - **--changed**: use the changed timestamp field
 - **--git**: list each file’s Git status, if tracked or ignored
+- **--no-git**: don't list Git status (always overrides --git)
 - **--time-style**: how to format timestamps
 - **--no-permissions**: suppress the permissions field
 - **--octal-permissions**: list each file's permission in octal format

--- a/completions/fish/exa.fish
+++ b/completions/fish/exa.fish
@@ -88,4 +88,5 @@ complete -c exa        -l 'no-time'        -d "Suppress the time field"
 
 # Optional extras
 complete -c exa -l 'git' -d "List each file's Git status, if tracked"
+complete -c exa -l 'no-git' -d "Don't list Git status"
 complete -c exa -s '@' -l 'extended' -d "List each file's extended attributes and sizes"

--- a/completions/zsh/_exa
+++ b/completions/zsh/_exa
@@ -52,6 +52,7 @@ __exa() {
         {-u,--accessed}"[Use the accessed timestamp field]" \
         {-U,--created}"[Use the created timestamp field]" \
         --git"[List each file's Git status, if tracked]" \
+        --no-git"[Don't list Git status]" \
         {-@,--extended}"[List each file's extended attributes and sizes]" \
         '*:filename:_files'
 }

--- a/man/exa.1.md
+++ b/man/exa.1.md
@@ -187,6 +187,9 @@ This adds a two-character column indicating the staged and unstaged statuses res
 
 Directories will be shown to have the status of their contents, which is how ‘deleted’ is possible: if a directory contains a file that has a certain status, it will be shown to have that status.
 
+`--no-git`  [if exa was built with git support]
+: Don't list Git status. (Always overrides --git)
+
 
 ENVIRONMENT VARIABLES
 =====================

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -63,6 +63,7 @@ pub static NO_ICONS: Arg = Arg { short: None, long: "no-icons", takes_value: Tak
 
 // optional feature options
 pub static GIT:       Arg = Arg { short: None,       long: "git",               takes_value: TakesValue::Forbidden };
+pub static NO_GIT:    Arg = Arg { short: None,       long: "no-git",            takes_value: TakesValue::Forbidden };
 pub static EXTENDED:  Arg = Arg { short: Some(b'@'), long: "extended",          takes_value: TakesValue::Forbidden };
 pub static OCTAL:     Arg = Arg { short: None,       long: "octal-permissions", takes_value: TakesValue::Forbidden };
 
@@ -80,5 +81,5 @@ pub static ALL_ARGS: Args = Args(&[
     &BLOCKS, &TIME, &ACCESSED, &CREATED, &TIME_STYLE,
     &NO_PERMISSIONS, &NO_FILESIZE, &NO_USER, &NO_TIME, &NO_ICONS,
 
-    &GIT, &EXTENDED, &OCTAL
+    &GIT, &NO_GIT, &EXTENDED, &OCTAL
 ]);

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -61,9 +61,10 @@ LONG VIEW OPTIONS
   --no-user            suppress the user field
   --no-time            suppress the time field";
 
-static GIT_FILTER_HELP: &str = "  --git-ignore               ignore files mentioned in '.gitignore'";
-static GIT_VIEW_HELP:   &str = "  --git                list each file's Git status, if tracked or ignored";
-static EXTENDED_HELP:   &str = "  -@, --extended       list each file's extended attributes and sizes";
+static GIT_FILTER_HELP:  &str = "  --git-ignore               ignore files mentioned in '.gitignore'";
+static GIT_VIEW_HELP:    &str = "  --git                list each file's Git status, if tracked or ignored";
+static NO_GIT_VIEW_HELP: &str = "  --no-git             don't list Git status (always overrides --git)";
+static EXTENDED_HELP:    &str = "  -@, --extended       list each file's extended attributes and sizes";
 
 
 /// All the information needed to display the help text, which depends
@@ -106,6 +107,7 @@ impl fmt::Display for HelpString {
 
         if cfg!(feature = "git") {
             write!(f, "\n{}", GIT_VIEW_HELP)?;
+            write!(f, "\n{}", NO_GIT_VIEW_HELP)?;
         }
 
         if xattr::ENABLED {

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -199,7 +199,7 @@ impl TableOptions {
 impl Columns {
     fn deduce(matches: &MatchedFlags<'_>) -> Result<Self, OptionsError> {
         let time_types = TimeTypes::deduce(matches)?;
-        let git = matches.has(&flags::GIT)?;
+        let git = matches.has(&flags::GIT)? && !matches.has(&flags::NO_GIT)?;
 
         let blocks = matches.has(&flags::BLOCKS)?;
         let group  = matches.has(&flags::GROUP)?;
@@ -357,8 +357,8 @@ mod test {
 
     static TEST_ARGS: &[&Arg] = &[ &flags::BINARY, &flags::BYTES,    &flags::TIME_STYLE,
                                    &flags::TIME,   &flags::MODIFIED, &flags::CHANGED,
-                                   &flags::CREATED, &flags::ACCESSED,
-                                   &flags::HEADER, &flags::GROUP,  &flags::INODE, &flags::GIT,
+                                   &flags::CREATED, &flags::ACCESSED, &flags::HEADER,
+                                   &flags::GROUP,  &flags::INODE, &flags::GIT, &flags::NO_GIT,
                                    &flags::LINKS,  &flags::BLOCKS, &flags::LONG,  &flags::LEVEL,
                                    &flags::GRID,   &flags::ACROSS, &flags::ONE_LINE, &flags::TREE,
                                    &flags::NUMERIC ];

--- a/xtests/outputs/help.ansitxt
+++ b/xtests/outputs/help.ansitxt
@@ -53,4 +53,5 @@ LONG VIEW OPTIONS
   --no-user            suppress the user field
   --no-time            suppress the time field
   --git                list each file's Git status, if tracked or ignored
+  --no-git             don't list Git status (always overrides --git)
   -@, --extended       list each file's extended attributes and sizes


### PR DESCRIPTION
<details>

<summary>Some unnecessary exposition about my use case</summary>

While updating my `home-manager` configuration recently, I discovered that `exa` now has a program module available, with the option `programs.exa.git` to [alias `exa` to `exa --git`](https://github.com/nix-community/home-manager/blob/bdb5bcad01ff7332fdcf4b128211e81905113f84/modules/programs/exa.nix#L45). I happily enabled this option but quickly found myself in situations where I didn't want the git status to shown. While I could use something like `$(which exa) -l`, I far prefer the ergonomics of a `--no-git` option (and it plays more nicely with other tools to boot).

</details>

This PR adds the `--no-git` option. This option overrides `--git` in all cases and disables showing the Git status of files in long view (`-l`). This enables users of shell aliases and the like to turn off git status display in an *ad hoc* manner

Somewhat tangentially related: #1044.

(This is my first contribution to this codebase; I've done my best to make all the appropriate changes, but I'd appreciate any pointers if there's something I've missed. I took inspiration from the `--no-icons` option as prior art.)